### PR TITLE
Add AUR package auto-update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,3 +359,40 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Update AUR packages (CLI + GUI)
+  update-aur:
+    name: Update AUR Packages
+    needs: release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Update AUR package versions
+        run: |
+          VERSION=${{ needs.release.outputs.version }}
+
+          # Update CLI PKGBUILD and .SRCINFO
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packages/aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" packages/aur/PKGBUILD
+          sed -i "s/pkgver = .*/pkgver = ${VERSION}/" packages/aur/.SRCINFO
+          sed -i "s/pkgrel = .*/pkgrel = 1/" packages/aur/.SRCINFO
+          sed -i "s|source = https://github.com/M-Igashi/mp3rgain/archive/v.*.tar.gz|source = https://github.com/M-Igashi/mp3rgain/archive/v${VERSION}.tar.gz|" packages/aur/.SRCINFO
+
+          # Update GUI PKGBUILD and .SRCINFO
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packages/aur-gui/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" packages/aur-gui/PKGBUILD
+          sed -i "s/pkgver = .*/pkgver = ${VERSION}/" packages/aur-gui/.SRCINFO
+          sed -i "s/pkgrel = .*/pkgrel = 1/" packages/aur-gui/.SRCINFO
+          sed -i "s|source = https://github.com/M-Igashi/mp3rgain/archive/v.*.tar.gz|source = https://github.com/M-Igashi/mp3rgain/archive/v${VERSION}.tar.gz|" packages/aur-gui/.SRCINFO
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add packages/aur/ packages/aur-gui/
+          git commit -m "Update AUR packages to ${{ needs.release.outputs.version }}" || exit 0
+          git push


### PR DESCRIPTION
## Summary

- Add `update-aur` job to release workflow that auto-updates both CLI and GUI AUR packages on new release tags
- Updates `pkgver`, `pkgrel`, and source URLs in PKGBUILD and .SRCINFO for `packages/aur/` and `packages/aur-gui/`

## Details

The new job runs after the release is created (`needs: release`) and:
1. Checks out master branch
2. Uses `sed` to update version numbers in all AUR package files
3. Commits and pushes the changes

Follows the same pattern as existing Scoop/Homebrew update jobs (`continue-on-error: true`).

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Verify the job runs successfully on next release tag push
- [ ] Verify PKGBUILD and .SRCINFO are updated with correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)