### PR TITLE
fix(id3v2): preserve ReplayGain write on ID3v2.2-tagged MP3s

### DIFF
--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -10,6 +10,8 @@ use id3::TagLike;
 
 use std::path::Path;
 
+const TARGET_VERSION: id3::Version = id3::Version::Id3v24;
+
 /// All known mp3gain/ReplayGain TXXX descriptions
 const ALL_RG_DESCRIPTIONS: &[&str] = &[
     TAG_MP3GAIN_UNDO,
@@ -45,7 +47,16 @@ fn read_tag(path: &Path) -> Result<id3::Tag> {
 }
 
 fn write_tag(path: &Path, tag: &id3::Tag) -> Result<()> {
-    tag.write_to_path(path, id3::Version::Id3v24)
+    // Drop frames whose IDs can't be expressed in the target version. Files
+    // authored with an ID3v2.2 tag can contain 3-byte IDs (e.g. "GP1") that
+    // the id3 crate keeps as-is during read but refuses to encode into v2.4,
+    // which would otherwise fail the whole write and lose the ReplayGain tags.
+    let mut sanitized = tag.clone();
+    sanitized
+        .frames_vec_mut()
+        .retain(|f| f.id_for_version(TARGET_VERSION).is_some());
+    sanitized
+        .write_to_path(path, TARGET_VERSION)
         .map_err(|e| Error::Id3v2Error {
             message: e.to_string(),
         })


### PR DESCRIPTION
## Summary
- Fix #113 — `mp3rgain -s i -a -r ...` wrote no ID3v2 ReplayGain tags on MP3s that carried an ID3v2.2 tag.
- Root cause: the `id3` crate reads v2.2 frames whose IDs don't remap to v2.3/v2.4 (e.g. `GP1`) as `ID::Invalid`, then refuses to encode them as v2.4 with `InvalidInput: Frame ID must be 4 bytes long`, aborting the whole write so the ReplayGain TXXX frames never get saved.
- Drop any frames that can't be expressed in the target version inside `write_tag` before calling `write_to_path`, so ReplayGain and undo tags are persisted correctly.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test --release`
- [x] Manual: `mp3rgain -s i -k -a -r *.mp3` on the reporter-style ID3v2.2 MP3s now completes without errors.
- [x] Manual: `mp3rgain -s i -s c` shows `REPLAYGAIN_TRACK_GAIN` / `_PEAK` and `REPLAYGAIN_ALBUM_GAIN` / `_PEAK` populated after the run.