### PR TITLE
feat: library API stabilization for v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mp3rgain"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp3rgain"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Jesse Pinkman <M-Igashi@users.noreply.github.com>"]
 description = "Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust"
@@ -17,6 +17,7 @@ default = ["replaygain"]
 replaygain = ["symphonia"]
 aac = ["symphonia-aac"]
 symphonia-aac = ["symphonia"]
+serde = []
 
 [dependencies]
 anyhow = "1.0"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,16 +98,22 @@ All core functionality complete:
 
 ### v1.7.0 - Library API Stabilization (Issue #68)
 
-- [ ] Add `#[non_exhaustive]` to all public enums and structs
+**Non-breaking additions (shipped in v1.7.0):**
+- [x] Add `#[non_exhaustive]` to all public enums and structs
+- [x] Add missing standard trait implementations (`PartialEq`, `Eq`, `Hash`)
+- [x] Add `Display` trait implementations to all public types
+- [x] Add `Serialize` / `Deserialize` behind a `serde` feature flag
+- [x] Add `ApeTag::iter()` and `ApeTag::len()` methods
+- [x] Make `MpegVersion` / `ChannelMode` enums public with typed accessors on `Mp3Analysis`
+- [x] Add `MaxAmplitudeResult` struct and `find_max_amplitude_detailed()` function
+- [x] Add `Channel::other()` convenience method
+- [x] Remove unnecessary `pub` from `filter_coeffs` internal constants
+
+**Breaking changes (deferred to v2.0):**
 - [ ] Replace `anyhow::Result` with custom error types (`thiserror`)
-- [ ] Make `Mp3Analysis.mpeg_version` / `channel_mode` proper enums instead of `String`
-- [ ] Replace `find_max_amplitude` tuple return with a named struct
+- [ ] Change `Mp3Analysis.mpeg_version` / `channel_mode` from `String` to enum
+- [ ] Remove old `find_max_amplitude` tuple return
 - [ ] Review public struct fields - consider private fields with accessor methods
-- [ ] Unify ReplayGain tag key constants across modules
-- [ ] Add `Display` trait implementations to public types
-- [ ] Add `Serialize` / `Deserialize` behind a feature flag
-- [ ] Add `ApeTag::iter()` method
-- [ ] Add missing standard trait implementations (`PartialEq`, `Eq`, `Hash`)
 - [ ] Consolidate `apply_gain*` function variants into builder/options pattern
 - [ ] Organize flat `lib.rs` exports into submodules
 

