### PR TITLE
docs: credit @Sappharad / #106 in progress-indication code

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,3 +1,10 @@
+//! Progress reporting helpers used during ReplayGain analysis.
+//!
+//! Per-file analysis progress was originally requested by @Sappharad in
+//! #106 to mirror the byte-level progress output of the legacy mp3gain CLI
+//! ("`54% of 119337493 bytes analyzed`"). The feature shipped in v2.2.0
+//! once the Symphonia v0.6 decoder migration landed.
+
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::path::Path;
 

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -1105,6 +1105,8 @@ pub fn analyze_track_with_index(
 ///
 /// The callback receives `(bytes_read, total_bytes)` and is called after each
 /// decoded packet. Use this to drive a progress bar during analysis.
+///
+/// Originally requested by @Sappharad in #106 (mp3gain-style byte progress).
 #[cfg(feature = "replaygain")]
 pub fn analyze_track_with_progress(
     file_path: &Path,
@@ -1228,6 +1230,9 @@ pub fn analyze_album_with_index(
 /// The callback receives `(file_index, bytes_read, total_bytes)` and is called
 /// after each decoded packet. `file_index` indicates which file is currently
 /// being analyzed (0-based).
+///
+/// Companion to [`analyze_track_with_progress`]; both stem from the
+/// progress-indication request in #106 (@Sappharad).
 #[cfg(feature = "replaygain")]
 pub fn analyze_album_with_progress(
     files: &[&Path],


### PR DESCRIPTION
## Summary

- Add a module-level doc to `src/progress.rs` noting that per-file analysis progress was originally requested by @Sappharad in #106 (mp3gain-style byte-progress output) and shipped in v2.2.0.
- Add short doc-comment notes on `analyze_track_with_progress` / `analyze_album_with_progress` in `src/replaygain.rs` pointing back to the same issue, so the public lib API surface also carries the historical context.

Same pattern as #133 (id3v2 / aac / mp4meta historical-credit doc additions). Pure doc — no behaviour change.

## Test plan

- [x] `cargo fmt`
- [x] `cargo build --release`
- [ ] CI green