### PR TITLE
chore(ci): add dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION
## Summary
- Add `dependency-review.yml` workflow to scan PR dependencies for vulnerabilities
- Uses `actions/dependency-review-action@v4.9.0` (pinned to SHA)
- Uses existing `actions/checkout` SHA already in use in the repo
- Fails on moderate or higher severity findings

## Security
- All actions pinned to full commit SHAs per GitHub Actions security best practices
- `permissions: contents: read` scoped to minimum required