--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "1.5.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgui"
-version = "1.2.1"
+version = "1.7.0"
 dependencies = [
  "eframe",
  "egui",

--- a/mp3rgui/Cargo.toml
+++ b/mp3rgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp3rgui"
-version = "1.3.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Jesse Pinkman <M-Igashi@users.noreply.github.com>"]
 description = "GUI application for mp3rgain - lossless MP3 volume adjustment"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,9 @@ pub const MAX_GAIN: u8 = 255;
 pub const MIN_GAIN: u8 = 0;
 
 /// Result of MP3 file analysis
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mp3Analysis {
     /// Number of audio frames in the file
     pub frame_count: usize,
@@ -75,15 +77,18 @@ pub struct Mp3Analysis {
 }
 
 /// MPEG version
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum MpegVersion {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum MpegVersion {
     Mpeg1,
     Mpeg2,
     Mpeg25,
 }
 
 impl MpegVersion {
-    fn as_str(&self) -> &'static str {
+    /// Get the string representation of this MPEG version
+    pub fn as_str(&self) -> &'static str {
         match self {
             MpegVersion::Mpeg1 => "MPEG1",
             MpegVersion::Mpeg2 => "MPEG2",
@@ -93,8 +98,10 @@ impl MpegVersion {
 }
 
 /// Channel mode
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum ChannelMode {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ChannelMode {
     Stereo,
     JointStereo,
     DualChannel,
@@ -102,14 +109,16 @@ enum ChannelMode {
 }
 
 impl ChannelMode {
-    fn channel_count(&self) -> usize {
+    /// Get the number of audio channels for this mode
+    pub fn channel_count(&self) -> usize {
         match self {
             ChannelMode::Mono => 1,
             _ => 2,
         }
     }
 
-    fn as_str(&self) -> &'static str {
+    /// Get the string representation of this channel mode
+    pub fn as_str(&self) -> &'static str {
         match self {
             ChannelMode::Stereo => "Stereo",
             ChannelMode::JointStereo => "Joint Stereo",
@@ -117,6 +126,99 @@ impl ChannelMode {
             ChannelMode::Mono => "Mono",
         }
     }
+}
+
+impl Mp3Analysis {
+    /// Get the MPEG version as a typed enum
+    pub fn mpeg_version_parsed(&self) -> Option<MpegVersion> {
+        match self.mpeg_version.as_str() {
+            "MPEG1" => Some(MpegVersion::Mpeg1),
+            "MPEG2" => Some(MpegVersion::Mpeg2),
+            "MPEG2.5" => Some(MpegVersion::Mpeg25),
+            _ => None,
+        }
+    }
+
+    /// Get the channel mode as a typed enum
+    pub fn channel_mode_parsed(&self) -> Option<ChannelMode> {
+        match self.channel_mode.as_str() {
+            "Stereo" => Some(ChannelMode::Stereo),
+            "Joint Stereo" => Some(ChannelMode::JointStereo),
+            "Dual Channel" => Some(ChannelMode::DualChannel),
+            "Mono" => Some(ChannelMode::Mono),
+            _ => None,
+        }
+    }
+}
+
+// =============================================================================
+// Display implementations
+// =============================================================================
+
+impl std::fmt::Display for MpegVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for ChannelMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for Mp3Analysis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {}, {} frames, headroom: {:+.1} dB",
+            self.mpeg_version, self.channel_mode, self.frame_count, self.headroom_db
+        )
+    }
+}
+
+impl std::fmt::Display for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Channel::Left => f.write_str("Left"),
+            Channel::Right => f.write_str("Right"),
+        }
+    }
+}
+
+impl std::fmt::Display for MaxAmplitudeResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "amplitude: {:.6}, gain range: {}-{}",
+            self.max_amplitude, self.min_global_gain, self.max_global_gain
+        )
+    }
+}
+
+impl std::fmt::Display for ApeItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}={}", self.key, self.value)
+    }
+}
+
+impl std::fmt::Display for ApeTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ApeTag({} items)", self.items.len())
+    }
+}
+
+/// Result of maximum amplitude analysis
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MaxAmplitudeResult {
+    /// Maximum amplitude (normalized, 0.0 to 1.0+, where >1.0 indicates clipping)
+    pub max_amplitude: f64,
+    /// Maximum global_gain value found across all granules
+    pub max_global_gain: u8,
+    /// Minimum global_gain value found across all granules
+    pub min_global_gain: u8,
 }
 
 /// Parsed MP3 frame header
@@ -639,7 +741,9 @@ pub fn steps_to_db(steps: i32) -> f64 {
 }
 
 /// Channel selection for independent gain adjustment
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Channel {
     /// Left channel (channel 0)
     Left,
@@ -662,6 +766,14 @@ impl Channel {
             0 => Some(Channel::Left),
             1 => Some(Channel::Right),
             _ => None,
+        }
+    }
+
+    /// Get the opposite channel
+    pub fn other(&self) -> Self {
+        match self {
+            Channel::Left => Channel::Right,
+            Channel::Right => Channel::Left,
         }
     }
 }
@@ -856,14 +968,18 @@ pub const TAG_REPLAYGAIN_ALBUM_GAIN: &str = "REPLAYGAIN_ALBUM_GAIN";
 pub const TAG_REPLAYGAIN_ALBUM_PEAK: &str = "REPLAYGAIN_ALBUM_PEAK";
 
 /// APEv2 tag item
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApeItem {
     pub key: String,
     pub value: String,
 }
 
 /// APEv2 tag collection
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApeTag {
     items: Vec<ApeItem>,
 }
@@ -910,6 +1026,16 @@ impl ApeTag {
     /// Check if tag is empty
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
+    }
+
+    /// Get the number of items in this tag
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Iterate over all items in this tag
+    pub fn iter(&self) -> impl Iterator<Item = &ApeItem> {
+        self.items.iter()
     }
 
     /// Get MP3GAIN_UNDO value as gain steps
