### PR TITLE
Fix rustls-webpki security advisory (GHSA-pwjx-qhcg-rvj4)

### DIFF
--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgui"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "eframe",
  "egui",
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Updates `rustls-webpki` from 0.103.8 to 0.103.10 in `mp3rgui/Cargo.lock`
- Fixes security advisory GHSA-pwjx-qhcg-rvj4

## Test plan

- [ ] Verify `cargo build` succeeds in `mp3rgui/`
- [ ] Confirm `rustls-webpki` version is 0.103.10 in `mp3rgui/Cargo.lock`