### PR TITLE
refactor: low-impact simplify cleanups

### DIFF
--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -845,6 +845,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1116,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -2126,12 +2151,13 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "colored",
  "id3",
  "indicatif",
+ "rayon",
  "serde",
  "serde_json",
  "symphonia",
@@ -2140,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgui"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "eframe",
  "egui",
@@ -2955,6 +2981,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rctree"

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -43,7 +43,6 @@ pub struct Mp3rgainApp {
     pub files: Vec<FileEntry>,
     pub target_volume: f64,
     pub selected_indices: Vec<usize>,
-    pub file_progress: f32,
     pub total_progress: f32,
     pub is_processing: bool,
     pub status_message: String,
@@ -55,7 +54,6 @@ impl Mp3rgainApp {
             files: Vec::new(),
             target_volume: 89.0,
             selected_indices: Vec::new(),
-            file_progress: 0.0,
             total_progress: 0.0,
             is_processing: false,
             status_message: String::new(),
@@ -141,7 +139,6 @@ impl Mp3rgainApp {
         }
 
         self.is_processing = true;
-        self.file_progress = 0.0;
         self.total_progress = 0.0;
 
         let total = self.files.len();

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -6,8 +6,6 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
             file_menu(app, ui, ctx);
             analysis_menu(app, ui);
             modify_menu(app, ui);
-            options_menu(ui);
-            help_menu(ui);
         });
     });
 }
@@ -73,34 +71,6 @@ fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                 app.apply_album_gain();
                 ui.close_menu();
             }
-            ui.separator();
-            if ui.button("Apply Constant Gain...").clicked() {
-                // TODO: Implement constant gain dialog
-                ui.close_menu();
-            }
-            ui.separator();
-            if ui.button("Undo Gain Changes").clicked() {
-                // TODO: Implement undo
-                ui.close_menu();
-            }
         });
-    });
-}
-
-fn options_menu(ui: &mut egui::Ui) {
-    ui.menu_button("Options", |ui| {
-        if ui.button("Settings...").clicked() {
-            // TODO: Implement settings dialog
-            ui.close_menu();
-        }
-    });
-}
-
-fn help_menu(ui: &mut egui::Ui) {
-    ui.menu_button("Help", |ui| {
-        if ui.button("About mp3rgain").clicked() {
-            // TODO: Implement about dialog
-            ui.close_menu();
-        }
     });
 }

