### PR TITLE
Apply -d dB modifier during -a / -r gain application (#147)

### DIFF
--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -73,4 +73,11 @@ impl Options {
             ""
         }
     }
+
+    /// Combined `-m` (steps) and `-d` (dB) modifier expressed as mp3 gain steps.
+    /// `-d` is rounded to the nearest 1.5 dB step; sub-step values silently
+    /// round to zero, matching mp3gain's quantized step model.
+    pub fn gain_modifier_steps(&self) -> i32 {
+        self.gain_modifier + mp3rgain::db_to_steps(self.gain_modifier_db)
+    }
 }

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -388,6 +388,33 @@ mod tests {
     }
 
     #[test]
+    fn gain_modifier_steps_combines_d_and_m() {
+        // -d alone: 3.0 dB rounds to +2 steps (1.5 dB per step)
+        let opts = parse_args(&args(&["-d", "3.0", "song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), 2);
+
+        // -m alone: untouched
+        let opts = parse_args(&args(&["-m", "3", "song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), 3);
+
+        // -d + -m: sum
+        let opts = parse_args(&args(&["-d", "3.0", "-m", "1", "song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), 3);
+
+        // Negative -d
+        let opts = parse_args(&args(&["-d", "-3.0", "song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), -2);
+
+        // Sub-step -d (0.5 dB < 0.75 dB threshold) rounds to zero
+        let opts = parse_args(&args(&["-d", "0.5", "song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), 0);
+
+        // No modifiers
+        let opts = parse_args(&args(&["song.mp3"])).unwrap();
+        assert_eq!(opts.gain_modifier_steps(), 0);
+    }
+
+    #[test]
     fn boolean_flags_individual() {
         let opts = parse_args(&args(&[
             "-r", "-p", "-q", "-k", "-c", "-w", "-t", "-R", "-n",

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use colored::*;
 use indicatif::MultiProgress;
 use mp3rgain::replaygain::{self, AlbumAnalysisReport, AlbumGainResult, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::steps_to_db;
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -17,6 +18,21 @@ use crate::progress::{
     progress_set_message,
 };
 use crate::util::get_filename;
+
+fn print_target_with_modifier(opts: &Options) {
+    let modifier_steps = opts.gain_modifier_steps();
+    if modifier_steps != 0 {
+        let modifier_db = steps_to_db(modifier_steps);
+        println!(
+            "  Target: {:.1} dB (ReplayGain {} dB {:+.1} dB modifier)",
+            REPLAYGAIN_REFERENCE_DB + modifier_db,
+            REPLAYGAIN_REFERENCE_DB,
+            modifier_db,
+        );
+    } else {
+        println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
+    }
+}
 
 fn require_replaygain_feature() {
     if !replaygain::is_available() {
@@ -65,10 +81,7 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             },
             files.len()
         );
-        println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
-        if opts.gain_modifier != 0 {
-            println!("  Gain modifier: {:+} steps", opts.gain_modifier);
-        }
+        print_target_with_modifier(opts);
         println!();
     }
 
@@ -173,10 +186,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             "mp3rgain".green().bold(),
             files.len()
         );
-        println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
-        if opts.gain_modifier != 0 {
-            println!("  Gain modifier: {:+} steps", opts.gain_modifier);
-        }
+        print_target_with_modifier(opts);
         println!();
     }
 
@@ -283,8 +293,9 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 file_to_track[*file_idx] = Some(track_idx);
             }
 
-            // Apply gain modifier
-            let modified_gain_steps = album_result.album_gain_steps() + opts.gain_modifier;
+            // Apply gain modifier (-m steps + -d dB, combined into steps)
+            let modifier_steps = opts.gain_modifier_steps();
+            let modified_gain_steps = album_result.album_gain_steps() + modifier_steps;
 
             let json_album = JsonAlbumResult {
                 loudness_db: album_result.album_loudness_db(),
@@ -308,8 +319,8 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                     "  Album gain:     {:+.1} dB ({} steps{})",
                     album_result.album_gain_db(),
                     album_result.album_gain_steps(),
-                    if opts.gain_modifier != 0 {
-                        format!(" + {} = {}", opts.gain_modifier, modified_gain_steps)
+                    if modifier_steps != 0 {
+                        format!(" + {} = {}", modifier_steps, modified_gain_steps)
                     } else {
                         String::new()
                     }

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -55,9 +55,10 @@ fn process_track_gain_into(
 
     match rg_result {
         Ok(result) => {
-            // Apply gain modifier
+            // Apply gain modifier (-m steps + -d dB, combined into steps)
             let base_steps = result.gain_steps();
-            let modified_steps = base_steps + opts.gain_modifier;
+            let modifier_steps = opts.gain_modifier_steps();
+            let modified_steps = base_steps + modifier_steps;
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(
@@ -66,8 +67,8 @@ fn process_track_gain_into(
                     result.loudness_db(),
                     result.gain_db(),
                     base_steps,
-                    if opts.gain_modifier != 0 {
-                        format!(" + {} = {}", opts.gain_modifier, modified_steps)
+                    if modifier_steps != 0 {
+                        format!(" + {} = {}", modifier_steps, modified_steps)
                     } else {
                         String::new()
                     },


### PR DESCRIPTION
Fixes #147.

## Summary

- `-d <dB>` was parsed into `opts.gain_modifier_db` but only the info / analysis path consumed it. `cmd_track_gain`, `cmd_album_gain`, and the underlying processor only honoured `-m` (steps), so `-d 3.0` silently did nothing during `-a` or `-r`.
- Add `Options::gain_modifier_steps()` that combines `-m` and `-d` (converting dB to steps via `db_to_steps`), and route it through both apply paths.
- Refresh the "Target" / "Album gain" / per-track output so the active modifier is visible to the user.

## Behavior after fix

```
$ mp3rgain -R -a -d 3.0 /music/
  Target: 92.0 dB (ReplayGain 89 dB +3.0 dB modifier)
  Album gain:     +84.8 dB (57 steps + 2 = 59)
  ~ would apply +88.5 dB, 59 steps
```

`-d 0.5` (sub-step) silently rounds to zero, matching mp3gain's quantized 1.5 dB step model. Negative `-d` works (`-d -3.0` → −2 steps).

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo test` — all 39 unit + 21 integration + 2 doc tests pass
- [x] New unit test `gain_modifier_steps_combines_d_and_m` covers: `-d` alone, `-m` alone, `-d + -m` summing, negative `-d`, sub-step `-d` rounding to 0, no modifiers
- [x] Manual smoke test on `tests/fixtures/test_stereo.mp3`:
  - `-a` baseline: 57 steps applied
  - `-a -d 3.0`: 59 steps applied (target line + album gain line both updated)
  - `-a -d -3.0`: 55 steps applied
  - `-a -d 0.5`: 57 steps applied (sub-step quantized to 0)
  - `-r -d 3.0`: 59 steps applied, per-track loudness line updated