### PR TITLE
fix: handle last frame before APE/ID3 tags and M4A info display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1777,7 +1777,36 @@ fn process_info(file: &Path, opts: &Options) -> Result<JsonFileResult> {
         }
     }
 
-    // Non-TSV output: use basic analysis
+    // Check if this is an M4A/AAC file - if so, show appropriate message
+    if mp4meta::is_mp4_file(file) {
+        match opts.output_format {
+            OutputFormat::Text => {
+                if opts.quiet {
+                    println!("{}\tM4A/AAC\t-\t-\t-\t-\t-", filename);
+                } else {
+                    println!("{}", filename.cyan().bold());
+                    println!("  Format:      M4A/AAC");
+                    println!(
+                        "  {}",
+                        "Note: Use -r or -a for ReplayGain analysis".yellow()
+                    );
+                    println!();
+                }
+            }
+            OutputFormat::Tsv => {
+                println!("{}\t-\t-\t-\t-\t-", filename);
+            }
+            OutputFormat::Json => {}
+        }
+
+        return Ok(JsonFileResult {
+            file: file.display().to_string(),
+            status: Some("info".to_string()),
+            ..Default::default()
+        });
+    }
+
+    // MP3 file: use basic analysis
     match analyze(file) {
         Ok(info) => {
             match opts.output_format {


### PR DESCRIPTION
## Summary

This PR fixes two issues:

### Issue #54: Last frame not modified when followed by APE/ID3 tag

**Problem**: When an MP3 file has metadata tags (APE or ID3v1) immediately following the last audio frame, mp3rgain was skipping the last frame during gain application.

**Solution**: Added `find_audio_end()` function that detects trailing APE/ID3v1 tags and returns the actual end of audio data. Updated all frame iteration functions to use this boundary instead of file size.

**Changes**:
- Added `find_audio_end()` in `lib.rs`
- Updated `iterate_frames()`, `apply_gain()`, `apply_gain_channel()`, `apply_gain_wrap()` to use `audio_end` boundary

### Issue #55: M4A/AAC files incorrectly show MP3 format info

**Problem**: Running `mp3rgain test.m4a` (without -r or -a) showed incorrect MP3 format info.

**Solution**: Added M4A/AAC detection in `process_info()` to display appropriate format information.

**Before**:
```
test.m4a
  Format:      MPEG2.5 Layer III, Mono
  Frames:      1
  Gain range:  235 - 235 (avg: 235.0)
```

**After**:
```
test.m4a
  Format:      M4A/AAC
  Note: Use -r or -a for ReplayGain analysis
```

## Testing

- [x] All existing tests pass
- [x] Manually tested with MP3 file containing APE tag - gain range correctly changes from 72-210 to 69-207 after applying -3 steps
- [x] Manually tested M4A file info display - shows correct format info

Fixes #54
Fixes #55