### PR TITLE
docs: credit reporters and discussion contributors for #115 / #118

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -7,6 +7,10 @@
 //! The parser supports AAC-LC single channel elements (SCE), channel pair
 //! elements (CPE), and LFE elements. Unsupported element types (CCE, PCE)
 //! cause the individual sample to be skipped with a warning count increment.
+//!
+//! Initial AAC support was driven by the investigation in #118 (slow path
+//! and ffmpeg-decode errors on rewritten m4a), which seeded #120 / #121
+//! before being superseded by the present parser implementation.
 
 use crate::error::{Error, Result};
 use std::path::Path;

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -1,4 +1,8 @@
 //! ID3v2 TXXX frame storage for ReplayGain and undo tags.
+//!
+//! Original write-path issue (#115) reported a case where mp3gain values
+//! were not persisted to the file; the fix landed in #116 and was later
+//! subsumed by a broader rewrite of this module.
 
 use crate::ape::{
     parse_undo_values, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN,

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -16,6 +16,9 @@
 //!               └── ---- (freeform tags for ReplayGain)
 //! mdat (media data)
 //! ```
+//!
+//! Related: #118 (m4a write-path round-trip — ffmpeg decode errors and
+//! atom-rewriter pitfalls noted in the discussion thread).
 
 use crate::error::{Error, Result};
 use std::fs;


### PR DESCRIPTION
## Summary

Add brief historical references in module-level docs to credit the bug reports and discussion that drove the initial fixes for #115 (ID3v2 write-path) and #118 (AAC/m4a parser).

The original fixes (#116, #120, #121) have since been superseded by broader rewrites of `id3v2.rs` / `aac.rs`, but the issues themselves were the seed of the work.

## Files changed

- `src/id3v2.rs` — note #115 / #116 history
- `src/aac.rs` — note #118 / #120 / #121 history
- `src/mp4meta.rs` — note #118 atom-rewriter discussion

No behavior change. Comments only.

## Co-authors

This PR is co-authored to surface the contributors on the GitHub Contributors page:

- @zz5zz — reporter of #115
- @andrewchen5678 — reporter of #118 and m4againpy diff sharer
- @m13v — atom-rewriter pitfalls context in #118

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt -- --check` (auto-formatted)