### PR TITLE
Fix GUI corrupting M4A files when applying gain (#149)

### DIFF
--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "2.5.0"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgui"
-version = "2.5.0"
+version = "2.6.2"
 dependencies = [
  "eframe",
  "egui",
@@ -3519,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38c0b8e99ce52271da0f3fec5780a8566edd703b181211dd0ff725efeaaae38"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -3533,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e64864167bd6cb39e743c19036cad4486ba4dcf299336b695249ea3cfd31ff"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
 dependencies = [
  "lazy_static",
  "log",
@@ -3544,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7139b6baf2f6df9877395d70bf16edc0860d72ff35eefbf51d083b10b36f7949"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
 dependencies = [
  "lazy_static",
  "log",
@@ -3556,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-common"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c029b5a948c81fd3a46647a151b959109d1d16b05a1d7c7eca1fdac0ace0a27"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3567,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2e760147497d7f939f18b7739387c7e6b5322d9ce0cf10cd93cf96f4d815c"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -3581,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0c9c23912250e33b40c0d36deded5c03aef33299e03c39f78e6125d492da61"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3593,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea744eea37a3336aeb2919b5632a5b79dc12695e60cac15adf3422814c0f32c"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
 dependencies = [
  "lazy_static",
  "log",

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -254,7 +254,7 @@ impl Mp3rgainApp {
 
             if let Some(gain_db) = file.track_gain {
                 file.status = FileStatus::Applying;
-                match mp3rgain::apply_gain_db(&file.path, gain_db) {
+                match mp3rgain::apply_gain_db_auto(&file.path, gain_db) {
                     Ok(_) => {
                         file.status = FileStatus::Done;
                         applied += 1;
@@ -289,7 +289,7 @@ impl Mp3rgainApp {
 
             if let Some(gain_db) = file.album_gain {
                 file.status = FileStatus::Applying;
-                match mp3rgain::apply_gain_db(&file.path, gain_db) {
+                match mp3rgain::apply_gain_db_auto(&file.path, gain_db) {
                     Ok(_) => {
                         file.status = FileStatus::Done;
                         applied += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,25 @@ pub fn collect_audio_files(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>> 
     Ok(result)
 }
 
+/// Apply gain in dB, auto-dispatching by file format.
+///
+/// Detects MP4/AAC files via [`mp4meta::is_aac_file`] and routes them through
+/// the AAC pipeline (which rewrites only the AAC `global_gain` bitfields inside
+/// `mdat`). All other files fall back to the MP3 pipeline.
+///
+/// Calling [`gain::apply_gain_db`] directly on an M4A file would scan the raw
+/// bytes for MP3 sync words and overwrite the byte following any match,
+/// corrupting the MP4 container — see issue #149.
+pub fn apply_gain_db_auto(file_path: &Path, gain_db: f64) -> Result<usize> {
+    #[cfg(feature = "aac")]
+    {
+        if mp4meta::is_aac_file(file_path) {
+            return aac::apply_aac_gain_to_path(file_path, file_path, gain::db_to_steps(gain_db));
+        }
+    }
+    gain::apply_gain_db(file_path, gain_db)
+}
+
 fn collect_audio_files_into(dir: &Path, recursive: bool, result: &mut Vec<PathBuf>) -> Result<()> {
     let entries = std::fs::read_dir(dir).map_err(|e| Error::io_read(dir, e))?;
     for entry in entries {
@@ -139,4 +158,58 @@ fn collect_audio_files_into(dir: &Path, recursive: bool, result: &mut Vec<PathBu
         }
     }
     Ok(())
+}
+
+#[cfg(all(test, feature = "aac"))]
+mod auto_dispatch_tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Regression for issue #149: applying gain to an MP4 file via the
+    /// auto-dispatcher must NOT run the MP3 sync-word scanner, which would
+    /// overwrite bytes inside MP4 atoms whenever they happen to look like a
+    /// valid MPEG L3 frame header and corrupt the container.
+    ///
+    /// The crafted MP4 below embeds a 72-byte MPEG2.5 L3 8kbps frame header
+    /// immediately after the ftyp box. The buggy MP3 path would treat byte 27
+    /// (the `global_gain` location inside the side info) as a writable gain
+    /// slot and rewrite it. The dispatch must hand the file to the AAC path
+    /// (which rejects it cleanly because there's no `mdat`) and leave the
+    /// bytes untouched.
+    #[test]
+    fn auto_dispatch_does_not_corrupt_mp4_when_payload_mimics_mp3_frame() {
+        let dir = std::env::temp_dir().join("mp3rgain_issue_149");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("fake.m4a");
+
+        // ftyp box (20 bytes) + two back-to-back MPEG2.5 L3 8kbps/11025Hz stereo
+        // "frames" (52 bytes each). The MP3 scanner validates a frame by looking
+        // for another sync word at next_pos or by next_pos == audio_end — so two
+        // chained frames make the first one parse as valid.
+        let mut bytes = vec![
+            0x00, 0x00, 0x00, 0x14, b'f', b't', b'y', b'p', b'M', b'4', b'A', b' ', 0x00, 0x00,
+            0x00, 0x00, b'M', b'4', b'A', b' ', // ftyp box (20 bytes, accepted brand)
+        ];
+        let frame_header = [0xFFu8, 0xE3, 0x10, 0x00];
+        bytes.extend_from_slice(&frame_header);
+        bytes.resize(20 + 52, 0x55); // pad first frame to 52 bytes
+        bytes.extend_from_slice(&frame_header);
+        bytes.resize(20 + 52 + 52, 0x55); // pad second frame to 52 bytes
+        let original = bytes.clone();
+
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+
+        let _ = apply_gain_db_auto(&path, 3.0);
+
+        let after = std::fs::read(&path).unwrap();
+        assert_eq!(
+            after, original,
+            "MP4 bytes must be untouched by auto dispatch"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

- The CLI already routes M4A/AAC files through `aac::apply_aac_gain_to_path`, but the GUI was calling MP3-only `mp3rgain::apply_gain_db` directly. That function scans raw bytes for MP3 sync words and rewrites the byte at the `global_gain` location of any match — on M4A this corrupts MP4 atoms whenever a 4-byte sequence happens to look like a valid MPEG L3 frame header. The file usually still plays, but strict tools (the reporter hit this with MP3GainGUI 1.3.4) reject it as "not a valid mp4/m4a file".
- Add `mp3rgain::apply_gain_db_auto(file, gain_db)` that dispatches by file type (`mp4meta::is_aac_file` → AAC pipeline; otherwise MP3 pipeline), and switch the GUI's track/album apply paths to use it.
- Add a regression test that builds an MP4 whose payload mimics two chained MP3 frames; the buggy dispatch corrupts bytes 28/36/80/88 (verified locally by reverting the dispatch), the fixed dispatch leaves them untouched.

Fixes #149.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo test` (lib 34 + integration 21 + doc 2, all pass)
- [x] `cargo build --release` (CLI)
- [x] `cd mp3rgui && cargo build --release` (GUI)
- [x] Regression test fails when dispatch is removed, passes when restored