--- a/mp3rgui/src/ui/status.rs
+++ b/mp3rgui/src/ui/status.rs
@@ -2,16 +2,8 @@ use crate::app::Mp3rgainApp;
 
 pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     egui::TopBottomPanel::bottom("status_panel").show(ctx, |ui| {
-        // Progress bars
         ui.horizontal(|ui| {
-            ui.label("File:");
-            ui.add(
-                egui::ProgressBar::new(app.file_progress)
-                    .desired_width(200.0)
-                    .show_percentage(),
-            );
-            ui.add_space(20.0);
-            ui.label("Total:");
+            ui.label("Progress:");
             ui.add(
                 egui::ProgressBar::new(app.total_progress)
                     .desired_width(200.0)
@@ -22,11 +14,6 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                 if ui.button("Exit").clicked() {
                     ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                 }
-                ui.add_enabled_ui(app.is_processing, |ui| {
-                    if ui.button("Cancel").clicked() {
-                        // TODO: Implement cancel
-                    }
-                });
             });
         });
 

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -317,9 +317,10 @@ pub fn expand_files_recursive(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
 fn collect_audio_files(dir: &Path, result: &mut Vec<PathBuf>) -> Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
+        let file_type = entry.file_type()?;
         let path = entry.path();
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             collect_audio_files(&path, result)?;
         } else if mp3rgain::is_supported_audio_path(&path) {
             result.push(path);

--- a/src/commands/max_amplitude.rs
+++ b/src/commands/max_amplitude.rs
@@ -32,10 +32,14 @@ pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
                 let min_gain = amp_result.min_global_gain();
                 // Convert to PCM scale (like mp3gain: 0-32768+)
                 let max_pcm_sample = max_amp * 32768.0;
-                let headroom_db = if max_amp > 0.0 {
-                    -20.0 * max_amp.log10()
+                let headroom_db: Option<f64> = if max_amp > 0.0 {
+                    Some(-20.0 * max_amp.log10())
                 } else {
-                    f64::INFINITY
+                    None
+                };
+                let headroom_text = match headroom_db {
+                    Some(d) => format!("{:+.2}", d),
+                    None => "(silent)".to_string(),
                 };
 
                 match opts.output_format {
@@ -43,25 +47,25 @@ pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
                         if !opts.quiet {
                             println!("{}", filename.cyan().bold());
                             println!("  Max PCM sample: {:.6}", max_pcm_sample);
-                            println!("  Headroom:       {:+.2} dB", headroom_db);
+                            println!("  Headroom:       {} dB", headroom_text);
                             println!("  Max global_gain: {}", max_gain);
                             println!("  Min global_gain: {}", min_gain);
                             println!();
                         } else {
-                            println!("{}\t{:.6}\t{:.2}", filename, max_pcm_sample, headroom_db);
+                            println!("{}\t{:.6}\t{}", filename, max_pcm_sample, headroom_text);
                         }
                     }
                     OutputFormat::Tsv => {
                         println!(
-                            "{}\t{:.6}\t{:.2}\t{}\t{}",
-                            filename, max_pcm_sample, headroom_db, max_gain, min_gain
+                            "{}\t{:.6}\t{}\t{}\t{}",
+                            filename, max_pcm_sample, headroom_text, max_gain, min_gain
                         );
                     }
                     OutputFormat::Json => {
                         json_results.push(JsonFileResult {
                             file: file.display().to_string(),
                             max_amplitude: Some(max_pcm_sample),
-                            headroom_db: Some(headroom_db),
+                            headroom_db,
                             max_gain: Some(max_gain),
                             min_gain: Some(min_gain),
                             ..Default::default()

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -17,7 +17,7 @@ use crate::progress::{
 };
 use crate::util::get_filename;
 
-pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
+fn require_replaygain_feature() {
     if !replaygain::is_available() {
         eprintln!(
             "{}: ReplayGain analysis requires the 'replaygain' feature",
@@ -26,6 +26,10 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
         eprintln!("  Install with: cargo install mp3rgain --features replaygain");
         std::process::exit(1);
     }
+}
+
+pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
+    require_replaygain_feature();
 
     let dry_run_prefix = opts.dry_run_prefix();
 
@@ -152,14 +156,7 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 }
 
 pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
-    if !replaygain::is_available() {
-        eprintln!(
-            "{}: ReplayGain analysis requires the 'replaygain' feature",
-            "error".red().bold()
-        );
-        eprintln!("  Install with: cargo install mp3rgain --features replaygain");
-        std::process::exit(1);
-    }
+    require_replaygain_feature();
 
     let dry_run_prefix = opts.dry_run_prefix();
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -8,7 +8,7 @@ use mp3rgain::{
 use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::utils::create_json_summary;
+use crate::commands::utils::{create_json_summary, print_dry_run_notice};
 use crate::json_output::{JsonFileResult, JsonOutput};
 use crate::processors::utils::restore_timestamp;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
@@ -199,9 +199,8 @@ pub fn cmd_delete_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
             )),
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
-    } else if opts.dry_run && !opts.quiet {
-        println!();
-        println!("{}", "No files were modified.".yellow());
+    } else {
+        print_dry_run_notice(opts);
     }
 
     Ok(())

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -12,22 +12,17 @@ where
     F: FnOnce(&Path) -> Result<usize>,
 {
     if opts.use_temp_file {
-        // Create temp file in the same directory
         let parent = file.parent().unwrap_or(Path::new("."));
         let temp_path = parent.join(format!(".mp3rgain_temp_{}.mp3", std::process::id()));
 
-        // Copy original to temp
         fs::copy(file, &temp_path)?;
 
-        // Apply operation to temp file
         match operation(&temp_path) {
             Ok(frames) => {
-                // Replace original with temp
                 fs::rename(&temp_path, file)?;
                 Ok(frames)
             }
             Err(e) => {
-                // Clean up temp file on error
                 let _ = fs::remove_file(&temp_path);
                 Err(e)
             }


### PR DESCRIPTION
## Summary

Low-impact cleanups identified during a `/simplify` review. Higher-impact findings (parallelization, I/O reduction, larger refactors) are tracked separately as #134–#140 and not included here.

- **`processors/utils`**: drop 5 WHAT-comments in `apply_with_temp_file`.
- **`commands/replaygain`**: extract `require_replaygain_feature()` to deduplicate the feature-gate message in `cmd_track_gain` / `cmd_album_gain`.
- **`commands/tags`**: route `cmd_delete_tags` through `print_dry_run_notice`, which incidentally fixes a real bug — the inline notice was polluting TSV output (other commands already gate on `OutputFormat::Text`).
- **`cli/parse_args::collect_audio_files`**: use `entry.file_type()` instead of `path.is_dir()` to avoid one extra `stat` syscall per directory entry on large libraries.
- **`commands/max_amplitude`**: silent files (peak == 0) previously emitted `+inf dB` and `f64::INFINITY` in JSON (invalid JSON). Now emits `(silent)` in text/TSV and `null` for `headroom_db` in JSON.
- **`mp3rgui`**: remove unused `file_progress` field + status-bar progress, and the no-op stub menu items (`Apply Constant Gain...`, `Undo Gain Changes`, `Settings...`, `About mp3rgain`) and Cancel button — all had empty handlers and clicked silently.
- **`mp3rgui/Cargo.lock`**: incidental refresh by cargo (was pointing to v2.3.1, missing `rayon`).

No behavior changes outside the two noted (TSV dry-run notice fix, silent-file headroom fix).

## Test plan

- [x] `cargo fmt --check` (both crates)
- [x] `cargo build --release` (both crates)
- [x] `cargo test` — 91 passed
- [x] `cargo clippy --release` — clean
- [x] CI green