### PR TITLE
feat: add --skip-errors to keep album analysis going past unreadable files

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -166,24 +166,40 @@ impl Mp3rgainApp {
 
         let paths: Vec<&std::path::Path> = self.files.iter().map(|f| f.path.as_path()).collect();
 
-        match replaygain::analyze_album(&paths) {
-            Ok(result) => {
+        // Use the lenient variant so a single bad file does not abort the
+        // whole album scan — the failed file is shown as Error in the table
+        // and the rest is analyzed normally (issue #144).
+        match replaygain::analyze_album_lenient_with_index(&paths, None) {
+            Ok(report) => {
                 let album_gain =
-                    self.target_volume - REPLAYGAIN_REFERENCE_DB + result.album_gain_db();
-                let album_volume = REPLAYGAIN_REFERENCE_DB - result.album_gain_db();
-                let album_clip = Self::would_clip(result.album_peak(), album_gain);
+                    self.target_volume - REPLAYGAIN_REFERENCE_DB + report.album.album_gain_db();
+                let album_volume = REPLAYGAIN_REFERENCE_DB - report.album.album_gain_db();
+                let album_clip = Self::would_clip(report.album.album_peak(), album_gain);
 
-                for (i, file) in self.files.iter_mut().enumerate() {
-                    if let Some(track_result) = result.tracks().get(i) {
-                        Self::populate_track_analysis(file, track_result, self.target_volume);
-                    }
+                for (track_idx, &file_idx) in report.successful_indices.iter().enumerate() {
+                    let track_result = &report.album.tracks()[track_idx];
+                    let file = &mut self.files[file_idx];
+                    Self::populate_track_analysis(file, track_result, self.target_volume);
                     file.album_volume = Some(album_volume);
                     file.album_gain = Some(album_gain);
                     file.album_clip = album_clip;
                     file.status = FileStatus::Analyzed;
                 }
-                self.status_message =
-                    format!("Album analysis complete ({} tracks)", self.files.len());
+
+                for (file_idx, msg) in &report.failures {
+                    self.files[*file_idx].status = FileStatus::Error(msg.clone());
+                }
+
+                let analyzed = report.successful_indices.len();
+                let skipped = report.failures.len();
+                self.status_message = if skipped > 0 {
+                    format!(
+                        "Album analysis complete ({} tracks, {} skipped)",
+                        analyzed, skipped
+                    )
+                } else {
+                    format!("Album analysis complete ({} tracks)", analyzed)
+                };
             }
             Err(e) => {
                 self.status_message = format!("Album analysis failed: {}", e);

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -55,6 +55,7 @@ pub struct Options {
     pub wrap_gain: bool,             // -w: wrap gain values
     pub use_temp_file: bool,         // -t: use temp file for writing
     pub assume_mpeg2: bool,          // -f: assume MPEG 2 Layer III
+    pub skip_errors: bool,           // --skip-errors: skip files that fail to analyze
 
     // Parallelism
     // -j N / --threads N. None = auto (available_parallelism). Some(0) = auto. Some(1) = serial.

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -19,6 +19,12 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
             continue;
         }
 
+        if arg == "--skip-errors" {
+            opts.skip_errors = true;
+            i += 1;
+            continue;
+        }
+
         if arg == "--help" {
             print_usage();
             std::process::exit(0);
@@ -608,6 +614,16 @@ mod tests {
     fn invalid_attached_gain_returns_error() {
         let result = parse_args(&args(&["-gabc"]));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn skip_errors_long_flag() {
+        let opts = parse_args(&args(&["--skip-errors", "song.mp3"])).unwrap();
+        assert!(opts.skip_errors);
+        assert_eq!(opts.files.len(), 1);
+
+        let opts = parse_args(&args(&["song.mp3"])).unwrap();
+        assert!(!opts.skip_errors);
     }
 
     #[test]

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -49,6 +49,8 @@ pub fn print_usage() {
     println!("    -R          Process directories recursively");
     println!("    -n          Dry-run mode (show what would be done)");
     println!("    --dry-run   Same as -n");
+    println!("    --skip-errors  Skip files that fail to analyze instead of");
+    println!("                   aborting (useful for `-a` on large libraries)");
     println!("    -j <n>      Worker threads for analysis (default: auto, 0=auto, 1=serial)");
     println!("    --threads <n>  Same as -j (also honors MP3RGAIN_THREADS env var)");
     println!("    -o <fmt>    Output format: 'text' (default), 'json', or 'tsv'");
@@ -73,6 +75,8 @@ pub fn print_usage() {
     println!("    mp3rgain -w -g 10 song.mp3     Apply gain with wrapping");
     println!("    mp3rgain -t -g 2 song.mp3      Apply gain using temp file");
     println!("    mp3rgain -R /path/to/music     Process directory recursively");
+    println!("    mp3rgain -Rpa --skip-errors /music  Album-scan a library, skipping");
+    println!("                                        files that fail to decode");
     println!("    mp3rgain -n -g 2 *.mp3         Dry-run (preview changes)");
     println!("    mp3rgain -o json song.mp3      Output in JSON format");
     println!("    mp3rgain -o tsv *.mp3          Output in tab-separated format");

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::*;
 use indicatif::MultiProgress;
-use mp3rgain::replaygain::{self, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{self, AlbumAnalysisReport, REPLAYGAIN_REFERENCE_DB};
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -174,52 +174,115 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     let show_progress = !opts.quiet && opts.output_format == OutputFormat::Text;
     let mp = MultiProgress::new();
 
-    let album_analysis = if show_progress && !parallel {
-        let analysis_pb = create_album_progress_pb_in(&mp, files.len(), false);
-
-        let file_names: Vec<&str> = files.iter().map(|f| get_filename(f)).collect();
-        let result = replaygain::analyze_album_with_progress(
-            &file_refs,
-            opts.track_index,
-            &|file_idx, bytes, total| {
-                analysis_pb.set_length(total);
-                analysis_pb.set_position(bytes);
-                analysis_pb.set_message(format!(
-                    "({}/{}) {}",
-                    file_idx + 1,
-                    files.len(),
-                    file_names[file_idx]
-                ));
-            },
-        );
-
-        analysis_pb.finish_and_clear();
-        result
-    } else if show_progress && parallel {
-        // Per-file byte bars would interleave in parallel mode, so show a
-        // file-count bar driven by completion notifications instead.
-        let analysis_pb = create_album_progress_pb_in(&mp, files.len(), true);
-
-        let pb_ref = &analysis_pb;
-        let result = replaygain::analyze_album_parallel_with_completion(
-            &file_refs,
-            opts.track_index,
-            threads,
-            &|completed_idx, _path| {
-                pb_ref.set_position((completed_idx + 1) as u64);
-            },
-        );
-
-        analysis_pb.finish_and_clear();
-        result
-    } else if parallel {
-        replaygain::analyze_album_parallel(&file_refs, opts.track_index, threads)
+    let album_analysis: mp3rgain::error::Result<AlbumAnalysisReport> = if opts.skip_errors {
+        if show_progress && !parallel {
+            let analysis_pb = create_album_progress_pb_in(&mp, files.len(), false);
+            let file_names: Vec<&str> = files.iter().map(|f| get_filename(f)).collect();
+            let result = replaygain::analyze_album_lenient_with_progress(
+                &file_refs,
+                opts.track_index,
+                &|file_idx, bytes, total| {
+                    analysis_pb.set_length(total);
+                    analysis_pb.set_position(bytes);
+                    analysis_pb.set_message(format!(
+                        "({}/{}) {}",
+                        file_idx + 1,
+                        files.len(),
+                        file_names[file_idx]
+                    ));
+                },
+            );
+            analysis_pb.finish_and_clear();
+            result
+        } else if show_progress && parallel {
+            let analysis_pb = create_album_progress_pb_in(&mp, files.len(), true);
+            let pb_ref = &analysis_pb;
+            let result = replaygain::analyze_album_lenient_parallel_with_completion(
+                &file_refs,
+                opts.track_index,
+                threads,
+                &|completed_idx, _path| {
+                    pb_ref.set_position((completed_idx + 1) as u64);
+                },
+            );
+            analysis_pb.finish_and_clear();
+            result
+        } else if parallel {
+            replaygain::analyze_album_lenient_parallel(&file_refs, opts.track_index, threads)
+        } else {
+            replaygain::analyze_album_lenient_with_index(&file_refs, opts.track_index)
+        }
     } else {
-        replaygain::analyze_album_with_index(&file_refs, opts.track_index)
+        let strict = if show_progress && !parallel {
+            let analysis_pb = create_album_progress_pb_in(&mp, files.len(), false);
+            let file_names: Vec<&str> = files.iter().map(|f| get_filename(f)).collect();
+            let result = replaygain::analyze_album_with_progress(
+                &file_refs,
+                opts.track_index,
+                &|file_idx, bytes, total| {
+                    analysis_pb.set_length(total);
+                    analysis_pb.set_position(bytes);
+                    analysis_pb.set_message(format!(
+                        "({}/{}) {}",
+                        file_idx + 1,
+                        files.len(),
+                        file_names[file_idx]
+                    ));
+                },
+            );
+            analysis_pb.finish_and_clear();
+            result
+        } else if show_progress && parallel {
+            let analysis_pb = create_album_progress_pb_in(&mp, files.len(), true);
+            let pb_ref = &analysis_pb;
+            let result = replaygain::analyze_album_parallel_with_completion(
+                &file_refs,
+                opts.track_index,
+                threads,
+                &|completed_idx, _path| {
+                    pb_ref.set_position((completed_idx + 1) as u64);
+                },
+            );
+            analysis_pb.finish_and_clear();
+            result
+        } else if parallel {
+            replaygain::analyze_album_parallel(&file_refs, opts.track_index, threads)
+        } else {
+            replaygain::analyze_album_with_index(&file_refs, opts.track_index)
+        };
+
+        // Lift the strict result into the unified report shape so the rest of
+        // this function can handle both paths uniformly.
+        strict.map(|album| AlbumAnalysisReport {
+            album,
+            failures: Vec::new(),
+            successful_indices: (0..files.len()).collect(),
+        })
     };
 
     match album_analysis {
-        Ok(album_result) => {
+        Ok(report) => {
+            let AlbumAnalysisReport {
+                album: album_result,
+                failures,
+                successful_indices,
+            } = report;
+
+            // Report skipped files up front (only happens with --skip-errors).
+            if opts.output_format == OutputFormat::Text && !opts.quiet {
+                for (idx, msg) in &failures {
+                    let filename = get_filename(&files[*idx]);
+                    eprintln!("  {} {} - {} (skipped)", "x".red(), filename, msg);
+                }
+            }
+
+            // Build a mapping from file index -> track-result index. Files that
+            // failed analysis map to None.
+            let mut file_to_track: Vec<Option<usize>> = vec![None; files.len()];
+            for (track_idx, file_idx) in successful_indices.iter().enumerate() {
+                file_to_track[*file_idx] = Some(track_idx);
+            }
+
             // Apply gain modifier
             let modified_gain_steps = album_result.album_gain_steps() + opts.gain_modifier;
 
@@ -263,24 +326,40 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                     let json_results: Vec<JsonFileResult> = files
                         .iter()
                         .enumerate()
-                        .map(|(i, file)| {
-                            let track = &album_result.tracks()[i];
-                            JsonFileResult {
-                                file: file.display().to_string(),
-                                status: Some(FileStatus::Skipped),
-                                loudness_db: Some(track.loudness_db()),
-                                peak: Some(track.peak()),
-                                gain_applied_steps: Some(0),
-                                gain_applied_db: Some(0.0),
-                                ..Default::default()
+                        .map(|(i, file)| match file_to_track[i] {
+                            Some(track_idx) => {
+                                let track = &album_result.tracks()[track_idx];
+                                JsonFileResult {
+                                    file: file.display().to_string(),
+                                    status: Some(FileStatus::Skipped),
+                                    loudness_db: Some(track.loudness_db()),
+                                    peak: Some(track.peak()),
+                                    gain_applied_steps: Some(0),
+                                    gain_applied_db: Some(0.0),
+                                    ..Default::default()
+                                }
                             }
+                            None => JsonFileResult {
+                                file: file.display().to_string(),
+                                status: Some(FileStatus::Error),
+                                error: failures
+                                    .iter()
+                                    .find(|(idx, _)| *idx == i)
+                                    .map(|(_, msg)| msg.clone()),
+                                ..Default::default()
+                            },
                         })
                         .collect();
 
                     let output = JsonOutput {
                         files: Some(json_results),
                         album: Some(json_album),
-                        summary: Some(create_json_summary(files.len(), 0, 0, opts.dry_run)),
+                        summary: Some(create_json_summary(
+                            files.len(),
+                            0,
+                            failures.len(),
+                            opts.dry_run,
+                        )),
                     };
                     println!("{}", serde_json::to_string_pretty(&output)?);
                 } else if !opts.quiet {
@@ -296,57 +375,96 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
             if parallel {
                 let pb_ref = pb.as_ref();
-                let collected: Vec<(JsonFileResult, String)> = files
+                // Process only successfully-analyzed files in parallel.
+                let collected: Vec<(usize, JsonFileResult, String)> = successful_indices
                     .par_iter()
                     .enumerate()
-                    .map(|(i, file)| -> Result<(JsonFileResult, String)> {
-                        let track_result = &album_result.tracks()[i];
-                        let r = process_apply_replaygain_with_album(
-                            file,
-                            steps,
-                            track_result,
-                            opts,
-                            Some(&album_info),
-                        )?;
-                        if let Some(pb) = pb_ref {
-                            pb.set_message(get_filename(file).to_string());
-                            pb.inc(1);
-                        }
-                        Ok(r)
-                    })
+                    .map(
+                        |(track_idx, &file_idx)| -> Result<(usize, JsonFileResult, String)> {
+                            let file = &files[file_idx];
+                            let track_result = &album_result.tracks()[track_idx];
+                            let (result, text) = process_apply_replaygain_with_album(
+                                file,
+                                steps,
+                                track_result,
+                                opts,
+                                Some(&album_info),
+                            )?;
+                            if let Some(pb) = pb_ref {
+                                pb.set_message(get_filename(file).to_string());
+                                pb.inc(1);
+                            }
+                            Ok((file_idx, result, text))
+                        },
+                    )
                     .collect::<Result<Vec<_>>>()?;
 
                 let stdout = io::stdout();
                 let mut handle = stdout.lock();
-                for (_, text) in &collected {
+                for (_, _, text) in &collected {
                     if !text.is_empty() {
                         handle.write_all(text.as_bytes())?;
                     }
                 }
                 drop(handle);
 
-                for (result, _) in collected {
-                    update_counters(&result, &mut successful, &mut failed);
-                    if opts.output_format == OutputFormat::Json {
-                        json_results.push(result);
+                // Re-assemble json_results in input file order, interleaving
+                // failures with successes so the JSON output stays aligned
+                // with the input list.
+                if opts.output_format == OutputFormat::Json {
+                    let mut by_index: Vec<Option<JsonFileResult>> =
+                        (0..files.len()).map(|_| None).collect();
+                    for (file_idx, result, _) in &collected {
+                        by_index[*file_idx] = Some(result.clone());
                     }
+                    for (file_idx, msg) in &failures {
+                        by_index[*file_idx] = Some(JsonFileResult {
+                            file: files[*file_idx].display().to_string(),
+                            status: Some(FileStatus::Error),
+                            error: Some(msg.clone()),
+                            ..Default::default()
+                        });
+                    }
+                    for entry in by_index.into_iter().flatten() {
+                        update_counters(&entry, &mut successful, &mut failed);
+                        json_results.push(entry);
+                    }
+                } else {
+                    for (_, result, _) in collected {
+                        update_counters(&result, &mut successful, &mut failed);
+                    }
+                    failed += failures.len();
                 }
             } else {
                 for (i, file) in files.iter().enumerate() {
                     let filename = get_filename(file);
                     progress_set_message(&pb, filename);
 
-                    let track_result = &album_result.tracks()[i];
-                    let (result, text) = process_apply_replaygain_with_album(
-                        file,
-                        steps,
-                        track_result,
-                        opts,
-                        Some(&album_info),
-                    )?;
-                    if !text.is_empty() {
-                        print!("{}", text);
-                    }
+                    let result = match file_to_track[i] {
+                        Some(track_idx) => {
+                            let track_result = &album_result.tracks()[track_idx];
+                            let (result, text) = process_apply_replaygain_with_album(
+                                file,
+                                steps,
+                                track_result,
+                                opts,
+                                Some(&album_info),
+                            )?;
+                            if !text.is_empty() {
+                                print!("{}", text);
+                            }
+                            result
+                        }
+                        None => JsonFileResult {
+                            file: file.display().to_string(),
+                            status: Some(FileStatus::Error),
+                            error: failures
+                                .iter()
+                                .find(|(idx, _)| *idx == i)
+                                .map(|(_, msg)| msg.clone()),
+                            ..Default::default()
+                        },
+                    };
                     update_counters(&result, &mut successful, &mut failed);
 
                     if opts.output_format == OutputFormat::Json {

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,9 @@ pub enum Error {
     #[error("Failed to parse any AAC samples ({warnings} errors)")]
     AacParseFailure { warnings: u32 },
 
+    #[error("All {count} file(s) failed to analyze")]
+    AllFilesFailed { count: usize },
+
     // ID3v2
     #[error("ID3v2 tag error: {message}")]
     Id3v2Error { message: String },

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -181,6 +181,19 @@ impl std::fmt::Display for AlbumGainResult {
     }
 }
 
+/// Report from a "lenient" album analysis that may skip files.
+///
+/// Returned by `analyze_album_lenient_*` family. `album` is computed from the
+/// successfully-analyzed tracks only; `failures` lists `(file_index,
+/// error_message)` pairs in input order; `successful_indices` maps
+/// `album.tracks()[k]` back to `files[successful_indices[k]]`.
+#[derive(Debug, Clone)]
+pub struct AlbumAnalysisReport {
+    pub album: AlbumGainResult,
+    pub failures: Vec<(usize, String)>,
+    pub successful_indices: Vec<usize>,
+}
+
 // =============================================================================
 // Equal-loudness filter coefficients
 // =============================================================================
@@ -1222,7 +1235,7 @@ pub fn analyze_album_with_index(
     files: &[&Path],
     track_index: Option<u32>,
 ) -> Result<AlbumGainResult> {
-    analyze_album_internal(files, track_index, None)
+    Ok(analyze_album_internal(files, track_index, None, false)?.album)
 }
 
 /// Analyze multiple tracks for album gain with progress reporting
@@ -1239,7 +1252,29 @@ pub fn analyze_album_with_progress(
     track_index: Option<u32>,
     on_progress: &dyn Fn(usize, u64, u64),
 ) -> Result<AlbumGainResult> {
-    analyze_album_internal(files, track_index, Some(on_progress))
+    Ok(analyze_album_internal(files, track_index, Some(on_progress), false)?.album)
+}
+
+/// Lenient counterpart of [`analyze_album_with_index`]: files that fail to
+/// analyze are skipped instead of aborting the whole album. Returns an
+/// [`AlbumAnalysisReport`] describing both the album result and the skipped
+/// files. Errors only when every file fails (or argument validation fails).
+#[cfg(feature = "replaygain")]
+pub fn analyze_album_lenient_with_index(
+    files: &[&Path],
+    track_index: Option<u32>,
+) -> Result<AlbumAnalysisReport> {
+    analyze_album_internal(files, track_index, None, true)
+}
+
+/// Lenient counterpart of [`analyze_album_with_progress`].
+#[cfg(feature = "replaygain")]
+pub fn analyze_album_lenient_with_progress(
+    files: &[&Path],
+    track_index: Option<u32>,
+    on_progress: &dyn Fn(usize, u64, u64),
+) -> Result<AlbumAnalysisReport> {
+    analyze_album_internal(files, track_index, Some(on_progress), true)
 }
 
 #[cfg(feature = "replaygain")]
@@ -1247,11 +1282,14 @@ fn analyze_album_internal(
     files: &[&Path],
     track_index: Option<u32>,
     on_progress: Option<&dyn Fn(usize, u64, u64)>,
-) -> Result<AlbumGainResult> {
+    skip_errors: bool,
+) -> Result<AlbumAnalysisReport> {
     let mut track_results = Vec::with_capacity(files.len());
     let mut album_peak: f64 = 0.0;
     // Album histogram accumulates all track histograms (like B[] in original mp3gain)
     let mut album_histogram = LoudnessHistogram::new();
+    let mut failures: Vec<(usize, String)> = Vec::new();
+    let mut successful_indices: Vec<usize> = Vec::with_capacity(files.len());
 
     for (i, file) in files.iter().enumerate() {
         // Create a per-file progress callback that includes the file index
@@ -1259,25 +1297,37 @@ fn analyze_album_internal(
             on_progress.map(|cb| Box::new(move |bytes, total| cb(i, bytes, total)) as _);
 
         // Analyze each track and get histogram
-        let internal = analyze_track_internal(file, track_index, file_progress.as_deref())?;
-        album_peak = album_peak.max(internal.result.peak);
+        match analyze_track_internal(file, track_index, file_progress.as_deref()) {
+            Ok(internal) => {
+                album_peak = album_peak.max(internal.result.peak);
+                album_histogram.accumulate(&internal.histogram);
+                track_results.push(internal.result);
+                successful_indices.push(i);
+            }
+            Err(e) => {
+                if skip_errors {
+                    failures.push((i, format!("{}", e)));
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
 
-        // Accumulate track histogram into album histogram
-        album_histogram.accumulate(&internal.histogram);
-
-        track_results.push(internal.result);
+    if track_results.is_empty() && !files.is_empty() {
+        return Err(Error::AllFilesFailed { count: files.len() });
     }
 
     // Calculate album loudness from combined histogram (95th percentile)
     let album_loudness_db = album_histogram.get_loudness();
     let album_gain_db = PINK_REF - album_loudness_db;
 
-    Ok(AlbumGainResult::new(
-        track_results,
-        album_loudness_db,
-        album_gain_db,
-        album_peak,
-    ))
+    let album = AlbumGainResult::new(track_results, album_loudness_db, album_gain_db, album_peak);
+    Ok(AlbumAnalysisReport {
+        album,
+        failures,
+        successful_indices,
+    })
 }
 
 /// Analyze multiple tracks for album gain in parallel.
@@ -1294,9 +1344,9 @@ pub fn analyze_album_parallel(
     threads: usize,
 ) -> Result<AlbumGainResult> {
     if threads <= 1 || files.len() <= 1 {
-        return analyze_album_internal(files, track_index, None);
+        return Ok(analyze_album_internal(files, track_index, None, false)?.album);
     }
-    analyze_album_parallel_internal::<fn(usize, &Path)>(files, track_index, None)
+    Ok(analyze_album_parallel_internal::<fn(usize, &Path)>(files, track_index, None, false)?.album)
 }
 
 /// Analyze multiple tracks for album gain in parallel, with a per-file
@@ -1317,13 +1367,48 @@ where
 {
     if threads <= 1 || files.len() <= 1 {
         // Serial fallback still drives the completion callback in input order.
-        let result = analyze_album_internal(files, track_index, None)?;
+        let result = analyze_album_internal(files, track_index, None, false)?.album;
         for (i, f) in files.iter().enumerate() {
             on_complete(i, f);
         }
         return Ok(result);
     }
-    analyze_album_parallel_internal(files, track_index, Some(on_complete))
+    Ok(analyze_album_parallel_internal(files, track_index, Some(on_complete), false)?.album)
+}
+
+/// Lenient counterpart of [`analyze_album_parallel`]: files that fail to
+/// analyze are skipped instead of aborting the whole album.
+#[cfg(feature = "replaygain")]
+pub fn analyze_album_lenient_parallel(
+    files: &[&Path],
+    track_index: Option<u32>,
+    threads: usize,
+) -> Result<AlbumAnalysisReport> {
+    if threads <= 1 || files.len() <= 1 {
+        return analyze_album_internal(files, track_index, None, true);
+    }
+    analyze_album_parallel_internal::<fn(usize, &Path)>(files, track_index, None, true)
+}
+
+/// Lenient counterpart of [`analyze_album_parallel_with_completion`].
+#[cfg(feature = "replaygain")]
+pub fn analyze_album_lenient_parallel_with_completion<F>(
+    files: &[&Path],
+    track_index: Option<u32>,
+    threads: usize,
+    on_complete: &F,
+) -> Result<AlbumAnalysisReport>
+where
+    F: Fn(usize, &Path) + Sync,
+{
+    if threads <= 1 || files.len() <= 1 {
+        let report = analyze_album_internal(files, track_index, None, true)?;
+        for (i, f) in files.iter().enumerate() {
+            on_complete(i, f);
+        }
+        return Ok(report);
+    }
+    analyze_album_parallel_internal(files, track_index, Some(on_complete), true)
 }
 
 #[cfg(feature = "replaygain")]
@@ -1331,7 +1416,8 @@ fn analyze_album_parallel_internal<F>(
     files: &[&Path],
     track_index: Option<u32>,
     on_complete: Option<&F>,
-) -> Result<AlbumGainResult>
+    skip_errors: bool,
+) -> Result<AlbumAnalysisReport>
 where
     F: Fn(usize, &Path) + Sync,
 {
@@ -1340,7 +1426,7 @@ where
     // par_iter().collect() preserves input order, which keeps album_peak
     // / album_histogram folding deterministic and matches the serial path
     // bit-for-bit.
-    let internals: Vec<TrackAnalysisInternal> = files
+    let internals: Vec<Result<TrackAnalysisInternal>> = files
         .par_iter()
         .enumerate()
         .map(|(i, file)| {
@@ -1350,27 +1436,45 @@ where
             }
             r
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect();
 
     let mut track_results = Vec::with_capacity(internals.len());
     let mut album_peak: f64 = 0.0;
     let mut album_histogram = LoudnessHistogram::new();
+    let mut failures: Vec<(usize, String)> = Vec::new();
+    let mut successful_indices: Vec<usize> = Vec::with_capacity(internals.len());
 
-    for internal in internals {
-        album_peak = album_peak.max(internal.result.peak);
-        album_histogram.accumulate(&internal.histogram);
-        track_results.push(internal.result);
+    for (i, internal) in internals.into_iter().enumerate() {
+        match internal {
+            Ok(internal) => {
+                album_peak = album_peak.max(internal.result.peak);
+                album_histogram.accumulate(&internal.histogram);
+                track_results.push(internal.result);
+                successful_indices.push(i);
+            }
+            Err(e) => {
+                if skip_errors {
+                    failures.push((i, format!("{}", e)));
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    if track_results.is_empty() && !files.is_empty() {
+        return Err(Error::AllFilesFailed { count: files.len() });
     }
 
     let album_loudness_db = album_histogram.get_loudness();
     let album_gain_db = PINK_REF - album_loudness_db;
 
-    Ok(AlbumGainResult::new(
-        track_results,
-        album_loudness_db,
-        album_gain_db,
-        album_peak,
-    ))
+    let album = AlbumGainResult::new(track_results, album_loudness_db, album_gain_db, album_peak);
+    Ok(AlbumAnalysisReport {
+        album,
+        failures,
+        successful_indices,
+    })
 }
 
 // =============================================================================
@@ -1458,6 +1562,57 @@ pub fn analyze_album_parallel_with_completion<F>(
     _threads: usize,
     _on_complete: &F,
 ) -> Result<AlbumGainResult>
+where
+    F: Fn(usize, &Path) + Sync,
+{
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_album_lenient_with_index(
+    _files: &[&Path],
+    _track_index: Option<u32>,
+) -> Result<AlbumAnalysisReport> {
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_album_lenient_with_progress(
+    _files: &[&Path],
+    _track_index: Option<u32>,
+    _on_progress: &dyn Fn(usize, u64, u64),
+) -> Result<AlbumAnalysisReport> {
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_album_lenient_parallel(
+    _files: &[&Path],
+    _track_index: Option<u32>,
+    _threads: usize,
+) -> Result<AlbumAnalysisReport> {
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_album_lenient_parallel_with_completion<F>(
+    _files: &[&Path],
+    _track_index: Option<u32>,
+    _threads: usize,
+    _on_complete: &F,
+) -> Result<AlbumAnalysisReport>
 where
     F: Fn(usize, &Path) + Sync,
 {
@@ -1713,6 +1868,40 @@ mod tests {
             "Loudness should be below 100 dB: {}",
             loudness
         );
+    }
+
+    #[cfg(feature = "replaygain")]
+    #[test]
+    fn lenient_album_skips_failed_files() {
+        // Issue #144: --skip-errors should let album analysis continue when a
+        // single file fails to probe. Mix one good fixture with one bogus path.
+        let good = std::path::PathBuf::from("tests/fixtures/test_stereo.mp3");
+        let bad = std::path::PathBuf::from("tests/fixtures/this-file-does-not-exist.mp3");
+        let files = vec![good.as_path(), bad.as_path()];
+
+        let strict = analyze_album_with_index(&files, None);
+        assert!(
+            strict.is_err(),
+            "strict variant must fail when any file is unreadable"
+        );
+
+        let report =
+            analyze_album_lenient_with_index(&files, None).expect("lenient must skip the bad file");
+        assert_eq!(report.album.tracks().len(), 1);
+        assert_eq!(report.successful_indices, vec![0]);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].0, 1);
+    }
+
+    #[cfg(feature = "replaygain")]
+    #[test]
+    fn lenient_album_errors_when_all_fail() {
+        let bad1 = std::path::PathBuf::from("tests/fixtures/missing-1.mp3");
+        let bad2 = std::path::PathBuf::from("tests/fixtures/missing-2.mp3");
+        let files = vec![bad1.as_path(), bad2.as_path()];
+
+        let result = analyze_album_lenient_with_index(&files, None);
+        assert!(matches!(result, Err(Error::AllFilesFailed { count: 2 })));
     }
 
     #[cfg(feature = "replaygain")]


### PR DESCRIPTION
## Summary

Adds a new `--skip-errors` flag for album mode (`-a`) that lets analysis
continue past individual files that fail to probe, instead of aborting
the whole run. Also makes the GUI lenient by default so a single bad
file no longer kills an entire album scan.

Closes #144 (reported by @exaveal — single decode error stops a full
library scan with `mp3rgain -Rpa /music`).

## CLI behavior

- Without `--skip-errors`: existing behavior is unchanged. The first
  unreadable file aborts the run with an error.
- With `--skip-errors`:
  - Files that fail analysis are reported with a warning line and
    skipped.
  - The album gain is computed from only the successfully-analyzed
    tracks.
  - Skipped files are surfaced in JSON output as
    `{ "status": "error", "error": "..." }`.
  - If every file fails, mp3rgain still exits with an error
    (`AllFilesFailed`).

## GUI behavior

The GUI now uses the lenient path by default — no opt-in flag, since
"abort everything on the first bad file" is rarely what an interactive
user wants. Failed files are shown as `Error(...)` rows in the table,
the remaining files are analyzed normally, and the status bar reports
the skipped count.

## Public API

Adds 4 new lenient variants alongside the existing strict ones (kept for
backwards compatibility):

- `replaygain::analyze_album_lenient_with_index`
- `replaygain::analyze_album_lenient_with_progress`
- `replaygain::analyze_album_lenient_parallel`
- `replaygain::analyze_album_lenient_parallel_with_completion`

All return a new `AlbumAnalysisReport { album, failures, successful_indices }`.

## Test plan

- [x] `cargo build --release` (CLI + GUI)
- [x] `cargo test --release` (added 2 new unit tests + 1 parser test)
- [x] `cargo fmt --check`
- [x] Manual smoke test reproducing #144:
  - `mp3rgain -Ra <dir-with-corrupt-file>` → aborts (unchanged)
  - `mp3rgain -Ra --skip-errors <same-dir>` → skips bad file, processes the rest
- [x] JSON output verified with `--skip-errors -o json`