### PR TITLE
Add AUR package for mp3rgui (GUI application)

### DIFF
--- a/packages/aur-gui/.SRCINFO
+++ b/packages/aur-gui/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = mp3rgui
+	pkgdesc = GUI application for mp3rgain - lossless MP3 volume adjustment
+	pkgver = 1.7.0
+	pkgrel = 1
+	url = https://github.com/M-Igashi/mp3rgain
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	makedepends = rust
+	makedepends = cargo
+	depends = gcc-libs
+	depends = gtk3
+	optdepends = mp3rgain: CLI tool for batch processing
+	source = https://github.com/M-Igashi/mp3rgain/archive/v1.7.0.tar.gz
+	sha256sums = SKIP
+
+pkgname = mp3rgui

--- a/packages/aur-gui/PKGBUILD
+++ b/packages/aur-gui/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Jesse Pinkman <M-Igashi@users.noreply.github.com>
+pkgname=mp3rgui
+pkgver=1.7.0
+pkgrel=1
+pkgdesc='GUI application for mp3rgain - lossless MP3 volume adjustment'
+arch=('x86_64' 'aarch64')
+url='https://github.com/M-Igashi/mp3rgain'
+license=('MIT')
+depends=('gcc-libs' 'gtk3')
+makedepends=('rust' 'cargo')
+optdepends=('mp3rgain: CLI tool for batch processing')
+source=("https://github.com/M-Igashi/mp3rgain/archive/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "mp3rgain-${pkgver}/mp3rgui"
+    export CARGO_HOME="${srcdir}/cargo-home"
+    cargo build --release --locked
+}
+
+check() {
+    cd "mp3rgain-${pkgver}/mp3rgui"
+    export CARGO_HOME="${srcdir}/cargo-home"
+    cargo test --release --locked
+}
+
+package() {
+    cd "mp3rgain-${pkgver}"
+    install -Dm755 mp3rgui/target/release/mp3rgui "${pkgdir}/usr/bin/mp3rgui"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/mp3rgui/LICENSE"
+    install -Dm644 mp3rgui/icons/icon_128x128.png "${pkgdir}/usr/share/icons/hicolor/128x128/apps/mp3rgui.png"
+    install -Dm644 mp3rgui/icons/icon_64x64.png "${pkgdir}/usr/share/icons/hicolor/64x64/apps/mp3rgui.png"
+    install -Dm644 mp3rgui/icons/icon_48x48.png "${pkgdir}/usr/share/icons/hicolor/48x48/apps/mp3rgui.png"
+    install -Dm644 mp3rgui/icons/icon_32x32.png "${pkgdir}/usr/share/icons/hicolor/32x32/apps/mp3rgui.png"
+    install -Dm644 mp3rgui/icons/icon_16x16.png "${pkgdir}/usr/share/icons/hicolor/16x16/apps/mp3rgui.png"
+    install -Dm644 packages/aur-gui/mp3rgui.desktop "${pkgdir}/usr/share/applications/mp3rgui.desktop"
+}

--- a/packages/aur-gui/README.md
+++ b/packages/aur-gui/README.md
@@ -1,0 +1,74 @@
+# mp3rgui AUR Package
+
+This directory contains the PKGBUILD for the **mp3rgui** (GUI application) Arch Linux User Repository (AUR) package.
+
+For the CLI tool (`mp3rgain`), see `../aur/`.
+
+## Installation (for users)
+
+```bash
+# Using yay
+yay -S mp3rgui
+
+# Using paru
+paru -S mp3rgui
+
+# Manual installation
+git clone https://aur.archlinux.org/mp3rgui.git
+cd mp3rgui
+makepkg -si
+```
+
+## Dependencies
+
+- **Runtime**: `gcc-libs`, `gtk3` (for native file dialogs)
+- **Build**: `rust`, `cargo`
+- **Optional**: `mp3rgain` (CLI tool for batch processing)
+
+## Publishing to AUR (for maintainers)
+
+1. Clone the AUR repository:
+   ```bash
+   git clone ssh://aur@aur.archlinux.org/mp3rgui.git aur-mp3rgui
+   cd aur-mp3rgui
+   ```
+
+2. Copy the package files:
+   ```bash
+   cp /path/to/mp3rgain/packages/aur-gui/PKGBUILD .
+   cp /path/to/mp3rgain/packages/aur-gui/.SRCINFO .
+   cp /path/to/mp3rgain/packages/aur-gui/mp3rgui.desktop .
+   ```
+
+3. Update the sha256sum in PKGBUILD:
+   ```bash
+   updpkgsums
+   ```
+
+4. Regenerate .SRCINFO:
+   ```bash
+   makepkg --printsrcinfo > .SRCINFO
+   ```
+
+5. Test the build:
+   ```bash
+   makepkg -si
+   ```
+
+6. Commit and push:
+   ```bash
+   git add PKGBUILD .SRCINFO mp3rgui.desktop
+   git commit -m "Update to version X.Y.Z"
+   git push
+   ```
+
+## Version Updates
+
+When releasing a new version:
+
+1. Update `pkgver` in PKGBUILD
+2. Reset `pkgrel` to 1
+3. Update sha256sum with `updpkgsums`
+4. Regenerate .SRCINFO
+5. Test build locally
+6. Push to AUR

--- a/packages/aur-gui/mp3rgui.desktop
+++ b/packages/aur-gui/mp3rgui.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=mp3rgui
+GenericName=Audio Volume Normalizer
+Comment=Lossless MP3 volume adjustment using ReplayGain
+Exec=mp3rgui
+Icon=mp3rgui
+Terminal=false
+Categories=AudioVideo;Audio;
+Keywords=mp3;audio;gain;volume;normalize;replaygain;
+MimeType=audio/mpeg;audio/mp4;audio/aac;


### PR DESCRIPTION
## Summary

- Add `packages/aur-gui/PKGBUILD` for building mp3rgui from source on Arch Linux
- Add `.desktop` entry for desktop environment integration (app launcher, MIME type associations)
- Add `.SRCINFO` for AUR submission
- Add `README.md` with installation and maintainer publishing instructions

## Details

- **Package name**: `mp3rgui`
- **Dependencies**: `gcc-libs`, `gtk3` (for native file dialogs via `rfd`)
- **Build deps**: `rust`, `cargo`
- **Icons**: Installs hicolor icons at 16x16 through 128x128

## Test plan

- [ ] Test PKGBUILD build on Arch Linux (`makepkg -si`)
- [ ] Verify desktop entry appears in application launcher
- [ ] Verify file dialog works with GTK3 backend
- [ ] Publish to AUR after merge

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)