### PR TITLE
fix(gui): Display volume relative to 89 dB reference for MP3Gain compatibility

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -168,7 +168,8 @@ impl Mp3rgainApp {
 
             match replaygain::analyze_track(&file.path) {
                 Ok(result) => {
-                    file.volume = Some(result.loudness_db);
+                    // Display volume relative to ReplayGain reference (89 dB) for MP3Gain compatibility
+                    file.volume = Some(REPLAYGAIN_REFERENCE_DB - result.gain_db);
                     file.clipping = result.peak >= 1.0;
                     let gain = self.target_volume - REPLAYGAIN_REFERENCE_DB + result.gain_db;
                     file.track_gain = Some(gain);
@@ -212,14 +213,16 @@ impl Mp3rgainApp {
 
                 for (i, file) in self.files.iter_mut().enumerate() {
                     if let Some(track_result) = result.tracks.get(i) {
-                        file.volume = Some(track_result.loudness_db);
+                        // Display volume relative to ReplayGain reference (89 dB) for MP3Gain compatibility
+                        file.volume = Some(REPLAYGAIN_REFERENCE_DB - track_result.gain_db);
                         file.clipping = track_result.peak >= 1.0;
                         let track_gain =
                             self.target_volume - REPLAYGAIN_REFERENCE_DB + track_result.gain_db;
                         file.track_gain = Some(track_gain);
                         file.track_clip = Self::would_clip(track_result.peak, track_gain);
                     }
-                    file.album_volume = Some(result.album_loudness_db);
+                    // Display album volume relative to ReplayGain reference (89 dB) for MP3Gain compatibility
+                    file.album_volume = Some(REPLAYGAIN_REFERENCE_DB - result.album_gain_db);
                     file.album_gain = Some(album_gain);
                     file.album_clip = Self::would_clip(result.album_peak, album_gain);
                     file.status = FileStatus::Analyzed;


### PR DESCRIPTION
## Summary

Fix the Volume column display in mp3rgui to match MP3Gain's behavior.

## Problem

A user [reported on Reddit](https://www.reddit.com/r/mp3players/comments/1pzmusy/comment/o0zr7os/) that MP3Gain shows volume values around 89 dB while MP3RGain GUI shows values around 64-65 dB for the same files.

![Comparison screenshot](https://imgur.com/a/lJwLRvY)

## Root Cause

The Volume column was displaying `result.loudness_db` directly, which is the internal loudness calculation value (around 64-65 dB based on the PINK_REF constant of 64.82).

MP3Gain displays the "perceived volume" relative to the ReplayGain reference level (89 dB).

**Important**: The Track Gain values were always calculated correctly - this was purely a display issue.

## Solution

Changed the Volume column to display:
```
REPLAYGAIN_REFERENCE_DB - result.gain_db
```

This is equivalent to `89.0 - (64.82 - loudness_db) = 24.18 + loudness_db`, which matches MP3Gain's display behavior.

## Changes

- `mp3rgui/src/app.rs`: Updated volume display calculation in both `analyze_tracks()` and `analyze_album()` functions