### PR TITLE
docs: add winget as recommended Windows installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ mp3rgain adjusts MP3 volume without re-encoding by modifying the `global_gain` f
 brew install M-Igashi/tap/mp3rgain
 ```
 
-### Windows
+### Windows (recommended)
+
+```powershell
+winget install M-Igashi.mp3rgain
+```
+
+### Windows (alternative)
 
 ```powershell
 scoop bucket add mp3rgain https://github.com/M-Igashi/scoop-bucket


### PR DESCRIPTION
## Summary

Add winget as the recommended installation method for Windows users.

## Changes

- Add `winget install M-Igashi.mp3rgain` as the primary Windows installation option
- Move Scoop installation to "alternative" section

## Related

- winget-pkgs PR merged: https://github.com/microsoft/winget-pkgs/pull/331125