### PR TITLE
Fix mp3gain compatibility issues (issue #79)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1939,14 +1939,15 @@ fn process_apply_channel(
 
     // Warn if file is Joint Stereo (mp3gain only supports Stereo for -l)
     if let Ok(info) = analyze(file) {
-        if info.channel_mode() == mp3rgain::ChannelMode::JointStereo {
-            if opts.output_format == OutputFormat::Text && !opts.quiet {
-                eprintln!(
-                    "  {} {} - Joint Stereo file: channel-specific gain may not work as expected",
-                    "!".yellow(),
-                    filename
-                );
-            }
+        if info.channel_mode() == mp3rgain::ChannelMode::JointStereo
+            && opts.output_format == OutputFormat::Text
+            && !opts.quiet
+        {
+            eprintln!(
+                "  {} {} - Joint Stereo file: channel-specific gain may not work as expected",
+                "!".yellow(),
+                filename
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 4 compatibility issues found during comprehensive testing against original mp3gain 1.6.2 with 152 real-world audio files (140 MP3 + 12 M4A).

- **Filter macOS resource fork files in `-R` mode**: `._*.mp3` files caused parse errors during recursive processing
- **Show ReplayGain analysis in default text output**: mp3gain always displays "Recommended Track/Album dB change" by default; mp3rgain only showed basic frame info
- **Add Album summary line to TSV/text output**: mp3gain outputs an `"Album"` row for analysis; mp3rgain was missing this
- **Warn on `-l` with Joint Stereo files**: mp3gain documents that `-l` only works for Stereo, not Joint Stereo; mp3rgain now shows a warning

All existing tests pass. Full test results posted in issue #79 comment.

Closes #79

## Test plan

- [x] `cargo test` — all 21 tests + 2 doc-tests pass
- [x] `cargo fmt -- --check` — no formatting issues
- [x] Tested default info, `-d`, `-o tsv`, `-R`, `-l` on real files
- [x] Verified TSV output matches mp3gain (gain values, album line)
- [x] SHA-256 roundtrip (apply + undo = binary identical)
- [x] beets integration command works: `mp3rgain -o tsv -s s -k -d 0 file.mp3`