### PR TITLE
Upgrade Symphonia v0.5 → v0.6.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,16 +15,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
+name = "autocfg"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -94,15 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +103,7 @@ version = "1.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c5e6a62a241f2f673df956ea5f52c27780bc1031855890a551ed9b869e2d1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "flate2",
 ]
@@ -201,6 +186,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +232,12 @@ checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "rustversion"
@@ -286,10 +295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "symphonia"
-version = "0.5.5"
+name = "smallvec"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "symphonia"
+version = "0.6.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a85941e1de62270fff9c09918703dd4cdcf8509f2683b9b8f36b229006dfbc8"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -301,73 +316,74 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "ae998661afd26776ccffeccbce9813dfcc5ab2ca93e184607a11db9ec66e0d8b"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.5"
+version = "0.6.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+checksum = "23378809c315d202721d469fcef480028dde8891a0f2e935ec07a3bc974ac9c4"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b043d5bdb722fc9ccb81f1658342e2d2f0bf3cafd12df3af23b80e85d79f0731"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "63d085a04fae2e73a2fb234d8cdd9d5025660534726388b73b4b3d2da8e3da7c"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.5"
+version = "0.6.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+checksum = "a6bede3f9592b84f287ad42056c4ca54082db544db1fdfa19a8510b415d9f50e"
 dependencies = [
- "encoding_rs",
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "b2952577ed22ba321bd6721d1ff9e01f1a4a1ee72830240796cf7147552c8fed"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "symphonia"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a85941e1de62270fff9c09918703dd4cdcf8509f2683b9b8f36b229006dfbc8"
+checksum = "b38c0b8e99ce52271da0f3fec5780a8566edd703b181211dd0ff725efeaaae38"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae998661afd26776ccffeccbce9813dfcc5ab2ca93e184607a11db9ec66e0d8b"
+checksum = "08e64864167bd6cb39e743c19036cad4486ba4dcf299336b695249ea3cfd31ff"
 dependencies = [
  "lazy_static",
  "log",
@@ -327,20 +327,21 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23378809c315d202721d469fcef480028dde8891a0f2e935ec07a3bc974ac9c4"
+checksum = "7139b6baf2f6df9877395d70bf16edc0860d72ff35eefbf51d083b10b36f7949"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-common"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b043d5bdb722fc9ccb81f1658342e2d2f0bf3cafd12df3af23b80e85d79f0731"
+checksum = "0c029b5a948c81fd3a46647a151b959109d1d16b05a1d7c7eca1fdac0ace0a27"
 dependencies = [
  "log",
  "symphonia-core",
@@ -349,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d085a04fae2e73a2fb234d8cdd9d5025660534726388b73b4b3d2da8e3da7c"
+checksum = "3be2e760147497d7f939f18b7739387c7e6b5322d9ce0cf10cd93cf96f4d815c"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -363,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bede3f9592b84f287ad42056c4ca54082db544db1fdfa19a8510b415d9f50e"
+checksum = "0a0c9c23912250e33b40c0d36deded5c03aef33299e03c39f78e6125d492da61"
 dependencies = [
  "log",
  "symphonia-common",
@@ -375,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2952577ed22ba321bd6721d1ff9e01f1a4a1ee72830240796cf7147552c8fed"
+checksum = "eea744eea37a3336aeb2919b5632a5b79dc12695e60cac15adf3422814c0f32c"
 dependencies = [
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = []
 anyhow = "1.0"
 thiserror = "2.0"
 colored = "3.1"
-symphonia = { version = "0.5", optional = true, default-features = false, features = ["mp3", "aac", "isomp4"] }
+symphonia = { version = "0.6.0-alpha.1", optional = true, default-features = false, features = ["mp3", "aac", "isomp4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 id3 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = []
 anyhow = "1.0"
 thiserror = "2.0"
 colored = "3.1"
-symphonia = { version = "0.6.0-alpha.1", optional = true, default-features = false, features = ["mp3", "aac", "isomp4", "all-meta"] }
+symphonia = { version = "0.6.0-alpha.2", optional = true, default-features = false, features = ["mp3", "aac", "isomp4", "all-meta"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 id3 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = []
 anyhow = "1.0"
 thiserror = "2.0"
 colored = "3.1"
-symphonia = { version = "0.6.0-alpha.1", optional = true, default-features = false, features = ["mp3", "aac", "isomp4"] }
+symphonia = { version = "0.6.0-alpha.1", optional = true, default-features = false, features = ["mp3", "aac", "isomp4", "all-meta"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 id3 = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,25 +615,11 @@ fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
                     f64::INFINITY
                 };
 
-                // Check if peak is at clipping threshold (Symphonia MP3 decoder limitation)
-                // Only applies to MP3 files - AAC/M4A decoder doesn't have this issue
-                let is_mp3 = file
-                    .extension()
-                    .map(|e| e.eq_ignore_ascii_case("mp3"))
-                    .unwrap_or(false);
-                let may_clip = is_mp3 && max_amp >= 0.9999;
-
                 match opts.output_format {
                     OutputFormat::Text => {
                         if !opts.quiet {
                             println!("{}", filename.cyan().bold());
                             println!("  Max PCM sample: {:.6}", max_pcm_sample);
-                            if may_clip {
-                                println!(
-                                    "  {}",
-                                    "  (may be clipped - actual peak could be higher)".yellow()
-                                );
-                            }
                             println!("  Headroom:       {:+.2} dB", headroom_db);
                             println!("  Max global_gain: {}", max_gain);
                             println!("  Min global_gain: {}", min_gain);
@@ -649,19 +635,14 @@ fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
                         );
                     }
                     OutputFormat::Json => {
-                        let mut result = JsonFileResult {
+                        json_results.push(JsonFileResult {
                             file: file.display().to_string(),
                             max_amplitude: Some(max_pcm_sample),
                             headroom_db: Some(headroom_db),
                             max_gain: Some(max_gain),
                             min_gain: Some(min_gain),
                             ..Default::default()
-                        };
-                        if may_clip {
-                            result.warning =
-                                Some("peak may be clipped - actual value could be higher".into());
-                        }
-                        json_results.push(result);
+                        });
                     }
                 }
             }

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -18,17 +18,17 @@ use std::path::Path;
 use crate::mp4meta;
 
 #[cfg(feature = "replaygain")]
-use symphonia::core::audio::{AudioBufferRef, Signal};
+use symphonia::core::audio::{Audio, GenericAudioBufferRef};
 #[cfg(feature = "replaygain")]
-use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::codecs::audio::{AudioDecoderOptions, CODEC_ID_NULL_AUDIO};
+#[cfg(feature = "replaygain")]
+use symphonia::core::formats::probe::Hint;
 #[cfg(feature = "replaygain")]
 use symphonia::core::formats::FormatOptions;
 #[cfg(feature = "replaygain")]
 use symphonia::core::io::MediaSourceStream;
 #[cfg(feature = "replaygain")]
 use symphonia::core::meta::MetadataOptions;
-#[cfg(feature = "replaygain")]
-use symphonia::core::probe::Hint;
 
 /// ReplayGain reference level in dB SPL
 /// Original mp3gain uses 89 dB (ReplayGain 1.0)
@@ -906,25 +906,28 @@ fn analyze_track_internal(
         hint.with_extension(ext);
     }
 
-    let probed = symphonia::default::get_probe()
-        .format(
+    let mut format = symphonia::default::get_probe()
+        .probe(
             &hint,
             mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
+            FormatOptions::default(),
+            MetadataOptions::default(),
         )
         .map_err(|e| Error::ProbeFailed {
             path: file_path.to_path_buf(),
             source: Box::new(e),
         })?;
 
-    let mut format = probed.format;
-
     // Find audio tracks
     let audio_tracks: Vec<_> = format
         .tracks()
         .iter()
-        .filter(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .filter(|t| {
+            t.codec_params
+                .as_ref()
+                .and_then(|p| p.audio())
+                .is_some_and(|a| a.codec != CODEC_ID_NULL_AUDIO)
+        })
         .collect();
 
     if audio_tracks.is_empty() {
@@ -947,15 +950,23 @@ fn analyze_track_internal(
     };
 
     let track_id = track.id;
-    let sample_rate = track
+    let audio_params = track
         .codec_params
+        .as_ref()
+        .and_then(|p| p.audio())
+        .ok_or(Error::NoAudioTrack)?;
+    let sample_rate = audio_params
         .sample_rate
         .ok_or(Error::UnsupportedSampleRate(0))?;
-    let channels = track.codec_params.channels.map(|c| c.count()).unwrap_or(2);
+    let channels = audio_params
+        .channels
+        .as_ref()
+        .map(|c| c.count())
+        .unwrap_or(2);
 
     // Create decoder
     let mut decoder = symphonia::default::get_codecs()
-        .make(&track.codec_params, &DecoderOptions::default())
+        .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
         .map_err(|e| Error::Decode(Box::new(e)))?;
 
     // Create filter for each channel
@@ -971,12 +982,8 @@ fn analyze_track_internal(
     // Process all packets
     loop {
         let packet = match format.next_packet() {
-            Ok(p) => p,
-            Err(symphonia::core::errors::Error::IoError(e))
-                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
-            {
-                break;
-            }
+            Ok(Some(p)) => p,
+            Ok(None) => break,
             Err(e) => return Err(Error::Decode(Box::new(e))),
         };
 
@@ -1036,25 +1043,25 @@ const SAMPLE_SCALE_16BIT: f64 = 32768.0;
 /// Process an audio buffer and feed filtered samples to the analyzer
 #[cfg(feature = "replaygain")]
 fn process_audio_buffer(
-    buffer: &AudioBufferRef,
+    buffer: &GenericAudioBufferRef,
     filters: &mut [EqualLoudnessFilter],
     analyzer: &mut ReplayGainAnalyzer,
     peak: &mut f64,
 ) {
     match buffer {
-        AudioBufferRef::F32(buf) => {
-            let channels = buf.spec().channels.count();
+        GenericAudioBufferRef::F32(buf) => {
+            let channels = buf.num_planes();
             let frames = buf.frames();
 
             for frame in 0..frames {
                 // Get normalized sample and track peak (in normalized range for peak reporting)
-                let left_norm = buf.chan(0)[frame] as f64;
+                let left_norm = buf.plane(0).unwrap()[frame] as f64;
                 *peak = peak.max(left_norm.abs());
                 // Scale to 16-bit range for ReplayGain algorithm compatibility
                 let left_filtered = filters[0].process(left_norm * SAMPLE_SCALE_16BIT);
 
                 if channels >= 2 {
-                    let right_norm = buf.chan(1)[frame] as f64;
+                    let right_norm = buf.plane(1).unwrap()[frame] as f64;
                     *peak = peak.max(right_norm.abs());
                     let right_filtered = filters[1].process(right_norm * SAMPLE_SCALE_16BIT);
                     analyzer.add_sample(left_filtered, right_filtered);
@@ -1063,20 +1070,20 @@ fn process_audio_buffer(
                 }
             }
         }
-        AudioBufferRef::S16(buf) => {
-            let channels = buf.spec().channels.count();
+        GenericAudioBufferRef::S16(buf) => {
+            let channels = buf.num_planes();
             let frames = buf.frames();
 
             for frame in 0..frames {
                 // S16 samples are already in the correct range for ReplayGain algorithm
                 // Convert to f64 directly without normalization for filter processing
-                let left = buf.chan(0)[frame] as f64;
+                let left = buf.plane(0).unwrap()[frame] as f64;
                 // Track peak in normalized range (0.0 to 1.0)
                 *peak = peak.max((left / SAMPLE_SCALE_16BIT).abs());
                 let left_filtered = filters[0].process(left);
 
                 if channels >= 2 {
-                    let right = buf.chan(1)[frame] as f64;
+                    let right = buf.plane(1).unwrap()[frame] as f64;
                     *peak = peak.max((right / SAMPLE_SCALE_16BIT).abs());
                     let right_filtered = filters[1].process(right);
                     analyzer.add_sample(left_filtered, right_filtered);
@@ -1085,20 +1092,20 @@ fn process_audio_buffer(
                 }
             }
         }
-        AudioBufferRef::S32(buf) => {
-            let channels = buf.spec().channels.count();
+        GenericAudioBufferRef::S32(buf) => {
+            let channels = buf.num_planes();
             let frames = buf.frames();
             // Scale S32 to 16-bit range: divide by 2^16 to go from 32-bit to 16-bit range
             let scale = SAMPLE_SCALE_16BIT / 2147483648.0;
 
             for frame in 0..frames {
-                let left = buf.chan(0)[frame] as f64 * scale;
+                let left = buf.plane(0).unwrap()[frame] as f64 * scale;
                 // Track peak in normalized range
                 *peak = peak.max((left / SAMPLE_SCALE_16BIT).abs());
                 let left_filtered = filters[0].process(left);
 
                 if channels >= 2 {
-                    let right = buf.chan(1)[frame] as f64 * scale;
+                    let right = buf.plane(1).unwrap()[frame] as f64 * scale;
                     *peak = peak.max((right / SAMPLE_SCALE_16BIT).abs());
                     let right_filtered = filters[1].process(right);
                     analyzer.add_sample(left_filtered, right_filtered);
@@ -1258,46 +1265,49 @@ pub fn find_peak_amplitude(file_path: &Path) -> Result<PeakAmplitudeResult> {
         hint.with_extension(ext);
     }
 
-    let probed = symphonia::default::get_probe()
-        .format(
+    let mut format = symphonia::default::get_probe()
+        .probe(
             &hint,
             mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
+            FormatOptions::default(),
+            MetadataOptions::default(),
         )
         .map_err(|e| Error::ProbeFailed {
             path: file_path.to_path_buf(),
             source: Box::new(e),
         })?;
 
-    let mut format = probed.format;
-
     let track = format
         .tracks()
         .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .find(|t| {
+            t.codec_params
+                .as_ref()
+                .and_then(|p| p.audio())
+                .is_some_and(|a| a.codec != CODEC_ID_NULL_AUDIO)
+        })
         .ok_or(Error::NoAudioTrack)?;
 
     let track_id = track.id;
-    let sample_rate = track
+    let audio_params = track
         .codec_params
+        .as_ref()
+        .and_then(|p| p.audio())
+        .ok_or(Error::NoAudioTrack)?;
+    let sample_rate = audio_params
         .sample_rate
         .ok_or(Error::UnsupportedSampleRate(0))?;
 
     let mut decoder = symphonia::default::get_codecs()
-        .make(&track.codec_params, &DecoderOptions::default())
+        .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
         .map_err(|e| Error::Decode(Box::new(e)))?;
 
     let mut max_peak: f64 = 0.0;
 
     loop {
         let packet = match format.next_packet() {
-            Ok(p) => p,
-            Err(symphonia::core::errors::Error::IoError(e))
-                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
-            {
-                break;
-            }
+            Ok(Some(p)) => p,
+            Ok(None) => break,
             Err(e) => return Err(Error::Decode(Box::new(e))),
         };
 
@@ -1321,31 +1331,32 @@ pub fn find_peak_amplitude(file_path: &Path) -> Result<PeakAmplitudeResult> {
         // To detect clipping, we check if the peak is exactly 1.0 (or very close),
         // which indicates the audio may have been clipped by the decoder.
         match &decoded {
-            AudioBufferRef::F32(buf) => {
-                let channels = buf.spec().channels.count();
+            GenericAudioBufferRef::F32(buf) => {
+                let channels = buf.num_planes();
                 for frame in 0..buf.frames() {
                     for ch in 0..channels {
-                        let sample = buf.chan(ch)[frame].abs() as f64;
+                        let sample = buf.plane(ch).unwrap()[frame].abs() as f64;
                         max_peak = max_peak.max(sample);
                     }
                 }
             }
-            AudioBufferRef::S16(buf) => {
-                let channels = buf.spec().channels.count();
+            GenericAudioBufferRef::S16(buf) => {
+                let channels = buf.num_planes();
                 for frame in 0..buf.frames() {
                     for ch in 0..channels {
                         // S16 samples: convert to normalized range
                         // This can exceed 1.0 if sample is at max (32767/32768 ≈ 0.99997)
-                        let sample = (buf.chan(ch)[frame] as f64).abs() / SAMPLE_SCALE_16BIT;
+                        let sample =
+                            (buf.plane(ch).unwrap()[frame] as f64).abs() / SAMPLE_SCALE_16BIT;
                         max_peak = max_peak.max(sample);
                     }
                 }
             }
-            AudioBufferRef::S32(buf) => {
-                let channels = buf.spec().channels.count();
+            GenericAudioBufferRef::S32(buf) => {
+                let channels = buf.num_planes();
                 for frame in 0..buf.frames() {
                     for ch in 0..channels {
-                        let sample = (buf.chan(ch)[frame] as f64).abs() / 2147483648.0;
+                        let sample = (buf.plane(ch).unwrap()[frame] as f64).abs() / 2147483648.0;
                         max_peak = max_peak.max(sample);
                     }
                 }


### PR DESCRIPTION
## Summary

- Upgrade Symphonia dependency from v0.5 to v0.6.0-alpha.2
- Migrate all v0.5 → v0.6 breaking API changes in `src/replaygain.rs`
- Add `all-meta` feature flag to fix codec misdetection with large ID3v2 tags
- Remove "may be clipped" warning for `-x` (no longer needed with accurate peak detection)

This resolves **#52** (MP3 peak values capped at 1.0) — the sample clamping (`clamp(-1.0, 1.0)`) was removed from the MP3 decoder in Symphonia v0.6 ([pdeljanov/Symphonia#434](https://github.com/pdeljanov/Symphonia/pull/434)).

## API Migration

| v0.5 | v0.6 |
|------|------|
| `AudioBufferRef` | `GenericAudioBufferRef` |
| `Signal::chan(n)` | `Audio::plane(n).unwrap()` |
| `spec().channels.count()` | `num_planes()` |
| `CODEC_TYPE_NULL` | `CODEC_ID_NULL_AUDIO` |
| `DecoderOptions` | `AudioDecoderOptions` |
| `probe::Hint` | `formats::probe::Hint` |
| `get_probe().format(...)` | `get_probe().probe(...)` |
| `get_codecs().make(...)` | `get_codecs().make_audio_decoder(...)` |
| `next_packet()` → `Err` at EOF | `next_packet()` → `Ok(None)` at EOF |

## Test Results

- All 52 tests pass (29 unit + 21 integration + 2 doc-test)
- Tested with 6 real MP3 files (ID3v2 tags from 4KB to 8.3MB):
  - ReplayGain analysis: peak values now correctly reported above 1.0
  - Gain apply/undo: fully reversible
  - Album gain: works correctly

| File | ID3v2 | Peak (v0.5) | Peak (v0.6) |
|------|-------|-------------|-------------|
| Lawrence James - Hold You In My Arms | 4KB | 1.0000 | **1.0318** |
| Livsey - Imagination | 8.3MB | 1.0000 | **1.3890** |
| Livsey - Past & Present | 2.9MB | 1.0000 | **1.0799** |
| Livsey - Tutorial | 17KB | 1.0000 | **1.1616** |
| See It Through My Eyes (Acapella) | 4KB | 1.0000 | **1.0543** |
| Verberate - Let the Rhythm Take Control | 3.5MB | 1.0000 | **1.1933** |

## Follow-up

- #108: Add per-file progress indication (built on the new decoder API)

Closes #107
Closes #52