### PR TITLE
chore: add cargo-deb configuration for Debian packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,29 @@ path = "src/main.rs"
 lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
+
+[package.metadata.deb]
+maintainer = "M-Igashi <M-Igashi@users.noreply.github.com>"
+copyright = "2025, M-Igashi"
+license-file = ["LICENSE", "0"]
+extended-description = """\
+mp3rgain is a modern, memory-safe replacement for the classic mp3gain tool, \
+written in Rust. It adjusts MP3 volume without re-encoding by modifying the \
+global_gain field in each frame's side information, preserving audio quality \
+while achieving permanent volume changes.
+
+Features:
+ * Lossless and reversible volume adjustment
+ * ReplayGain track and album analysis
+ * Full command-line compatibility with original mp3gain
+ * Support for MP3, AAC/M4A formats
+ * Memory-safe implementation (addresses CVE-2021-34085, CVE-2019-18359)"""
+section = "sound"
+priority = "optional"
+depends = "$auto"
+assets = [
+    ["target/release/mp3rgain", "usr/bin/", "755"],
+    ["docs/man/mp3rgain.1", "usr/share/man/man1/", "644"],
+    ["README.md", "usr/share/doc/mp3rgain/README.md", "644"],
+    ["LICENSE", "usr/share/doc/mp3rgain/copyright", "644"],
+]


### PR DESCRIPTION
## Summary

Add cargo-deb configuration to enable building Debian packages (.deb).

## Changes

Add `[package.metadata.deb]` section to Cargo.toml with:
- Package metadata (maintainer, copyright, license)
- Extended description highlighting key features and CVE fixes
- Section: `sound`, Priority: `optional`
- Asset definitions for binary, man page, and documentation

## Usage

```bash
# Install cargo-deb
cargo install cargo-deb

# Build .deb package
cargo deb

# Cross-compile for Linux (from macOS)
cargo deb --target x86_64-unknown-linux-gnu
```

## Package Contents

- `/usr/bin/mp3rgain` - Main binary
- `/usr/share/man/man1/mp3rgain.1` - Man page
- `/usr/share/doc/mp3rgain/README.md` - Documentation
- `/usr/share/doc/mp3rgain/copyright` - License

## Related Issue

Part of #14 (Debian/Ubuntu packaging preparation)

## Notes

This is preparation for potential Debian repository submission. The official Debian process uses debcargo, but cargo-deb provides a quick way to create .deb packages for distribution via GitHub releases or PPAs.