@@ -1226,6 +1352,31 @@ pub fn find_max_amplitude(file_path: &Path) -> Result<(f64, u8, u8)> {
     let max_amplitude = 10.0_f64.powf(-headroom_db / 20.0);
 
     Ok((max_amplitude, max_gain, min_gain))
+}
+
+/// Find maximum amplitude in an MP3 file and return a named struct.
+///
+/// This is the preferred alternative to [`find_max_amplitude`] which returns
+/// a tuple. The tuple variant will be removed in a future major release.
+#[cfg(feature = "replaygain")]
+pub fn find_max_amplitude_detailed(file_path: &Path) -> Result<MaxAmplitudeResult> {
+    let (max_amplitude, max_global_gain, min_global_gain) = find_max_amplitude(file_path)?;
+    Ok(MaxAmplitudeResult {
+        max_amplitude,
+        max_global_gain,
+        min_global_gain,
+    })
+}
+
+/// Find maximum amplitude (fallback without replaygain feature), returning a named struct.
+#[cfg(not(feature = "replaygain"))]
+pub fn find_max_amplitude_detailed(file_path: &Path) -> Result<MaxAmplitudeResult> {
+    let (max_amplitude, max_global_gain, min_global_gain) = find_max_amplitude(file_path)?;
+    Ok(MaxAmplitudeResult {
+        max_amplitude,
+        max_global_gain,
+        min_global_gain,
+    })
 }
 
 /// Apply gain with wrapping (values wrap around instead of clamping)

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,10 @@ use mp3rgain::mp4meta;
 use mp3rgain::replaygain::{self, AudioFileType, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{
     analyze, apply_gain, apply_gain_channel_with_undo, apply_gain_with_undo,
-    apply_gain_with_undo_wrap, apply_gain_wrap, db_to_steps, delete_ape_tag, find_max_amplitude,
-    read_ape_tag_from_file, steps_to_db, undo_gain, Channel, GAIN_STEP_DB, TAG_MP3GAIN_MINMAX,
-    TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
-    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
+    apply_gain_with_undo_wrap, apply_gain_wrap, db_to_steps, delete_ape_tag,
+    find_max_amplitude_detailed, read_ape_tag_from_file, steps_to_db, undo_gain, Channel,
+    GAIN_STEP_DB, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN,
+    TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use serde::Serialize;
 use std::env;
@@ -597,8 +597,11 @@ fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
         let filename = get_filename(file);
         progress_set_message(&pb, filename);
 
-        match find_max_amplitude(file) {
-            Ok((max_amp, max_gain, min_gain)) => {
+        match find_max_amplitude_detailed(file) {
+            Ok(amp_result) => {
+                let max_amp = amp_result.max_amplitude;
+                let max_gain = amp_result.max_global_gain;
+                let min_gain = amp_result.min_global_gain;
                 // Convert to PCM scale (like mp3gain: 0-32768+)
                 let max_pcm_sample = max_amp * 32768.0;
                 let headroom_db = if max_amp > 0.0 {
@@ -1057,6 +1060,7 @@ fn cmd_apply_channel(
     let channel_name = match channel {
         Channel::Left => "left",
         Channel::Right => "right",
+        _ => "unknown",
     };
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
@@ -1625,6 +1629,7 @@ fn process_apply_channel(
     let channel_name = match channel {
         Channel::Left => "left",
         Channel::Right => "right",
+        _ => "unknown",
     };
 
     // Save original timestamp if needed
@@ -1704,8 +1709,9 @@ fn process_info(file: &Path, opts: &Options) -> Result<JsonFileResult> {
         match replaygain::analyze_track_with_index(file, opts.track_index) {
             Ok(rg_result) => {
                 // Get max amplitude info
-                let (max_amp, max_gain, min_gain) =
-                    find_max_amplitude(file).unwrap_or((1.0, 255, 0));
+                let (max_amp, max_gain, min_gain) = find_max_amplitude_detailed(file)
+                    .map(|r| (r.max_amplitude, r.max_global_gain, r.min_global_gain))
+                    .unwrap_or((1.0, 255, 0));
 
                 // Calculate gain with modifier (mp3gain compatible: -d modifies suggested gain)
                 let gain_db = rg_result.gain_db + opts.gain_modifier_db;
@@ -2093,6 +2099,7 @@ fn process_apply_replaygain_with_album(
             let format_info = match result.file_type {
                 AudioFileType::Aac => " (tags only)",
                 AudioFileType::Mp3 => "",
+                _ => "",
             };
             println!(
                 "  {} [DRY RUN] {} (would apply {:+.1} dB, {} steps{})",

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -103,15 +103,25 @@ impl BoxHeader {
 }
 
 /// Freeform tag (---- box) for ReplayGain
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeformTag {
     pub namespace: String,
     pub name: String,
     pub value: String,
 }
 
+impl std::fmt::Display for FreeformTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}={}", self.namespace, self.name, self.value)
+    }
+}
+
 /// Collection of ReplayGain tags
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReplayGainTags {
     pub track_gain: Option<String>,
     pub track_peak: Option<String>,
@@ -140,7 +150,32 @@ impl ReplayGainTags {
             && self.album_gain.is_none()
             && self.album_peak.is_none()
     }
+}
 
+impl std::fmt::Display for ReplayGainTags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut parts = Vec::new();
+        if let Some(ref g) = self.track_gain {
+            parts.push(format!("Track: {}", g));
+        }
+        if let Some(ref p) = self.track_peak {
+            parts.push(format!("Peak: {}", p));
+        }
+        if let Some(ref g) = self.album_gain {
+            parts.push(format!("Album: {}", g));
+        }
+        if let Some(ref p) = self.album_peak {
+            parts.push(format!("Album Peak: {}", p));
+        }
+        if parts.is_empty() {
+            f.write_str("(no tags)")
+        } else {
+            write!(f, "{}", parts.join(", "))
+        }
+    }
+}
+
+impl ReplayGainTags {
     fn to_freeform_tags(&self) -> Vec<FreeformTag> {
         let entries: [(&str, &Option<String>); 4] = [
             (RG_TRACK_GAIN, &self.track_gain),
@@ -993,11 +1028,23 @@ const ALAC: u32 = u32::from_be_bytes(*b"alac");
 const STSD: u32 = u32::from_be_bytes(*b"stsd");
 
 /// Audio codec detected in an MP4 file
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Mp4AudioCodec {
     Aac,
     Alac,
     Unknown,
+}
+
+impl std::fmt::Display for Mp4AudioCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Mp4AudioCodec::Aac => f.write_str("AAC"),
+            Mp4AudioCodec::Alac => f.write_str("ALAC"),
+            Mp4AudioCodec::Unknown => f.write_str("Unknown"),
+        }
+    }
 }
 
 /// Detect the audio codec in an MP4 file by inspecting the stsd box.

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -44,7 +44,9 @@ pub const REPLAYGAIN_REFERENCE_DB: f64 = 89.0;
 const PINK_REF: f64 = 64.82;
 
 /// Audio file type
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AudioFileType {
     /// MP3 file
     Mp3,
@@ -52,8 +54,19 @@ pub enum AudioFileType {
     Aac,
 }
 
+impl std::fmt::Display for AudioFileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AudioFileType::Mp3 => f.write_str("MP3"),
+            AudioFileType::Aac => f.write_str("AAC"),
+        }
+    }
+}
+
 /// Result of ReplayGain analysis for a single track
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReplayGainResult {
     /// Calculated loudness in dB
     pub loudness_db: f64,
@@ -74,8 +87,16 @@ impl ReplayGainResult {
     }
 }
 
+impl std::fmt::Display for ReplayGainResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:+.2} dB (peak: {:.6})", self.gain_db, self.peak)
+    }
+}
+
 /// Result of album gain analysis
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlbumGainResult {
     /// Individual track results
     pub tracks: Vec<ReplayGainResult>,
@@ -94,6 +115,18 @@ impl AlbumGainResult {
     }
 }
 
+impl std::fmt::Display for AlbumGainResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Album: {:+.2} dB (peak: {:.6}, {} tracks)",
+            self.album_gain_db,
+            self.album_peak,
+            self.tracks.len()
+        )
+    }
+}
+
 // =============================================================================
 // Equal-loudness filter coefficients
 // =============================================================================
@@ -107,7 +140,7 @@ mod filter_coeffs {
     // =========================================================================
     // 96000 Hz coefficients (ABYule[0], ABButter[0])
     // =========================================================================
-    pub const YULE_A_96000: [f64; 11] = [
+    pub(super) const YULE_A_96000: [f64; 11] = [
         1.0,
         -7.22103125152679,
         24.7034187975904,
@@ -121,7 +154,7 @@ mod filter_coeffs {
         0.340344741393305,
     ];
 
-    pub const YULE_B_96000: [f64; 11] = [
+    pub(super) const YULE_B_96000: [f64; 11] = [
         0.006471345933032,
         -0.02567678242161,
         0.049805860704367,
@@ -135,14 +168,15 @@ mod filter_coeffs {
         -0.000261819276949,
     ];
 
-    pub const BUTTER_A_96000: [f64; 3] = [1.0, -1.98611621154089, 0.986211929160751];
+    pub(super) const BUTTER_A_96000: [f64; 3] = [1.0, -1.98611621154089, 0.986211929160751];
 
-    pub const BUTTER_B_96000: [f64; 3] = [0.99308203517541, -1.98616407035082, 0.99308203517541];
+    pub(super) const BUTTER_B_96000: [f64; 3] =
+        [0.99308203517541, -1.98616407035082, 0.99308203517541];
 
     // =========================================================================
     // 88200 Hz coefficients (ABYule[1], ABButter[1])
     // =========================================================================
-    pub const YULE_A_88200: [f64; 11] = [
+    pub(super) const YULE_A_88200: [f64; 11] = [
         1.0,
         -7.19001570087017,
         24.4109412087159,
@@ -156,7 +190,7 @@ mod filter_coeffs {
         0.223619893831468,
     ];
 
-    pub const YULE_B_88200: [f64; 11] = [
+    pub(super) const YULE_B_88200: [f64; 11] = [
         0.015415414474287,
         -0.07691359399407,
         0.196677418516518,
@@ -170,14 +204,15 @@ mod filter_coeffs {
         0.001748085184539,
     ];
 
-    pub const BUTTER_A_88200: [f64; 3] = [1.0, -1.98488843762334, 0.979389350028798];
+    pub(super) const BUTTER_A_88200: [f64; 3] = [1.0, -1.98488843762334, 0.979389350028798];
 
-    pub const BUTTER_B_88200: [f64; 3] = [0.992472550461293, -1.98494510092258, 0.992472550461293];
+    pub(super) const BUTTER_B_88200: [f64; 3] =
+        [0.992472550461293, -1.98494510092258, 0.992472550461293];
 
     // =========================================================================
     // 64000 Hz coefficients (ABYule[2], ABButter[2])
     // =========================================================================
-    pub const YULE_A_64000: [f64; 11] = [
+    pub(super) const YULE_A_64000: [f64; 11] = [
         1.0,
         -5.74819833657784,
         16.246507961894,
@@ -191,7 +226,7 @@ mod filter_coeffs {
         0.223619893831468,
     ];
 
-    pub const YULE_B_64000: [f64; 11] = [
+    pub(super) const YULE_B_64000: [f64; 11] = [
         0.021776466467053,
         -0.062376961003801,
         0.107731165328514,
@@ -205,14 +240,15 @@ mod filter_coeffs {
         0.00117925454213,
     ];
 
-    pub const BUTTER_A_64000: [f64; 3] = [1.0, -1.97917472731008, 0.979389350028798];
+    pub(super) const BUTTER_A_64000: [f64; 3] = [1.0, -1.97917472731008, 0.979389350028798];
 
-    pub const BUTTER_B_64000: [f64; 3] = [0.989641019334721, -1.97928203866944, 0.989641019334721];
+    pub(super) const BUTTER_B_64000: [f64; 3] =
+        [0.989641019334721, -1.97928203866944, 0.989641019334721];
 
     // =========================================================================
     // 48000 Hz coefficients (ABYule[3], ABButter[3])
     // =========================================================================
-    pub const YULE_A_48000: [f64; 11] = [
+    pub(super) const YULE_A_48000: [f64; 11] = [
         1.0,
         -3.84664617118067,
         7.81501653005538,
@@ -226,7 +262,7 @@ mod filter_coeffs {
         0.13919314567432,
     ];
 
-    pub const YULE_B_48000: [f64; 11] = [
+    pub(super) const YULE_B_48000: [f64; 11] = [
         0.03857599435200,
         -0.02160367184185,
         -0.00123395316851,
@@ -240,14 +276,15 @@ mod filter_coeffs {
         0.00288463683916,
     ];
 
-    pub const BUTTER_A_48000: [f64; 3] = [1.0, -1.97223372919527, 0.97261396931306];
+    pub(super) const BUTTER_A_48000: [f64; 3] = [1.0, -1.97223372919527, 0.97261396931306];
 
-    pub const BUTTER_B_48000: [f64; 3] = [0.98621192462708, -1.97242384925416, 0.98621192462708];
+    pub(super) const BUTTER_B_48000: [f64; 3] =
+        [0.98621192462708, -1.97242384925416, 0.98621192462708];
 
     // =========================================================================
     // 44100 Hz coefficients (ABYule[4], ABButter[4])
     // =========================================================================
-    pub const YULE_A_44100: [f64; 11] = [
+    pub(super) const YULE_A_44100: [f64; 11] = [
         1.0,
         -3.47845948550071,
         6.36317777566148,
@@ -261,7 +298,7 @@ mod filter_coeffs {
         0.13149317958808,
     ];
 
-    pub const YULE_B_44100: [f64; 11] = [
+    pub(super) const YULE_B_44100: [f64; 11] = [
         0.05418656406430,
         -0.02911007808948,
         -0.00848709379851,
@@ -275,14 +312,15 @@ mod filter_coeffs {
         -0.00187763777362,
     ];
 
-    pub const BUTTER_A_44100: [f64; 3] = [1.0, -1.96977855582618, 0.97022847566350];
+    pub(super) const BUTTER_A_44100: [f64; 3] = [1.0, -1.96977855582618, 0.97022847566350];
 
-    pub const BUTTER_B_44100: [f64; 3] = [0.98500175787242, -1.97000351574484, 0.98500175787242];
+    pub(super) const BUTTER_B_44100: [f64; 3] =
+        [0.98500175787242, -1.97000351574484, 0.98500175787242];
 
     // =========================================================================
     // 32000 Hz coefficients (ABYule[5], ABButter[5])
     // =========================================================================
-    pub const YULE_A_32000: [f64; 11] = [
+    pub(super) const YULE_A_32000: [f64; 11] = [
         1.0,
         -2.37898834973084,
         2.84868151156327,
@@ -296,7 +334,7 @@ mod filter_coeffs {
         0.02347897407020,
     ];
 
-    pub const YULE_B_32000: [f64; 11] = [
+    pub(super) const YULE_B_32000: [f64; 11] = [
         0.15457299681924,
         -0.09331049056315,
         -0.06247880153653,
@@ -310,14 +348,15 @@ mod filter_coeffs {
         -0.00881362733839,
     ];
 
-    pub const BUTTER_A_32000: [f64; 3] = [1.0, -1.95835380975398, 0.95920349965459];
+    pub(super) const BUTTER_A_32000: [f64; 3] = [1.0, -1.95835380975398, 0.95920349965459];
 
-    pub const BUTTER_B_32000: [f64; 3] = [0.97938932735214, -1.95877865470428, 0.97938932735214];
+    pub(super) const BUTTER_B_32000: [f64; 3] =
+        [0.97938932735214, -1.95877865470428, 0.97938932735214];
 
     // =========================================================================
     // 24000 Hz coefficients (ABYule[6], ABButter[6])
     // =========================================================================
-    pub const YULE_A_24000: [f64; 11] = [
+    pub(super) const YULE_A_24000: [f64; 11] = [
         1.0,
         -1.61273165137247,
         1.07977492259970,
@@ -331,7 +370,7 @@ mod filter_coeffs {
         0.00302439095741,
     ];
 
-    pub const YULE_B_24000: [f64; 11] = [
+    pub(super) const YULE_B_24000: [f64; 11] = [
         0.30296907319327,
         -0.22613988682123,
         -0.08587323730772,
@@ -345,14 +384,15 @@ mod filter_coeffs {
         -0.02950134983287,
     ];
 
-    pub const BUTTER_A_24000: [f64; 3] = [1.0, -1.95002759149878, 0.95124613669835];
+    pub(super) const BUTTER_A_24000: [f64; 3] = [1.0, -1.95002759149878, 0.95124613669835];
 
-    pub const BUTTER_B_24000: [f64; 3] = [0.97531843204928, -1.95063686409857, 0.97531843204928];
+    pub(super) const BUTTER_B_24000: [f64; 3] =
+        [0.97531843204928, -1.95063686409857, 0.97531843204928];
 
     // =========================================================================
     // 22050 Hz coefficients (ABYule[7], ABButter[7])
     // =========================================================================
-    pub const YULE_A_22050: [f64; 11] = [
+    pub(super) const YULE_A_22050: [f64; 11] = [
         1.0,
         -1.49858979367799,
         0.87350271418188,
@@ -366,7 +406,7 @@ mod filter_coeffs {
         0.02977207319925,
     ];
 
-    pub const YULE_B_22050: [f64; 11] = [
+    pub(super) const YULE_B_22050: [f64; 11] = [
         0.33642304856132,
         -0.25572241425570,
         -0.11828570177555,
@@ -380,14 +420,15 @@ mod filter_coeffs {
         -0.01760176568150,
     ];
 
-    pub const BUTTER_A_22050: [f64; 3] = [1.0, -1.94561023566527, 0.94705070426118];
+    pub(super) const BUTTER_A_22050: [f64; 3] = [1.0, -1.94561023566527, 0.94705070426118];
 
-    pub const BUTTER_B_22050: [f64; 3] = [0.97316523498161, -1.94633046996323, 0.97316523498161];
+    pub(super) const BUTTER_B_22050: [f64; 3] =
+        [0.97316523498161, -1.94633046996323, 0.97316523498161];
 
     // =========================================================================
     // 16000 Hz coefficients (ABYule[8], ABButter[8])
     // =========================================================================
-    pub const YULE_A_16000: [f64; 11] = [
+    pub(super) const YULE_A_16000: [f64; 11] = [
         1.0,
         -0.62820619233671,
         0.29661783706366,
@@ -401,7 +442,7 @@ mod filter_coeffs {
         0.03222754072173,
     ];
 
-    pub const YULE_B_16000: [f64; 11] = [
+    pub(super) const YULE_B_16000: [f64; 11] = [
         0.44915256608450,
         -0.14351757464547,
         -0.22784394429749,
@@ -415,14 +456,15 @@ mod filter_coeffs {
         0.00541907748707,
     ];
 
-    pub const BUTTER_A_16000: [f64; 3] = [1.0, -1.92783286977036, 0.93034775234268];
+    pub(super) const BUTTER_A_16000: [f64; 3] = [1.0, -1.92783286977036, 0.93034775234268];
 
-    pub const BUTTER_B_16000: [f64; 3] = [0.96454515552826, -1.92909031105652, 0.96454515552826];
+    pub(super) const BUTTER_B_16000: [f64; 3] =
+        [0.96454515552826, -1.92909031105652, 0.96454515552826];
 
     // =========================================================================
     // 12000 Hz coefficients (ABYule[9], ABButter[9])
     // =========================================================================
-    pub const YULE_A_12000: [f64; 11] = [
+    pub(super) const YULE_A_12000: [f64; 11] = [
         1.0,
         -1.04800335126349,
         0.29156311971249,
@@ -436,7 +478,7 @@ mod filter_coeffs {
         0.01807364323573,
     ];
 
-    pub const YULE_B_12000: [f64; 11] = [
+    pub(super) const YULE_B_12000: [f64; 11] = [
         0.56619470757641,
         -0.75464456939302,
         0.16242137742230,
@@ -450,14 +492,15 @@ mod filter_coeffs {
         -0.00588215443421,
     ];
 
-    pub const BUTTER_A_12000: [f64; 3] = [1.0, -1.91858953033784, 0.92177618768381];
+    pub(super) const BUTTER_A_12000: [f64; 3] = [1.0, -1.91858953033784, 0.92177618768381];
 
-    pub const BUTTER_B_12000: [f64; 3] = [0.96009142950541, -1.92018285901082, 0.96009142950541];
+    pub(super) const BUTTER_B_12000: [f64; 3] =
+        [0.96009142950541, -1.92018285901082, 0.96009142950541];
 
     // =========================================================================
     // 11025 Hz coefficients (ABYule[10], ABButter[10])
     // =========================================================================
-    pub const YULE_A_11025: [f64; 11] = [
+    pub(super) const YULE_A_11025: [f64; 11] = [
         1.0,
         -0.51035327095184,
         -0.31863563325245,
@@ -471,7 +514,7 @@ mod filter_coeffs {
         0.01818801111503,
     ];
 
-    pub const YULE_B_11025: [f64; 11] = [
+    pub(super) const YULE_B_11025: [f64; 11] = [
         0.58100494960553,
         -0.53174909058578,
         -0.14289799034253,
@@ -485,14 +528,15 @@ mod filter_coeffs {
         -0.00749618797172,
     ];
 
-    pub const BUTTER_A_11025: [f64; 3] = [1.0, -1.91542108074780, 0.91885558323625];
+    pub(super) const BUTTER_A_11025: [f64; 3] = [1.0, -1.91542108074780, 0.91885558323625];
 
-    pub const BUTTER_B_11025: [f64; 3] = [0.95856916599601, -1.91713833199203, 0.95856916599601];
+    pub(super) const BUTTER_B_11025: [f64; 3] =
+        [0.95856916599601, -1.91713833199203, 0.95856916599601];
 
     // =========================================================================
     // 8000 Hz coefficients (ABYule[11], ABButter[11])
     // =========================================================================
-    pub const YULE_A_8000: [f64; 11] = [
+    pub(super) const YULE_A_8000: [f64; 11] = [
         1.0,
         -0.25049871956020,
         -0.43193942311114,
@@ -506,7 +550,7 @@ mod filter_coeffs {
         0.04704409688120,
     ];
 
-    pub const YULE_B_8000: [f64; 11] = [
+    pub(super) const YULE_B_8000: [f64; 11] = [
         0.53648789255105,
         -0.42163034350696,
         -0.00275953611929,
@@ -520,9 +564,10 @@ mod filter_coeffs {
         -0.02217936801134,
     ];
 
-    pub const BUTTER_A_8000: [f64; 3] = [1.0, -1.88903307939452, 0.89487434461664];
+    pub(super) const BUTTER_A_8000: [f64; 3] = [1.0, -1.88903307939452, 0.89487434461664];
 
-    pub const BUTTER_B_8000: [f64; 3] = [0.94597685600279, -1.89195371200558, 0.94597685600279];
+    pub(super) const BUTTER_B_8000: [f64; 3] =
+        [0.94597685600279, -1.89195371200558, 0.94597685600279];
 }
 
 /// Small constant to prevent denormal float slowdowns
@@ -1121,7 +1166,9 @@ pub fn is_available() -> bool {
 }
 
 /// Result of peak amplitude analysis
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeakAmplitudeResult {
     /// Maximum peak amplitude (normalized, can exceed 1.0 for clipping audio)
     pub peak: f64,
@@ -1129,6 +1176,12 @@ pub struct PeakAmplitudeResult {
     pub peak_pcm: f64,
     /// Sample rate of the audio
     pub sample_rate: u32,
+}
+
+impl std::fmt::Display for PeakAmplitudeResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "peak: {:.6} ({:.1} PCM)", self.peak, self.peak_pcm)
+    }
 }
 
 /// Find the peak amplitude of an audio file by decoding the audio.


### PR DESCRIPTION
## Summary

Closes #68 (partial — non-breaking items only)

Non-breaking library API enhancements to prepare for a stable v2.0 release. All changes are additive and backward-compatible.

## Changes

### P0 - Critical
- Add `#[non_exhaustive]` to all public enums and structs — allows adding variants/fields in future minor releases without breaking downstream code

### P1 - High (preparation)
- Make `MpegVersion` and `ChannelMode` enums public (previously internal) with `Display` and standard traits
- Add typed accessors `Mp3Analysis::mpeg_version_parsed()` / `channel_mode_parsed()` as non-breaking bridge to v2.0 field type change
- Add `MaxAmplitudeResult` struct and `find_max_amplitude_detailed()` function as named-struct alternative to the tuple-returning `find_max_amplitude()`

### P2 - Medium
- Add standard trait derives (`PartialEq`, `Eq`, `Hash`) to all applicable public types
- Add `Display` implementations for all public types
- Add `Serialize` / `Deserialize` behind a `serde` feature flag
- Add `ApeTag::iter()` and `ApeTag::len()` methods
- Add `Channel::other()` convenience method

### P3 - Low
- Remove unnecessary `pub` from `filter_coeffs` internal constants (changed to `pub(super)`)

### Other
- Bump version to 1.7.0
- Update roadmap with completed v1.7.0 items and deferred v2.0 breaking changes

## Deferred to v2.0 (breaking changes)
- Replace `anyhow::Result` with custom error types (`thiserror`)
- Change `Mp3Analysis` String fields to enum types
- Remove old tuple-returning `find_max_amplitude`
- Private struct fields with accessor methods
- Builder pattern for `apply_gain*` functions
- Submodule reorganization

## Verification
- `cargo build --release` ✅
- `cargo test` ✅ (14 unit + 21 integration + 1 doc test)
- `cargo build --release --features serde` ✅
- GUI build (`mp3rgui`) ✅