### PR TITLE
ci: improve Debian package build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,10 +328,20 @@ jobs:
       - name: Build package
         run: dpkg-buildpackage -us -uc -b -d
 
+      - name: List built packages
+        run: ls -la ../mp3rgain*.deb
+
+      - name: Generate checksum
+        run: |
+          cd ..
+          sha256sum mp3rgain_${{ needs.release.outputs.version }}-1_amd64.deb > mp3rgain_${{ needs.release.outputs.version }}-1_amd64.deb.sha256
+
       - name: Upload to release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         with:
-          files: ../mp3rgain_${{ needs.release.outputs.version }}-1_amd64.deb
+          files: |
+            ../mp3rgain_${{ needs.release.outputs.version }}-1_amd64.deb
+            ../mp3rgain_${{ needs.release.outputs.version }}-1_amd64.deb.sha256
 
   # Publish to crates.io
   publish-cargo:

--- a/packages/debian/debian/rules
+++ b/packages/debian/debian/rules
@@ -10,6 +10,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -Dm755 target/release/mp3rgain debian/mp3rgain/usr/bin/mp3rgain
+	install -Dm644 docs/man/mp3rgain.1 debian/mp3rgain/usr/share/man/man1/mp3rgain.1
 
 override_dh_auto_test:
 	# Skip integration tests as test fixtures (MP3 files) are not available in source package


### PR DESCRIPTION
## Summary

Improve the Debian package build in the release workflow.

## Changes

### debian/rules
- Install man page to `/usr/share/man/man1/mp3rgain.1`

### release.yml (build-deb job)
- Add step to list built packages for debugging
- Generate SHA256 checksum for .deb file
- Upload both .deb and .sha256 to release assets

## Package Contents

The .deb package now includes:
- `/usr/bin/mp3rgain` - Main binary
- `/usr/share/man/man1/mp3rgain.1` - Man page

## Related Issue

Part of #14 (Debian/Ubuntu packaging preparation)

## Testing

The build-deb job runs on release tag push. The `continue-on-error: true` ensures it won't block other release jobs if there are issues.