### PR TITLE
refactor(main): move run() to commands/mod.rs, trim main.rs (step 4 of #127)

### DIFF
--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::get_filename;
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::processors::apply::{process_apply, process_apply_channel};
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::util::get_filename;
 
 pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
     if steps == 0 {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -5,10 +5,10 @@ use mp3rgain::{db_to_steps, mp4meta};
 use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::get_filename;
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::processors::info::process_info;
 use crate::progress::{create_analysis_progress_bar, finish_analysis_progress, PROGRESS_THRESHOLD};
+use crate::util::get_filename;
 
 pub fn cmd_info(files: &[PathBuf], opts: &Options) -> Result<()> {
     // Print mp3gain-compatible TSV header

--- a/src/commands/max_amplitude.rs
+++ b/src/commands/max_amplitude.rs
@@ -4,9 +4,9 @@ use mp3rgain::find_max_amplitude;
 use std::path::PathBuf;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::get_filename;
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::util::get_filename;
 
 pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
     if opts.output_format == OutputFormat::Text && !opts.quiet {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,3 +5,87 @@ pub mod replaygain;
 pub mod tags;
 pub mod undo;
 pub mod utils;
+
+use anyhow::Result;
+use colored::*;
+
+use crate::cli::options::{Options, OutputFormat, StoredTagMode};
+use crate::cli::parse_args::expand_files_recursive;
+
+use apply::{cmd_apply, cmd_apply_channel};
+use info::cmd_info;
+use max_amplitude::cmd_max_amplitude;
+use replaygain::{cmd_album_gain, cmd_track_gain};
+use tags::{cmd_check_tags, cmd_delete_tags};
+use undo::cmd_undo;
+
+/// Validate options and dispatch to the appropriate `cmd_*` handler.
+pub fn run(mut opts: Options) -> Result<()> {
+    // Validate options
+    if opts.files.is_empty() {
+        eprintln!("{}: no files specified", "error".red().bold());
+        std::process::exit(1);
+    }
+
+    // Expand files if recursive mode
+    if opts.recursive {
+        opts.files = expand_files_recursive(&opts.files)?;
+        if opts.files.is_empty() {
+            eprintln!("{}: no audio files found (MP3/M4A)", "error".red().bold());
+            std::process::exit(1);
+        }
+    }
+
+    // -f option warning (assume MPEG2)
+    if opts.assume_mpeg2 && !opts.quiet && opts.output_format == OutputFormat::Text {
+        eprintln!(
+            "{}: -f (assume MPEG2) is accepted for compatibility but has no effect",
+            "note".cyan()
+        );
+    }
+
+    // Determine action based on options
+    if opts.max_amplitude_only {
+        // -x: only find max amplitude
+        return cmd_max_amplitude(&opts.files, &opts);
+    }
+
+    if opts.stored_tag_mode == StoredTagMode::Delete {
+        // -s d: delete stored tag info
+        return cmd_delete_tags(&opts.files, &opts);
+    }
+
+    if opts.stored_tag_mode == StoredTagMode::Check {
+        // -s c: check/show stored tag info
+        return cmd_check_tags(&opts.files, &opts);
+    }
+
+    if opts.undo {
+        // -u: undo from APEv2 tags
+        return cmd_undo(&opts.files, &opts);
+    }
+
+    if opts.album_gain && !opts.skip_album {
+        // -a: apply album gain (ReplayGain)
+        return cmd_album_gain(&opts.files, &opts);
+    }
+
+    if opts.track_gain || opts.skip_album {
+        // -r or -e: apply track gain (ReplayGain)
+        return cmd_track_gain(&opts.files, &opts);
+    }
+
+    if let Some((channel, steps)) = opts.channel_gain {
+        // -l: apply channel-specific gain
+        return cmd_apply_channel(&opts.files, channel, steps, &opts);
+    }
+
+    if let Some(steps) = opts.gain_steps {
+        // -g: apply fixed gain steps
+        cmd_apply(&opts.files, steps, &opts)
+    } else {
+        // Default: analyze files (mp3gain compatible)
+        // With -d modifier, perform ReplayGain analysis
+        cmd_info(&opts.files, &opts)
+    }
+}

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 
 use crate::cli::options::{AacAlbumInfo, Options, OutputFormat};
 use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::get_filename;
 use crate::json_output::{JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
 use crate::progress::{
     create_analysis_progress_bar, create_progress_bar, finish_analysis_progress, progress_finish,
     progress_inc, progress_set_message, PROGRESS_THRESHOLD,
 };
+use crate::util::get_filename;
 
 pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     if !replaygain::is_available() {

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -9,10 +9,10 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::create_json_summary;
-use crate::get_filename;
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::processors::utils::restore_timestamp;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::util::get_filename;
 
 /// Tag values and labels for display in cmd_check_tags
 struct CheckTagInfo<'a> {

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::get_filename;
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::processors::undo::process_undo;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::util::get_filename;
 
 pub fn cmd_undo(files: &[PathBuf], opts: &Options) -> Result<()> {
     let dry_run_prefix = opts.dry_run_prefix();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,107 +8,19 @@ mod commands;
 mod json_output;
 mod processors;
 mod progress;
+mod util;
 
 use anyhow::Result;
-use colored::*;
 use std::env;
-use std::path::Path;
-
-use cli::options::{Options, OutputFormat, StoredTagMode};
-use cli::parse_args::{expand_files_recursive, parse_args};
-use cli::usage::print_usage;
-use commands::apply::{cmd_apply, cmd_apply_channel};
-use commands::info::cmd_info;
-use commands::max_amplitude::cmd_max_amplitude;
-use commands::replaygain::{cmd_album_gain, cmd_track_gain};
-use commands::tags::{cmd_check_tags, cmd_delete_tags};
-use commands::undo::cmd_undo;
-
-/// Extract filename from path, returning "unknown" if extraction fails
-pub(crate) fn get_filename(path: &Path) -> &str {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-}
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        print_usage();
+        cli::usage::print_usage();
         return Ok(());
     }
 
-    let opts = parse_args(&args[1..])?;
-    run(opts)
-}
-
-fn run(mut opts: Options) -> Result<()> {
-    // Validate options
-    if opts.files.is_empty() {
-        eprintln!("{}: no files specified", "error".red().bold());
-        std::process::exit(1);
-    }
-
-    // Expand files if recursive mode
-    if opts.recursive {
-        opts.files = expand_files_recursive(&opts.files)?;
-        if opts.files.is_empty() {
-            eprintln!("{}: no audio files found (MP3/M4A)", "error".red().bold());
-            std::process::exit(1);
-        }
-    }
-
-    // -f option warning (assume MPEG2)
-    if opts.assume_mpeg2 && !opts.quiet && opts.output_format == OutputFormat::Text {
-        eprintln!(
-            "{}: -f (assume MPEG2) is accepted for compatibility but has no effect",
-            "note".cyan()
-        );
-    }
-
-    // Determine action based on options
-    if opts.max_amplitude_only {
-        // -x: only find max amplitude
-        return cmd_max_amplitude(&opts.files, &opts);
-    }
-
-    if opts.stored_tag_mode == StoredTagMode::Delete {
-        // -s d: delete stored tag info
-        return cmd_delete_tags(&opts.files, &opts);
-    }
-
-    if opts.stored_tag_mode == StoredTagMode::Check {
-        // -s c: check/show stored tag info
-        return cmd_check_tags(&opts.files, &opts);
-    }
-
-    if opts.undo {
-        // -u: undo from APEv2 tags
-        return cmd_undo(&opts.files, &opts);
-    }
-
-    if opts.album_gain && !opts.skip_album {
-        // -a: apply album gain (ReplayGain)
-        return cmd_album_gain(&opts.files, &opts);
-    }
-
-    if opts.track_gain || opts.skip_album {
-        // -r or -e: apply track gain (ReplayGain)
-        return cmd_track_gain(&opts.files, &opts);
-    }
-
-    if let Some((channel, steps)) = opts.channel_gain {
-        // -l: apply channel-specific gain
-        return cmd_apply_channel(&opts.files, channel, steps, &opts);
-    }
-
-    if let Some(steps) = opts.gain_steps {
-        // -g: apply fixed gain steps
-        cmd_apply(&opts.files, steps, &opts)
-    } else {
-        // Default: analyze files (mp3gain compatible)
-        // With -d modifier, perform ReplayGain analysis
-        cmd_info(&opts.files, &opts)
-    }
+    let opts = cli::parse_args::parse_args(&args[1..])?;
+    commands::run(opts)
 }

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -4,8 +4,8 @@ use mp3rgain::{aac, analyze, id3v2, mp4meta, steps_to_db, Channel, GainOptions};
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
-use crate::get_filename;
 use crate::json_output::JsonFileResult;
+use crate::util::get_filename;
 
 use super::utils::{apply_with_temp_file, restore_timestamp};
 

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -6,9 +6,9 @@ use mp3rgain::{analyze, db_to_steps, find_max_amplitude, mp4meta};
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::get_filename;
 use crate::json_output::JsonFileResult;
 use crate::progress::update_analysis_progress;
+use crate::util::get_filename;
 
 pub fn process_info(
     file: &Path,

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -6,9 +6,9 @@ use mp3rgain::{aac, analyze, db_to_steps, id3v2, mp4meta, steps_to_db, GainOptio
 use std::path::Path;
 
 use crate::cli::options::{AacAlbumInfo, Options, OutputFormat};
-use crate::get_filename;
 use crate::json_output::JsonFileResult;
 use crate::progress::update_analysis_progress;
+use crate::util::get_filename;
 
 use super::utils::{apply_with_temp_file, restore_timestamp};
 

--- a/src/processors/undo.rs
+++ b/src/processors/undo.rs
@@ -4,8 +4,8 @@ use mp3rgain::{aac, id3v2, mp4meta, undo_gain};
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::get_filename;
 use crate::json_output::JsonFileResult;
+use crate::util::get_filename;
 
 use super::utils::restore_timestamp;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+/// Extract filename from path, returning "unknown" if extraction fails
+pub fn get_filename(path: &Path) -> &str {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+}


### PR DESCRIPTION
## Summary

Final step of #127. `main.rs` is now **26 lines** — just imports and `main()`.

| Change | Reason |
|--------|--------|
| New `src/util.rs` with `get_filename` | Was `pub(crate) fn` in `main.rs`. Moving it lets `main.rs` drop the `Path` dependency entirely. |
| `commands/mod.rs` gains `pub fn run` | The dispatch/validation logic moves out of `main.rs` to where it logically belongs (next to the `cmd_*` it dispatches to). |
| `main.rs` reduced to `main()` only | Closes the issue's acceptance criterion (`main.rs` under 100 lines). |

The 14 call sites of `get_filename` across `commands/*` and `processors/*`
all switch from `crate::get_filename` to `crate::util::get_filename` —
`pub(crate)` items at the binary crate root are awkward to discover and
this is the natural home for a shared path helper.

## Acceptance criteria (per #127) — final state

- [x] `main.rs` under 100 lines (now 26)
- [x] No file in the new structure exceeds ~500 lines (largest: `commands/replaygain.rs` 316, `processors/replaygain.rs` 398)
- [x] `parse_args` has unit-test coverage (27 tests)
- [x] `cargo test`, `cargo clippy --release --no-deps`, `cargo fmt -- --check` all pass
- [x] No public API change in the `mp3rgain` library crate

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` — lib 31, bin 27, integration 21, doc 2 — all pass
- [x] `cargo clippy --release --no-deps` clean
- [x] `cargo fmt -- --check` clean
- [x] `./target/release/mp3rgain --version` smoke test

Closes #127.