### PR TITLE
Implement AAC undo, validation, and extended support (issue #64 phases 3-5)

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -51,8 +51,10 @@ pub struct AacAnalysis {
 
 const ID_SCE: u32 = 0; // Single Channel Element
 const ID_CPE: u32 = 1; // Channel Pair Element
+const ID_CCE: u32 = 2; // Coupling Channel Element
 const ID_LFE: u32 = 3; // LFE Channel Element
 const ID_DSE: u32 = 4; // Data Stream Element
+const ID_PCE: u32 = 5; // Program Config Element
 const ID_FIL: u32 = 6; // Fill Element
 const ID_END: u32 = 7; // End
 
@@ -920,11 +922,67 @@ fn skip_dse(reader: &mut BitReader) -> Result<()> {
 }
 
 fn skip_fil(reader: &mut BitReader) -> Result<()> {
+    // FIL carries extension data including SBR (HE-AAC).
+    // Skipping it is safe — the base layer global_gain is in SCE/CPE elements.
     let mut count = reader.read_bits(4)? as usize;
     if count == 15 {
         count += reader.read_bits(8)? as usize - 1;
     }
     reader.skip_bits(count * 8)?;
+    Ok(())
+}
+
+/// Skip program_config_element (ISO 14496-3 Table 4.2).
+/// PCE describes channel configuration but contains no audio data or global_gain.
+fn skip_pce(reader: &mut BitReader) -> Result<()> {
+    let _element_instance_tag = reader.read_bits(4)?;
+    let _object_type = reader.read_bits(2)?;
+    let _sampling_frequency_index = reader.read_bits(4)?;
+    let num_front = reader.read_bits(4)? as usize;
+    let num_side = reader.read_bits(4)? as usize;
+    let num_back = reader.read_bits(4)? as usize;
+    let num_lfe = reader.read_bits(2)? as usize;
+    let num_assoc_data = reader.read_bits(3)? as usize;
+    let num_valid_cc = reader.read_bits(4)? as usize;
+    let mono_mixdown_present = reader.read_bit()?;
+    if mono_mixdown_present {
+        reader.read_bits(4)?;
+    }
+    let stereo_mixdown_present = reader.read_bit()?;
+    if stereo_mixdown_present {
+        reader.read_bits(4)?;
+    }
+    let matrix_mixdown_idx_present = reader.read_bit()?;
+    if matrix_mixdown_idx_present {
+        reader.read_bits(3)?;
+    }
+    // front: is_cpe(1) + tag(4) = 5 bits each
+    for _ in 0..num_front {
+        reader.read_bits(5)?;
+    }
+    // side: is_cpe(1) + tag(4) = 5 bits each
+    for _ in 0..num_side {
+        reader.read_bits(5)?;
+    }
+    // back: is_cpe(1) + tag(4) = 5 bits each
+    for _ in 0..num_back {
+        reader.read_bits(5)?;
+    }
+    // LFE: tag(4) only
+    for _ in 0..num_lfe {
+        reader.read_bits(4)?;
+    }
+    // assoc_data: tag(4)
+    for _ in 0..num_assoc_data {
+        reader.read_bits(4)?;
+    }
+    // valid_cc: is_ind_sw(1) + tag(4) = 5 bits each
+    for _ in 0..num_valid_cc {
+        reader.read_bits(5)?;
+    }
+    reader.byte_align();
+    let comment_len = reader.read_bits(8)? as usize;
+    reader.skip_bits(comment_len * 8)?;
     Ok(())
 }
 
@@ -946,7 +1004,13 @@ fn parse_raw_data_block(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<
                 let locs = parse_cpe(reader, sample_rate)?;
                 locations.extend(locs);
             }
+            ID_CCE => {
+                // Coupling channel — complex interactions with other channels,
+                // skip this sample to avoid unintended effects
+                anyhow::bail!("CCE element found - sample skipped");
+            }
             ID_DSE => skip_dse(reader)?,
+            ID_PCE => skip_pce(reader)?,
             ID_FIL => skip_fil(reader)?,
             ID_END => break,
             _ => {
@@ -1055,6 +1119,96 @@ pub fn apply_aac_gain(file_path: &Path, gain_steps: i32) -> Result<usize> {
         .with_context(|| format!("Failed to write: {}", file_path.display()))?;
 
     Ok(modified)
+}
+
+/// Apply gain adjustment and store undo information in iTunes freeform tags.
+///
+/// Undo tags are stored cumulatively: each application adds to the existing
+/// undo value, so multiple gain changes can be fully reversed with a single undo.
+///
+/// Returns the number of modified gain locations.
+pub fn apply_aac_gain_with_undo(file_path: &Path, gain_steps: i32) -> Result<usize> {
+    if gain_steps == 0 {
+        return Ok(0);
+    }
+
+    let analysis = analyze_aac_gains(file_path)?;
+
+    // Read existing undo tags
+    let existing_undo = mp4meta::read_undo_tags(file_path)?;
+
+    // Parse existing undo value and accumulate
+    let existing_gain = parse_undo_gain(existing_undo.undo.as_deref());
+    let new_undo_gain = existing_gain + gain_steps;
+
+    // Apply gain to bitstream (in-place, no container change)
+    let mut data = std::fs::read(file_path)
+        .with_context(|| format!("Failed to read: {}", file_path.display()))?;
+
+    let modified = apply_aac_gain_to_data(&mut data, &analysis, gain_steps);
+
+    std::fs::write(file_path, &data)
+        .with_context(|| format!("Failed to write: {}", file_path.display()))?;
+
+    // Write undo tags (may change container structure)
+    let mut undo_tags = mp4meta::UndoTags::new();
+    undo_tags.undo = Some(format!("{:+04},{:+04},N", new_undo_gain, new_undo_gain));
+    undo_tags.minmax = if existing_undo.minmax.is_some() {
+        existing_undo.minmax
+    } else {
+        Some(format!("{},{}", analysis.min_gain, analysis.max_gain))
+    };
+    mp4meta::write_undo_tags(file_path, &undo_tags)?;
+
+    Ok(modified)
+}
+
+/// Undo gain changes on AAC/M4A file using stored undo information.
+///
+/// Reads the cumulative gain adjustment from undo tags, applies the inverse,
+/// and removes the undo tags. Note: the result is functionally equivalent to the
+/// original but may not be bit-for-bit identical due to MP4 container restructuring.
+///
+/// Returns the number of modified gain locations.
+pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
+    let undo_tags = mp4meta::read_undo_tags(file_path)?;
+    let undo_str = undo_tags
+        .undo
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("No undo tag found - cannot undo"))?;
+
+    let undo_gain = parse_undo_gain(Some(undo_str));
+
+    if undo_gain == 0 {
+        return Ok(0);
+    }
+
+    // Apply inverse gain
+    let analysis = analyze_aac_gains(file_path)?;
+    let mut data = std::fs::read(file_path)
+        .with_context(|| format!("Failed to read: {}", file_path.display()))?;
+
+    let modified = apply_aac_gain_to_data(&mut data, &analysis, -undo_gain);
+
+    std::fs::write(file_path, &data)
+        .with_context(|| format!("Failed to write: {}", file_path.display()))?;
+
+    // Remove undo tags
+    mp4meta::delete_undo_tags(file_path)?;
+
+    Ok(modified)
+}
+
+/// Parse undo gain value from tag string (e.g., "+003,+003,N" -> 3)
+fn parse_undo_gain(undo_str: Option<&str>) -> i32 {
+    match undo_str {
+        Some(v) => v
+            .split(',')
+            .next()
+            .and_then(|s| s.trim().parse::<i32>().ok())
+            .unwrap_or(0),
+        None => 0,
+    }
 }
 
 /// Analyze AAC/M4A file and locate all global_gain fields (read-only)
@@ -1298,5 +1452,14 @@ mod tests {
         let modified = apply_aac_gain_to_data(&mut data, &analysis, 0);
         assert_eq!(modified, 0);
         assert_eq!(data[10], 80); // unchanged
+    }
+
+    #[test]
+    fn test_parse_undo_gain() {
+        assert_eq!(parse_undo_gain(None), 0);
+        assert_eq!(parse_undo_gain(Some("+003,+003,N")), 3);
+        assert_eq!(parse_undo_gain(Some("-005,-005,N")), -5);
+        assert_eq!(parse_undo_gain(Some("+000,+000,N")), 0);
+        assert_eq!(parse_undo_gain(Some("invalid")), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,14 @@ fn cmd_delete_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
                 None
             };
 
-            match delete_ape_tag(file) {
+            let delete_result = if mp4meta::is_aac_file(file) {
+                // AAC: delete both ReplayGain and undo freeform tags
+                mp4meta::delete_replaygain_tags(file).and_then(|()| mp4meta::delete_undo_tags(file))
+            } else {
+                delete_ape_tag(file)
+            };
+
+            match delete_result {
                 Ok(()) => {
                     if let Some(mtime) = original_mtime {
                         restore_timestamp(file, mtime);
@@ -814,91 +821,153 @@ fn cmd_check_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
         let filename = get_filename(file);
         progress_set_message(&pb, filename);
 
-        match read_ape_tag_from_file(file) {
-            Ok(Some(tag)) => {
-                let undo = tag.get(TAG_MP3GAIN_UNDO);
-                let minmax = tag.get(TAG_MP3GAIN_MINMAX);
-                let track_gain = tag.get(TAG_REPLAYGAIN_TRACK_GAIN);
-                let track_peak = tag.get(TAG_REPLAYGAIN_TRACK_PEAK);
-                let album_gain = tag.get(TAG_REPLAYGAIN_ALBUM_GAIN);
-                let album_peak = tag.get(TAG_REPLAYGAIN_ALBUM_PEAK);
+        let is_aac = mp4meta::is_aac_file(file);
 
-                match opts.output_format {
-                    OutputFormat::Text => {
-                        println!("{}", filename.cyan().bold());
-                        if let Some(v) = undo {
-                            println!("  MP3GAIN_UNDO:         {}", v);
-                        }
-                        if let Some(v) = minmax {
-                            println!("  MP3GAIN_MINMAX:       {}", v);
-                        }
-                        if let Some(v) = track_gain {
-                            println!("  REPLAYGAIN_TRACK_GAIN: {}", v);
-                        }
-                        if let Some(v) = track_peak {
-                            println!("  REPLAYGAIN_TRACK_PEAK: {}", v);
-                        }
-                        if let Some(v) = album_gain {
-                            println!("  REPLAYGAIN_ALBUM_GAIN: {}", v);
-                        }
-                        if let Some(v) = album_peak {
-                            println!("  REPLAYGAIN_ALBUM_PEAK: {}", v);
-                        }
-                        if undo.is_none() && minmax.is_none() && track_gain.is_none() {
-                            println!("  (no mp3gain tags found)");
-                        }
-                        println!();
-                    }
-                    OutputFormat::Tsv => {
-                        println!(
-                            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                            filename,
-                            undo.unwrap_or("-"),
-                            minmax.unwrap_or("-"),
-                            track_gain.unwrap_or("-"),
-                            track_peak.unwrap_or("-"),
-                            album_gain.unwrap_or("-"),
-                            album_peak.unwrap_or("-")
-                        );
-                    }
-                    OutputFormat::Json => {
-                        let result = JsonFileResult {
-                            file: file.display().to_string(),
-                            status: Some("success".to_string()),
-                            ..Default::default()
-                        };
-                        // Note: we can add tag info to JSON if needed
-                        json_results.push(result);
-                    }
-                }
-            }
-            Ok(None) => match opts.output_format {
+        if is_aac {
+            // AAC: read iTunes freeform tags
+            let undo_tags = mp4meta::read_undo_tags(file).unwrap_or_default();
+            let rg_tags = mp4meta::read_replaygain_tags(file).unwrap_or_default();
+
+            let undo = undo_tags.undo.as_deref();
+            let minmax = undo_tags.minmax.as_deref();
+            let track_gain = rg_tags.track_gain.as_deref();
+            let track_peak = rg_tags.track_peak.as_deref();
+            let album_gain = rg_tags.album_gain.as_deref();
+            let album_peak = rg_tags.album_peak.as_deref();
+
+            match opts.output_format {
                 OutputFormat::Text => {
                     println!("{}", filename.cyan().bold());
-                    println!("  (no APE tag found)");
+                    if let Some(v) = undo {
+                        println!("  MP3RGAIN_UNDO:        {}", v);
+                    }
+                    if let Some(v) = minmax {
+                        println!("  MP3RGAIN_MINMAX:      {}", v);
+                    }
+                    if let Some(v) = track_gain {
+                        println!("  REPLAYGAIN_TRACK_GAIN: {}", v);
+                    }
+                    if let Some(v) = track_peak {
+                        println!("  REPLAYGAIN_TRACK_PEAK: {}", v);
+                    }
+                    if let Some(v) = album_gain {
+                        println!("  REPLAYGAIN_ALBUM_GAIN: {}", v);
+                    }
+                    if let Some(v) = album_peak {
+                        println!("  REPLAYGAIN_ALBUM_PEAK: {}", v);
+                    }
+                    if undo.is_none() && minmax.is_none() && track_gain.is_none() {
+                        println!("  (no tags found)");
+                    }
                     println!();
                 }
                 OutputFormat::Tsv => {
-                    println!("{}\t-\t-\t-\t-\t-\t-", filename);
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                        filename,
+                        undo.unwrap_or("-"),
+                        minmax.unwrap_or("-"),
+                        track_gain.unwrap_or("-"),
+                        track_peak.unwrap_or("-"),
+                        album_gain.unwrap_or("-"),
+                        album_peak.unwrap_or("-")
+                    );
                 }
                 OutputFormat::Json => {
                     json_results.push(JsonFileResult {
                         file: file.display().to_string(),
-                        status: Some("no_tag".to_string()),
+                        status: Some("success".to_string()),
                         ..Default::default()
                     });
                 }
-            },
-            Err(e) => {
-                if opts.output_format != OutputFormat::Json {
-                    eprintln!("{} - {}", filename.red(), e);
-                } else {
-                    json_results.push(JsonFileResult {
-                        file: file.display().to_string(),
-                        status: Some("error".to_string()),
-                        error: Some(e.to_string()),
-                        ..Default::default()
-                    });
+            }
+        } else {
+            // MP3: read APEv2 tags
+            match read_ape_tag_from_file(file) {
+                Ok(Some(tag)) => {
+                    let undo = tag.get(TAG_MP3GAIN_UNDO);
+                    let minmax = tag.get(TAG_MP3GAIN_MINMAX);
+                    let track_gain = tag.get(TAG_REPLAYGAIN_TRACK_GAIN);
+                    let track_peak = tag.get(TAG_REPLAYGAIN_TRACK_PEAK);
+                    let album_gain = tag.get(TAG_REPLAYGAIN_ALBUM_GAIN);
+                    let album_peak = tag.get(TAG_REPLAYGAIN_ALBUM_PEAK);
+
+                    match opts.output_format {
+                        OutputFormat::Text => {
+                            println!("{}", filename.cyan().bold());
+                            if let Some(v) = undo {
+                                println!("  MP3GAIN_UNDO:         {}", v);
+                            }
+                            if let Some(v) = minmax {
+                                println!("  MP3GAIN_MINMAX:       {}", v);
+                            }
+                            if let Some(v) = track_gain {
+                                println!("  REPLAYGAIN_TRACK_GAIN: {}", v);
+                            }
+                            if let Some(v) = track_peak {
+                                println!("  REPLAYGAIN_TRACK_PEAK: {}", v);
+                            }
+                            if let Some(v) = album_gain {
+                                println!("  REPLAYGAIN_ALBUM_GAIN: {}", v);
+                            }
+                            if let Some(v) = album_peak {
+                                println!("  REPLAYGAIN_ALBUM_PEAK: {}", v);
+                            }
+                            if undo.is_none() && minmax.is_none() && track_gain.is_none() {
+                                println!("  (no mp3gain tags found)");
+                            }
+                            println!();
+                        }
+                        OutputFormat::Tsv => {
+                            println!(
+                                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                                filename,
+                                undo.unwrap_or("-"),
+                                minmax.unwrap_or("-"),
+                                track_gain.unwrap_or("-"),
+                                track_peak.unwrap_or("-"),
+                                album_gain.unwrap_or("-"),
+                                album_peak.unwrap_or("-")
+                            );
+                        }
+                        OutputFormat::Json => {
+                            let result = JsonFileResult {
+                                file: file.display().to_string(),
+                                status: Some("success".to_string()),
+                                ..Default::default()
+                            };
+                            json_results.push(result);
+                        }
+                    }
+                }
+                Ok(None) => match opts.output_format {
+                    OutputFormat::Text => {
+                        println!("{}", filename.cyan().bold());
+                        println!("  (no APE tag found)");
+                        println!();
+                    }
+                    OutputFormat::Tsv => {
+                        println!("{}\t-\t-\t-\t-\t-\t-", filename);
+                    }
+                    OutputFormat::Json => {
+                        json_results.push(JsonFileResult {
+                            file: file.display().to_string(),
+                            status: Some("no_tag".to_string()),
+                            ..Default::default()
+                        });
+                    }
+                },
+                Err(e) => {
+                    if opts.output_format != OutputFormat::Json {
+                        eprintln!("{} - {}", filename.red(), e);
+                    } else {
+                        json_results.push(JsonFileResult {
+                            file: file.display().to_string(),
+                            status: Some("error".to_string()),
+                            error: Some(e.to_string()),
+                            ..Default::default()
+                        });
+                    }
                 }
             }
         }
@@ -1503,6 +1572,20 @@ fn process_apply(file: &PathBuf, steps: i32, opts: &Options) -> Result<JsonFileR
 
     let is_aac = mp4meta::is_aac_file(file);
 
+    // Multi-track warning for AAC files
+    if is_aac && opts.output_format == OutputFormat::Text && !opts.quiet {
+        let track_count = mp4meta::count_audio_tracks(file);
+        if track_count > 1 {
+            eprintln!(
+                "  {} {}{} - {} audio tracks detected, processing first track only",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                track_count
+            );
+        }
+    }
+
     // Check for clipping and possibly prevent it
     let mut actual_steps = steps;
     let mut warning_msg: Option<String> = None;
@@ -1581,7 +1664,15 @@ fn process_apply(file: &PathBuf, steps: i32, opts: &Options) -> Result<JsonFileR
 
     // Apply gain
     let apply_result = if is_aac {
-        apply_with_temp_file(file, |f| aac::apply_aac_gain(f, actual_steps), opts)
+        if opts.stored_tag_mode == StoredTagMode::Skip {
+            apply_with_temp_file(file, |f| aac::apply_aac_gain(f, actual_steps), opts)
+        } else {
+            apply_with_temp_file(
+                file,
+                |f| aac::apply_aac_gain_with_undo(f, actual_steps),
+                opts,
+            )
+        }
     } else if opts.stored_tag_mode == StoredTagMode::Skip {
         if opts.wrap_gain {
             apply_with_temp_file(file, |f| apply_gain_wrap(f, actual_steps), opts)
@@ -1915,7 +2006,14 @@ fn process_undo(file: &PathBuf, opts: &Options) -> Result<JsonFileResult> {
         });
     }
 
-    match undo_gain(file) {
+    let is_aac = mp4meta::is_aac_file(file);
+    let undo_result = if is_aac {
+        aac::undo_aac_gain(file)
+    } else {
+        undo_gain(file)
+    };
+
+    match undo_result {
         Ok(frames) => {
             if frames == 0 {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {
@@ -2210,9 +2308,22 @@ fn process_apply_replaygain_aac_with_album(
 ) -> Result<JsonFileResult> {
     let filename = get_filename(file);
 
-    // Apply bitstream gain modification
+    // Multi-track warning
+    if opts.output_format == OutputFormat::Text && !opts.quiet {
+        let track_count = mp4meta::count_audio_tracks(file);
+        if track_count > 1 {
+            eprintln!(
+                "  {} {} - {} audio tracks detected, processing first track only",
+                "!".yellow(),
+                filename,
+                track_count
+            );
+        }
+    }
+
+    // Apply bitstream gain modification with undo support
     let gain_modified = if actual_steps != 0 {
-        match aac::apply_aac_gain(file, actual_steps) {
+        match aac::apply_aac_gain_with_undo(file, actual_steps) {
             Ok(n) => n,
             Err(e) => {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -28,6 +28,10 @@ pub const RG_TRACK_PEAK: &str = "replaygain_track_peak";
 pub const RG_ALBUM_GAIN: &str = "replaygain_album_gain";
 pub const RG_ALBUM_PEAK: &str = "replaygain_album_peak";
 
+/// Undo tag keys (iTunes freeform format, same namespace)
+pub const UNDO_TAG: &str = "mp3rgain_undo";
+pub const MINMAX_TAG: &str = "mp3rgain_minmax";
+
 /// iTunes namespace for freeform tags
 const ITUNES_NAMESPACE: &str = "com.apple.iTunes";
 
@@ -183,6 +187,43 @@ impl ReplayGainTags {
             (RG_ALBUM_GAIN, &self.album_gain),
             (RG_ALBUM_PEAK, &self.album_peak),
         ];
+
+        entries
+            .into_iter()
+            .filter_map(|(name, value)| {
+                value.as_ref().map(|v| FreeformTag {
+                    namespace: ITUNES_NAMESPACE.to_string(),
+                    name: name.to_string(),
+                    value: v.clone(),
+                })
+            })
+            .collect()
+    }
+}
+
+/// Undo information stored as iTunes freeform tags
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UndoTags {
+    /// Cumulative gain adjustment, format: "+003,+003,N" (left,right,wrap_flag)
+    pub undo: Option<String>,
+    /// Original min/max global_gain before any modification, format: "80,120"
+    pub minmax: Option<String>,
+}
+
+impl UndoTags {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.undo.is_none() && self.minmax.is_none()
+    }
+
+    fn to_freeform_tags(&self) -> Vec<FreeformTag> {
+        let entries: [(&str, &Option<String>); 2] =
+            [(UNDO_TAG, &self.undo), (MINMAX_TAG, &self.minmax)];
 
         entries
             .into_iter()
@@ -437,6 +478,112 @@ pub fn read_replaygain_tags(file_path: &Path) -> Result<ReplayGainTags> {
     Ok(tags)
 }
 
+/// Read undo tags from MP4/M4A file
+pub fn read_undo_tags(file_path: &Path) -> Result<UndoTags> {
+    let data =
+        fs::read(file_path).with_context(|| format!("Failed to read: {}", file_path.display()))?;
+
+    let mut tags = UndoTags::new();
+
+    let (moov_pos, moov_header) = match find_box(&data, MOOV) {
+        Some(x) => x,
+        None => return Ok(tags),
+    };
+
+    let moov_content_start = moov_pos + moov_header.header_size as usize;
+    let moov_content_size = moov_header.content_size() as usize;
+
+    let (udta_pos, udta_header) =
+        match find_box_in_container(&data, moov_content_start, moov_content_size, UDTA) {
+            Some(x) => x,
+            None => return Ok(tags),
+        };
+
+    let udta_content_start = udta_pos + udta_header.header_size as usize;
+    let udta_content_size = udta_header.content_size() as usize;
+
+    let (meta_pos, meta_header) =
+        match find_box_in_container(&data, udta_content_start, udta_content_size, META) {
+            Some(x) => x,
+            None => return Ok(tags),
+        };
+
+    let meta_content_start = meta_pos + meta_header.header_size as usize + 4;
+    let meta_content_size = meta_header.content_size() as usize - 4;
+
+    let (ilst_pos, ilst_header) =
+        match find_box_in_container(&data, meta_content_start, meta_content_size, ILST) {
+            Some(x) => x,
+            None => return Ok(tags),
+        };
+
+    let ilst_content_start = ilst_pos + ilst_header.header_size as usize;
+    let ilst_content_size = ilst_header.content_size() as usize;
+
+    let mut pos = ilst_content_start;
+    while pos + 8 <= ilst_content_start + ilst_content_size {
+        let mut cursor = Cursor::new(&data[pos..]);
+        if let Ok(Some(header)) = BoxHeader::read(&mut cursor) {
+            if header.box_type == FREEFORM {
+                let tag_data = &data[pos + header.header_size as usize..pos + header.size as usize];
+                if let Some(tag) = parse_freeform_tag(tag_data) {
+                    if tag.namespace == ITUNES_NAMESPACE {
+                        match tag.name.as_str() {
+                            x if x.eq_ignore_ascii_case(UNDO_TAG) => {
+                                tags.undo = Some(tag.value);
+                            }
+                            x if x.eq_ignore_ascii_case(MINMAX_TAG) => {
+                                tags.minmax = Some(tag.value);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            if header.size == 0 {
+                break;
+            }
+            pos += header.size as usize;
+        } else {
+            break;
+        }
+    }
+
+    Ok(tags)
+}
+
+/// Write undo tags to MP4/M4A file.
+/// Uses atomic write (temp file + rename) to prevent corruption on interruption.
+pub fn write_undo_tags(file_path: &Path, tags: &UndoTags) -> Result<()> {
+    let data =
+        fs::read(file_path).with_context(|| format!("Failed to read: {}", file_path.display()))?;
+
+    let new_data = update_mp4_undo_metadata(&data, tags)?;
+
+    let parent = file_path.parent().unwrap_or(Path::new("."));
+    let temp_path = parent.join(format!(".mp3rgain_temp_{}.m4a", std::process::id()));
+
+    if let Err(e) = fs::write(&temp_path, &new_data) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(e).with_context(|| format!("Failed to write temp: {}", temp_path.display()));
+    }
+
+    if let Err(_rename_err) = fs::rename(&temp_path, file_path) {
+        let _ = fs::remove_file(&temp_path);
+        fs::write(file_path, &new_data)
+            .with_context(|| format!("Failed to write: {}", file_path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Delete undo tags from MP4/M4A file
+pub fn delete_undo_tags(file_path: &Path) -> Result<()> {
+    let empty_tags = UndoTags::new();
+    write_undo_tags(file_path, &empty_tags)
+}
+
 /// Write ReplayGain tags to MP4/M4A file.
 /// Uses atomic write (temp file + rename) to prevent corruption on interruption.
 pub fn write_replaygain_tags(file_path: &Path, tags: &ReplayGainTags) -> Result<()> {
@@ -466,6 +613,19 @@ pub fn write_replaygain_tags(file_path: &Path, tags: &ReplayGainTags) -> Result<
 
 /// Update MP4 metadata with new ReplayGain tags
 fn update_mp4_metadata(data: &[u8], tags: &ReplayGainTags) -> Result<Vec<u8>> {
+    let make_ilst = |existing: &[u8]| create_ilst_box(tags, existing);
+    rebuild_mp4_with_ilst(data, make_ilst)
+}
+
+/// Update MP4 metadata with new undo tags
+fn update_mp4_undo_metadata(data: &[u8], tags: &UndoTags) -> Result<Vec<u8>> {
+    let make_ilst = |existing: &[u8]| create_ilst_box_undo(tags, existing);
+    rebuild_mp4_with_ilst(data, make_ilst)
+}
+
+/// Common logic for rebuilding MP4 file with updated ilst content.
+/// `make_ilst` takes existing ilst content (or empty) and returns the new ilst box.
+fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> Result<Vec<u8>> {
     // Find moov box
     let (moov_pos, moov_header) =
         find_box(data, MOOV).ok_or_else(|| anyhow::anyhow!("No moov box found in MP4 file"))?;
@@ -476,7 +636,7 @@ fn update_mp4_metadata(data: &[u8], tags: &ReplayGainTags) -> Result<Vec<u8>> {
 
     // Try to find existing ilst or create new metadata structure
     let (new_ilst, ilst_info) =
-        create_or_update_ilst(data, moov_content_start, moov_content_size, tags)?;
+        find_ilst_location(data, moov_content_start, moov_content_size, &make_ilst)?;
 
     // Rebuild the file
     let mut result = Vec::with_capacity(data.len() + 1024);
@@ -631,19 +791,18 @@ enum IlstLocation {
     NeedsUdta,
 }
 
-fn create_or_update_ilst(
+fn find_ilst_location(
     data: &[u8],
     moov_content_start: usize,
     moov_content_size: usize,
-    tags: &ReplayGainTags,
+    make_ilst: &impl Fn(&[u8]) -> Vec<u8>,
 ) -> Result<(Vec<u8>, IlstLocation)> {
     // Find udta
     let (udta_pos, udta_header) =
         match find_box_in_container(data, moov_content_start, moov_content_size, UDTA) {
             Some(x) => x,
             None => {
-                // No udta, need to create everything
-                let ilst = create_ilst_box(tags, &[]);
+                let ilst = make_ilst(&[]);
                 return Ok((ilst, IlstLocation::NeedsUdta));
             }
         };
@@ -656,7 +815,7 @@ fn create_or_update_ilst(
         match find_box_in_container(data, udta_content_start, udta_content_size, META) {
             Some(x) => x,
             None => {
-                let ilst = create_ilst_box(tags, &[]);
+                let ilst = make_ilst(&[]);
                 return Ok((
                     ilst,
                     IlstLocation::NeedsMeta {
@@ -675,8 +834,7 @@ fn create_or_update_ilst(
         match find_box_in_container(data, meta_content_start, meta_content_size, ILST) {
             Some(x) => x,
             None => {
-                // meta exists but has no ilst — insert ilst into existing meta
-                let ilst = create_ilst_box(tags, &[]);
+                let ilst = make_ilst(&[]);
                 return Ok((
                     ilst,
                     IlstLocation::NeedsIlst {
@@ -693,7 +851,7 @@ fn create_or_update_ilst(
     let ilst_content_size = ilst_header.content_size() as usize;
     let existing_content = &data[ilst_content_start..ilst_content_start + ilst_content_size];
 
-    let new_ilst = create_ilst_box(tags, existing_content);
+    let new_ilst = make_ilst(existing_content);
 
     Ok((
         new_ilst,
@@ -724,10 +882,30 @@ fn is_replaygain_freeform(data: &[u8], pos: usize, header: &BoxHeader) -> bool {
     }
 }
 
-fn create_ilst_box(tags: &ReplayGainTags, existing_content: &[u8]) -> Vec<u8> {
+/// Check if a box at the given position is an undo freeform tag
+fn is_undo_freeform(data: &[u8], pos: usize, header: &BoxHeader) -> bool {
+    if header.box_type != FREEFORM {
+        return false;
+    }
+    let inner_data = &data[pos + header.header_size as usize..pos + header.size as usize];
+    match parse_freeform_tag(inner_data) {
+        Some(tag) => {
+            tag.namespace == ITUNES_NAMESPACE
+                && (tag.name.eq_ignore_ascii_case(UNDO_TAG)
+                    || tag.name.eq_ignore_ascii_case(MINMAX_TAG))
+        }
+        None => false,
+    }
+}
+
+fn create_ilst_box_filtered(
+    new_tags: &[FreeformTag],
+    existing_content: &[u8],
+    should_replace: impl Fn(&[u8], usize, &BoxHeader) -> bool,
+) -> Vec<u8> {
     let mut content = Vec::new();
 
-    // Copy existing non-ReplayGain tags
+    // Copy existing tags that don't match the filter
     let mut pos = 0;
     while pos + 8 <= existing_content.len() {
         let mut cursor = Cursor::new(&existing_content[pos..]);
@@ -738,7 +916,7 @@ fn create_ilst_box(tags: &ReplayGainTags, existing_content: &[u8]) -> Vec<u8> {
 
             let tag_data = &existing_content[pos..pos + header.size as usize];
 
-            if !is_replaygain_freeform(existing_content, pos, &header) {
+            if !should_replace(existing_content, pos, &header) {
                 content.extend_from_slice(tag_data);
             }
 
@@ -748,9 +926,9 @@ fn create_ilst_box(tags: &ReplayGainTags, existing_content: &[u8]) -> Vec<u8> {
         }
     }
 
-    // Add new ReplayGain tags
-    for tag in tags.to_freeform_tags() {
-        content.extend_from_slice(&serialize_freeform_tag(&tag));
+    // Add new tags
+    for tag in new_tags {
+        content.extend_from_slice(&serialize_freeform_tag(tag));
     }
 
     // Wrap in ilst box
@@ -761,6 +939,18 @@ fn create_ilst_box(tags: &ReplayGainTags, existing_content: &[u8]) -> Vec<u8> {
     ilst.extend_from_slice(&content);
 
     ilst
+}
+
+fn create_ilst_box(tags: &ReplayGainTags, existing_content: &[u8]) -> Vec<u8> {
+    create_ilst_box_filtered(
+        &tags.to_freeform_tags(),
+        existing_content,
+        is_replaygain_freeform,
+    )
+}
+
+fn create_ilst_box_undo(tags: &UndoTags, existing_content: &[u8]) -> Vec<u8> {
+    create_ilst_box_filtered(&tags.to_freeform_tags(), existing_content, is_undo_freeform)
 }
 
 fn create_meta_box(ilst: &[u8]) -> Vec<u8> {
@@ -1125,6 +1315,45 @@ pub fn is_aac_file(file_path: &Path) -> bool {
     )
 }
 
+/// Count the number of audio tracks in an MP4 file.
+/// Returns 0 if the file cannot be read or has no moov box.
+pub fn count_audio_tracks(file_path: &Path) -> usize {
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(_) => return 0,
+    };
+
+    let (moov_pos, moov_header) = match find_box(&data, MOOV) {
+        Some(x) => x,
+        None => return 0,
+    };
+
+    let moov_start = moov_pos + moov_header.header_size as usize;
+    let moov_end = moov_start + moov_header.content_size() as usize;
+
+    let mut count = 0;
+    let mut search_pos = moov_start;
+
+    while search_pos < moov_end {
+        let (trak_pos, trak_header) =
+            match find_box_in_container(&data, search_pos, moov_end - search_pos, TRAK) {
+                Some(x) => x,
+                None => break,
+            };
+
+        // Check if this trak has an audio codec (mp4a or alac)
+        let trak_start = trak_pos + trak_header.header_size as usize;
+        let trak_size = trak_header.content_size() as usize;
+        if detect_codec_in_trak(&data, trak_start, trak_size).is_some() {
+            count += 1;
+        }
+
+        search_pos = trak_pos + trak_header.size as usize;
+    }
+
+    count
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1162,6 +1391,76 @@ mod tests {
 
         let freeform_tags = tags.to_freeform_tags();
         assert_eq!(freeform_tags.len(), 4);
+    }
+
+    #[test]
+    fn test_undo_tags() {
+        let mut tags = UndoTags::new();
+        assert!(tags.is_empty());
+
+        tags.undo = Some("+003,+003,N".to_string());
+        tags.minmax = Some("80,120".to_string());
+        assert!(!tags.is_empty());
+
+        let freeform_tags = tags.to_freeform_tags();
+        assert_eq!(freeform_tags.len(), 2);
+        assert_eq!(freeform_tags[0].name, UNDO_TAG);
+        assert_eq!(freeform_tags[0].value, "+003,+003,N");
+        assert_eq!(freeform_tags[1].name, MINMAX_TAG);
+        assert_eq!(freeform_tags[1].value, "80,120");
+    }
+
+    #[test]
+    fn test_undo_tag_serialization_roundtrip() {
+        let tag = FreeformTag {
+            namespace: "com.apple.iTunes".to_string(),
+            name: UNDO_TAG.to_string(),
+            value: "+005,+005,N".to_string(),
+        };
+
+        let serialized = serialize_freeform_tag(&tag);
+        let parsed = parse_freeform_tag(&serialized[8..]).unwrap();
+        assert_eq!(parsed.namespace, tag.namespace);
+        assert_eq!(parsed.name, tag.name);
+        assert_eq!(parsed.value, tag.value);
+    }
+
+    #[test]
+    fn test_ilst_box_filtered_preserves_other_tags() {
+        // Create an ilst with one RG tag and one undo tag
+        let rg_tag = FreeformTag {
+            namespace: ITUNES_NAMESPACE.to_string(),
+            name: RG_TRACK_GAIN.to_string(),
+            value: "+3.50 dB".to_string(),
+        };
+        let undo_tag = FreeformTag {
+            namespace: ITUNES_NAMESPACE.to_string(),
+            name: UNDO_TAG.to_string(),
+            value: "+002,+002,N".to_string(),
+        };
+
+        let mut existing = Vec::new();
+        existing.extend_from_slice(&serialize_freeform_tag(&rg_tag));
+        existing.extend_from_slice(&serialize_freeform_tag(&undo_tag));
+
+        // Writing new RG tags should preserve the undo tag
+        let new_rg = ReplayGainTags {
+            track_gain: Some("+5.00 dB".to_string()),
+            track_peak: None,
+            album_gain: None,
+            album_peak: None,
+        };
+        let result = create_ilst_box(&new_rg, &existing);
+        // Result should contain the new RG tag AND the preserved undo tag
+        assert!(result.len() > 8); // more than just the ilst header
+
+        // Writing new undo tags should preserve the RG tag
+        let new_undo = UndoTags {
+            undo: Some("+005,+005,N".to_string()),
+            minmax: None,
+        };
+        let result = create_ilst_box_undo(&new_undo, &existing);
+        assert!(result.len() > 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the remaining phases (3-5) of issue #64 (AAC lossless bitstream gain adjustment):

- **Phase 3 (Undo Support)**: Store original gain values in iTunes freeform metadata tags so AAC gain changes can be reversed with `-u`. Undo values are cumulative, matching MP3 behavior.
- **Phase 4 (Essential Validation)**: Multi-track warning, HE-AAC (SBR) documented as supported via FIL element skipping. DRM/ALAC rejection was already in place.
- **Phase 5 (Extended Support)**: PCE (program_config_element) parser enables multi-channel layouts (5.1 etc.). Multi-track detection warns when >1 audio track exists.

### Key changes

**`src/mp4meta.rs`** - Undo tag infrastructure:
- `UndoTags` struct with `mp3rgain_undo` and `mp3rgain_minmax` iTunes freeform tags
- Read/write/delete functions following existing ReplayGain tag patterns
- Refactored `create_ilst_box` into `create_ilst_box_filtered` so undo and RG tags coexist independently
- `count_audio_tracks()` for multi-track detection

**`src/aac.rs`** - Undo-aware gain application:
- `apply_aac_gain_with_undo()` - applies gain + stores cumulative undo info
- `undo_aac_gain()` - reverses gain using stored undo tag
- `skip_pce()` - ISO 14496-3 program_config_element parser for multi-channel support
- CCE/PCE element type constants

**`src/main.rs`** - CLI integration:
- `-u` works for AAC files (calls `undo_aac_gain`)
- `-g` and `-r`/`-a` modes store undo info for AAC (unless `-s s`)
- `-s c` shows AAC undo/RG tags from iTunes freeform metadata
- `-s d` deletes both AAC undo and RG tags
- Multi-track warning displayed when >1 audio track detected

### Limitations (documented)

- AAC undo is **functionally equivalent** but not bit-for-bit identical to original (MP4 container restructuring when writing/deleting undo tags)
- CCE (coupling channel) elements still cause per-sample skip (safe, rare in practice)

## Test plan

- [x] `cargo build --release` compiles
- [x] `cargo test` - all 51 tests pass (4 new)
- [x] `cargo clippy` - no warnings
- [ ] Manual test: `mp3rgain -g 3 test.m4a` → `mp3rgain -s c test.m4a` → `mp3rgain -u test.m4a`
- [ ] Manual test: cumulative undo with multiple gain applications
- [ ] Manual test: `-r test.m4a` stores undo + RG tags

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)