### PR TITLE
Refactor apply pipeline + GUI worker thread (#153 steps 1-4)

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,4 +1,6 @@
+use mp3rgain::apply::{apply_with_options, ApplyOptions};
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::{db_to_steps, AacAlbumInfo};
 use std::path::{Path, PathBuf};
 
 #[derive(Default, Clone, PartialEq)]
@@ -37,6 +39,10 @@ pub struct FileEntry {
     pub album_gain: Option<f64>,
     pub album_clip: bool,
     pub status: FileStatus,
+    /// Cached per-track ReplayGain analysis. Required by `apply_with_options`
+    /// to drive the peak-based clipping check and to write ReplayGain tags
+    /// (`replaygain_track_gain` / `replaygain_track_peak`) on apply.
+    pub track_result: Option<ReplayGainResult>,
 }
 
 pub struct Mp3rgainApp {
@@ -46,6 +52,9 @@ pub struct Mp3rgainApp {
     pub total_progress: f32,
     pub is_processing: bool,
     pub status_message: String,
+    /// Most-recent album analysis. Feeds the `replaygain_album_*` tag fields
+    /// when `apply_album_gain` runs.
+    pub album_info: Option<AacAlbumInfo>,
 }
 
 impl Mp3rgainApp {
@@ -57,6 +66,7 @@ impl Mp3rgainApp {
             total_progress: 0.0,
             is_processing: false,
             status_message: String::new(),
+            album_info: None,
         }
     }
 
@@ -114,6 +124,7 @@ impl Mp3rgainApp {
     pub fn clear_files(&mut self) {
         self.files.clear();
         self.selected_indices.clear();
+        self.album_info = None;
     }
 
     pub fn analyze_tracks(&mut self) {
@@ -126,6 +137,8 @@ impl Mp3rgainApp {
 
         self.is_processing = true;
         self.total_progress = 0.0;
+        // Track-only analysis invalidates any previously-computed album info.
+        self.album_info = None;
 
         let total = self.files.len();
         let mut analyzed = 0;
@@ -138,10 +151,12 @@ impl Mp3rgainApp {
             match replaygain::analyze_track(&file.path) {
                 Ok(result) => {
                     Self::populate_track_analysis(file, &result, self.target_volume);
+                    file.track_result = Some(result);
                     file.status = FileStatus::Analyzed;
                     analyzed += 1;
                 }
                 Err(e) => {
+                    file.track_result = None;
                     file.status = FileStatus::Error(e.to_string());
                     errors += 1;
                 }
@@ -163,6 +178,7 @@ impl Mp3rgainApp {
 
         self.is_processing = true;
         self.total_progress = 0.0;
+        self.album_info = None;
 
         let paths: Vec<&std::path::Path> = self.files.iter().map(|f| f.path.as_path()).collect();
 
@@ -180,6 +196,7 @@ impl Mp3rgainApp {
                     let track_result = &report.album.tracks()[track_idx];
                     let file = &mut self.files[file_idx];
                     Self::populate_track_analysis(file, track_result, self.target_volume);
+                    file.track_result = Some(track_result.clone());
                     file.album_volume = Some(album_volume);
                     file.album_gain = Some(album_gain);
                     file.album_clip = album_clip;
@@ -187,8 +204,14 @@ impl Mp3rgainApp {
                 }
 
                 for (file_idx, msg) in &report.failures {
+                    self.files[*file_idx].track_result = None;
                     self.files[*file_idx].status = FileStatus::Error(msg.clone());
                 }
+
+                self.album_info = Some(AacAlbumInfo {
+                    album_gain_db: report.album.album_gain_db(),
+                    album_peak: report.album.album_peak(),
+                });
 
                 let analyzed = report.successful_indices.len();
                 let skipped = report.failures.len();
@@ -252,17 +275,20 @@ impl Mp3rgainApp {
         for (i, file) in self.files.iter_mut().enumerate() {
             self.total_progress = i as f32 / total as f32;
 
-            if let Some(gain_db) = file.track_gain {
-                file.status = FileStatus::Applying;
-                match mp3rgain::apply_gain_db_auto(&file.path, gain_db) {
-                    Ok(_) => {
-                        file.status = FileStatus::Done;
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        file.status = FileStatus::Error(e.to_string());
-                        errors += 1;
-                    }
+            let Some(gain_db) = file.track_gain else {
+                continue;
+            };
+            file.status = FileStatus::Applying;
+            // Track-only path: no album info, only the per-track RG result.
+            let opts = build_apply_options(db_to_steps(gain_db), file.track_result.clone(), None);
+            match apply_with_options(&file.path, &opts) {
+                Ok(_) => {
+                    file.status = FileStatus::Done;
+                    applied += 1;
+                }
+                Err(e) => {
+                    file.status = FileStatus::Error(e.to_string());
+                    errors += 1;
                 }
             }
         }
@@ -284,20 +310,27 @@ impl Mp3rgainApp {
         let mut applied = 0;
         let mut errors = 0;
 
+        // Copy out so we can iterate `self.files` mutably without holding a
+        // borrow of `self`.
+        let album_info = self.album_info;
+
         for (i, file) in self.files.iter_mut().enumerate() {
             self.total_progress = i as f32 / total as f32;
 
-            if let Some(gain_db) = file.album_gain {
-                file.status = FileStatus::Applying;
-                match mp3rgain::apply_gain_db_auto(&file.path, gain_db) {
-                    Ok(_) => {
-                        file.status = FileStatus::Done;
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        file.status = FileStatus::Error(e.to_string());
-                        errors += 1;
-                    }
+            let Some(gain_db) = file.album_gain else {
+                continue;
+            };
+            file.status = FileStatus::Applying;
+            let opts =
+                build_apply_options(db_to_steps(gain_db), file.track_result.clone(), album_info);
+            match apply_with_options(&file.path, &opts) {
+                Ok(_) => {
+                    file.status = FileStatus::Done;
+                    applied += 1;
+                }
+                Err(e) => {
+                    file.status = FileStatus::Error(e.to_string());
+                    errors += 1;
                 }
             }
         }
@@ -306,6 +339,26 @@ impl Mp3rgainApp {
         self.is_processing = false;
         self.status_message = Self::format_result_message("Applied album gain to", applied, errors);
     }
+}
+
+/// Build `ApplyOptions` with the GUI's "safe defaults":
+///   - `write_undo`             — files can be reverted later (was missing pre-#153, A1)
+///   - `write_replaygain_tags`  — RG metadata is recorded so players see it (A2 for AAC)
+///   - `use_temp_file`          — atomic rename so a crash mid-apply can't corrupt (A4)
+///   - `preserve_timestamp`     — playlist sort order doesn't get jumbled (A5)
+fn build_apply_options(
+    steps: i32,
+    track_result: Option<ReplayGainResult>,
+    album_info: Option<AacAlbumInfo>,
+) -> ApplyOptions {
+    let mut opts = ApplyOptions::new(steps);
+    opts.track_result = track_result;
+    opts.album_info = album_info;
+    opts.write_undo = true;
+    opts.write_replaygain_tags = true;
+    opts.use_temp_file = true;
+    opts.preserve_timestamp = true;
+    opts
 }
 
 impl eframe::App for Mp3rgainApp {

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,4 +1,4 @@
-use crate::worker::{self, ApplyJob, WorkerEvent, WorkerHandle};
+use crate::worker::{self, ApplyJob, ApplyOptionsUi, WorkerEvent, WorkerHandle};
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_steps, AacAlbumInfo};
 use std::path::{Path, PathBuf};
@@ -66,6 +66,8 @@ pub struct Mp3rgainApp {
     /// Most-recent album analysis. Feeds `replaygain_album_*` tag fields
     /// when `apply_album_gain` runs.
     pub album_info: Option<AacAlbumInfo>,
+    /// User-toggleable apply flags surfaced in the Options panel.
+    pub apply_options: ApplyOptionsUi,
 
     /// Active worker thread + its mpsc receiver and cancel flag.
     /// `None` when nothing is running.
@@ -90,6 +92,7 @@ impl Mp3rgainApp {
             is_processing: false,
             status_message: String::new(),
             album_info: None,
+            apply_options: ApplyOptionsUi::default(),
             worker: None,
             worker_kind: None,
             started_files: 0,
@@ -255,10 +258,11 @@ impl Mp3rgainApp {
             self.files[job_idx].status = FileStatus::Pending;
         }
         let count = jobs.len();
+        let ui_opts = self.apply_options;
         self.begin_worker(
             WorkerKind::TrackApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "track gain"),
+            worker::spawn_apply(ctx.clone(), jobs, "track gain", ui_opts),
         );
     }
 
@@ -292,10 +296,11 @@ impl Mp3rgainApp {
             self.files[job_idx].status = FileStatus::Pending;
         }
         let count = jobs.len();
+        let ui_opts = self.apply_options;
         self.begin_worker(
             WorkerKind::AlbumApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "album gain"),
+            worker::spawn_apply(ctx.clone(), jobs, "album gain", ui_opts),
         );
     }
 

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,7 +1,8 @@
-use mp3rgain::apply::{apply_with_options, ApplyOptions};
+use crate::worker::{self, ApplyJob, WorkerEvent, WorkerHandle};
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_steps, AacAlbumInfo};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::TryRecvError;
 
 #[derive(Default, Clone, PartialEq)]
 pub enum FileStatus {
@@ -40,9 +41,19 @@ pub struct FileEntry {
     pub album_clip: bool,
     pub status: FileStatus,
     /// Cached per-track ReplayGain analysis. Required by `apply_with_options`
-    /// to drive the peak-based clipping check and to write ReplayGain tags
-    /// (`replaygain_track_gain` / `replaygain_track_peak`) on apply.
+    /// for the peak-based clipping check and for writing
+    /// `replaygain_track_*` tags on apply.
     pub track_result: Option<ReplayGainResult>,
+}
+
+/// What kind of work the active worker is doing — drives messaging and
+/// final-event handling.
+#[derive(Clone, Copy, PartialEq)]
+enum WorkerKind {
+    TrackAnalysis,
+    AlbumAnalysis,
+    TrackApply,
+    AlbumApply,
 }
 
 pub struct Mp3rgainApp {
@@ -52,9 +63,21 @@ pub struct Mp3rgainApp {
     pub total_progress: f32,
     pub is_processing: bool,
     pub status_message: String,
-    /// Most-recent album analysis. Feeds the `replaygain_album_*` tag fields
+    /// Most-recent album analysis. Feeds `replaygain_album_*` tag fields
     /// when `apply_album_gain` runs.
     pub album_info: Option<AacAlbumInfo>,
+
+    /// Active worker thread + its mpsc receiver and cancel flag.
+    /// `None` when nothing is running.
+    worker: Option<WorkerHandle>,
+    /// What kind of work the active worker is doing.
+    worker_kind: Option<WorkerKind>,
+    /// Counter incremented as worker emits `FileStart` events — drives the
+    /// progress bar without needing to know the total in advance.
+    started_files: usize,
+    /// Total files the worker was launched against (denominator for the
+    /// progress bar).
+    total_files_in_job: usize,
 }
 
 impl Mp3rgainApp {
@@ -67,10 +90,17 @@ impl Mp3rgainApp {
             is_processing: false,
             status_message: String::new(),
             album_info: None,
+            worker: None,
+            worker_kind: None,
+            started_files: 0,
+            total_files_in_job: 0,
         }
     }
 
     pub fn add_files(&mut self, paths: Vec<PathBuf>) {
+        if self.is_processing {
+            return;
+        }
         let mut added = 0;
         let mut skipped = 0;
 
@@ -106,11 +136,17 @@ impl Mp3rgainApp {
     }
 
     pub fn add_folder(&mut self, folder: PathBuf, recursive: bool) {
+        if self.is_processing {
+            return;
+        }
         let paths_to_add = mp3rgain::collect_audio_files(&folder, recursive).unwrap_or_default();
         self.add_files(paths_to_add);
     }
 
     pub fn remove_selected(&mut self) {
+        if self.is_processing {
+            return;
+        }
         let mut indices = self.selected_indices.clone();
         indices.sort_unstable();
         for &idx in indices.iter().rev() {
@@ -122,115 +158,276 @@ impl Mp3rgainApp {
     }
 
     pub fn clear_files(&mut self) {
+        if self.is_processing {
+            return;
+        }
         self.files.clear();
         self.selected_indices.clear();
         self.album_info = None;
     }
 
-    pub fn analyze_tracks(&mut self) {
-        if self.files.is_empty() || !replaygain::is_available() {
-            if !replaygain::is_available() {
-                self.status_message = "ReplayGain feature not available".to_string();
-            }
-            return;
+    pub fn cancel_current_work(&mut self) {
+        if let Some(worker) = self.worker.as_ref() {
+            worker.request_cancel();
+            self.status_message = "Cancelling...".to_string();
         }
-
-        self.is_processing = true;
-        self.total_progress = 0.0;
-        // Track-only analysis invalidates any previously-computed album info.
-        self.album_info = None;
-
-        let total = self.files.len();
-        let mut analyzed = 0;
-        let mut errors = 0;
-
-        for (i, file) in self.files.iter_mut().enumerate() {
-            file.status = FileStatus::Analyzing;
-            self.total_progress = i as f32 / total as f32;
-
-            match replaygain::analyze_track(&file.path) {
-                Ok(result) => {
-                    Self::populate_track_analysis(file, &result, self.target_volume);
-                    file.track_result = Some(result);
-                    file.status = FileStatus::Analyzed;
-                    analyzed += 1;
-                }
-                Err(e) => {
-                    file.track_result = None;
-                    file.status = FileStatus::Error(e.to_string());
-                    errors += 1;
-                }
-            }
-        }
-
-        self.total_progress = 1.0;
-        self.is_processing = false;
-        self.status_message = Self::format_result_message("Analyzed", analyzed, errors);
     }
 
-    pub fn analyze_album(&mut self) {
-        if self.files.is_empty() || !replaygain::is_available() {
+    pub fn start_analyze_tracks(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing || !replaygain::is_available() {
             if !replaygain::is_available() {
                 self.status_message = "ReplayGain feature not available".to_string();
             }
             return;
         }
 
-        self.is_processing = true;
-        self.total_progress = 0.0;
+        // Track-only analysis invalidates any previously-computed album info.
         self.album_info = None;
-
-        let paths: Vec<&std::path::Path> = self.files.iter().map(|f| f.path.as_path()).collect();
-
-        // Use the lenient variant so a single bad file does not abort the
-        // whole album scan — the failed file is shown as Error in the table
-        // and the rest is analyzed normally (issue #144).
-        match replaygain::analyze_album_lenient_with_index(&paths, None) {
-            Ok(report) => {
-                let album_gain =
-                    self.target_volume - REPLAYGAIN_REFERENCE_DB + report.album.album_gain_db();
-                let album_volume = REPLAYGAIN_REFERENCE_DB - report.album.album_gain_db();
-                let album_clip = Self::would_clip(report.album.album_peak(), album_gain);
-
-                for (track_idx, &file_idx) in report.successful_indices.iter().enumerate() {
-                    let track_result = &report.album.tracks()[track_idx];
-                    let file = &mut self.files[file_idx];
-                    Self::populate_track_analysis(file, track_result, self.target_volume);
-                    file.track_result = Some(track_result.clone());
-                    file.album_volume = Some(album_volume);
-                    file.album_gain = Some(album_gain);
-                    file.album_clip = album_clip;
-                    file.status = FileStatus::Analyzed;
-                }
-
-                for (file_idx, msg) in &report.failures {
-                    self.files[*file_idx].track_result = None;
-                    self.files[*file_idx].status = FileStatus::Error(msg.clone());
-                }
-
-                self.album_info = Some(AacAlbumInfo {
-                    album_gain_db: report.album.album_gain_db(),
-                    album_peak: report.album.album_peak(),
-                });
-
-                let analyzed = report.successful_indices.len();
-                let skipped = report.failures.len();
-                self.status_message = if skipped > 0 {
-                    format!(
-                        "Album analysis complete ({} tracks, {} skipped)",
-                        analyzed, skipped
-                    )
-                } else {
-                    format!("Album analysis complete ({} tracks)", analyzed)
-                };
-            }
-            Err(e) => {
-                self.status_message = format!("Album analysis failed: {}", e);
-            }
+        for file in &mut self.files {
+            file.status = FileStatus::Pending;
         }
 
-        self.total_progress = 1.0;
-        self.is_processing = false;
+        let jobs: Vec<(usize, PathBuf)> = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (i, f.path.clone()))
+            .collect();
+        self.begin_worker(
+            WorkerKind::TrackAnalysis,
+            jobs.len(),
+            worker::spawn_track_analysis(ctx.clone(), jobs),
+        );
+    }
+
+    pub fn start_analyze_album(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing || !replaygain::is_available() {
+            if !replaygain::is_available() {
+                self.status_message = "ReplayGain feature not available".to_string();
+            }
+            return;
+        }
+
+        self.album_info = None;
+        for file in &mut self.files {
+            file.status = FileStatus::Pending;
+        }
+
+        let jobs: Vec<(usize, PathBuf)> = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (i, f.path.clone()))
+            .collect();
+        self.begin_worker(
+            WorkerKind::AlbumAnalysis,
+            jobs.len(),
+            worker::spawn_album_analysis(ctx.clone(), jobs),
+        );
+    }
+
+    pub fn start_apply_track_gain(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+
+        let jobs: Vec<ApplyJob> = self
+            .files
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, f)| {
+                f.track_gain.map(|gain_db| ApplyJob {
+                    idx,
+                    path: f.path.clone(),
+                    steps: db_to_steps(gain_db),
+                    track_result: f.track_result.clone(),
+                    album_info: None,
+                })
+            })
+            .collect();
+
+        if jobs.is_empty() {
+            self.status_message = "No track gain values — run Track Analysis first".to_string();
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        self.begin_worker(
+            WorkerKind::TrackApply,
+            count,
+            worker::spawn_apply(ctx.clone(), jobs, "track gain"),
+        );
+    }
+
+    pub fn start_apply_album_gain(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+
+        let album_info = self.album_info;
+        let jobs: Vec<ApplyJob> = self
+            .files
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, f)| {
+                f.album_gain.map(|gain_db| ApplyJob {
+                    idx,
+                    path: f.path.clone(),
+                    steps: db_to_steps(gain_db),
+                    track_result: f.track_result.clone(),
+                    album_info,
+                })
+            })
+            .collect();
+
+        if jobs.is_empty() {
+            self.status_message = "No album gain values — run Album Analysis first".to_string();
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        self.begin_worker(
+            WorkerKind::AlbumApply,
+            count,
+            worker::spawn_apply(ctx.clone(), jobs, "album gain"),
+        );
+    }
+
+    fn begin_worker(&mut self, kind: WorkerKind, total: usize, handle: WorkerHandle) {
+        self.worker = Some(handle);
+        self.worker_kind = Some(kind);
+        self.is_processing = true;
+        self.total_progress = 0.0;
+        self.status_message = match kind {
+            WorkerKind::TrackAnalysis => "Analyzing tracks...".to_string(),
+            WorkerKind::AlbumAnalysis => "Analyzing album...".to_string(),
+            WorkerKind::TrackApply => "Applying track gain...".to_string(),
+            WorkerKind::AlbumApply => "Applying album gain...".to_string(),
+        };
+        self.started_files = 0;
+        self.total_files_in_job = total;
+    }
+
+    /// Drain pending worker events into UI state. Called from `update()`.
+    pub fn pump_worker_events(&mut self) {
+        // Drain into a local Vec first so we can hand `&mut self` to
+        // `apply_event` without conflicting with the receiver borrow.
+        let mut events = Vec::new();
+        let mut worker_finished = false;
+        if let Some(worker) = self.worker.as_ref() {
+            loop {
+                match worker.rx.try_recv() {
+                    Ok(event) => events.push(event),
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        worker_finished = true;
+                        break;
+                    }
+                }
+            }
+        }
+        for event in events {
+            self.apply_event(event);
+        }
+        if worker_finished {
+            self.worker = None;
+            self.worker_kind = None;
+            self.is_processing = false;
+        }
+    }
+
+    fn apply_event(&mut self, event: WorkerEvent) {
+        match event {
+            WorkerEvent::FileStart { idx } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = match self.worker_kind {
+                        Some(WorkerKind::TrackApply) | Some(WorkerKind::AlbumApply) => {
+                            FileStatus::Applying
+                        }
+                        _ => FileStatus::Analyzing,
+                    };
+                }
+                self.started_files = self.started_files.saturating_add(1);
+                self.bump_progress();
+            }
+            WorkerEvent::TrackAnalyzed { idx, result } => {
+                let target = self.target_volume;
+                if let Some(file) = self.files.get_mut(idx) {
+                    Self::populate_track_analysis(file, &result, target);
+                    file.track_result = Some(result);
+                    file.status = FileStatus::Analyzed;
+                }
+            }
+            WorkerEvent::TrackAnalysisFailed { idx, message } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.track_result = None;
+                    file.status = FileStatus::Error(message);
+                }
+            }
+            WorkerEvent::AlbumAnalysisDone {
+                successful,
+                failures,
+                album_info,
+            } => {
+                let target = self.target_volume;
+                let album_gain = target - REPLAYGAIN_REFERENCE_DB + album_info.album_gain_db;
+                let album_volume = REPLAYGAIN_REFERENCE_DB - album_info.album_gain_db;
+                let album_clip = Self::would_clip(album_info.album_peak, album_gain);
+
+                for (idx, track_result) in successful {
+                    if let Some(file) = self.files.get_mut(idx) {
+                        Self::populate_track_analysis(file, &track_result, target);
+                        file.track_result = Some(track_result);
+                        file.album_volume = Some(album_volume);
+                        file.album_gain = Some(album_gain);
+                        file.album_clip = album_clip;
+                        file.status = FileStatus::Analyzed;
+                    }
+                }
+                for (idx, msg) in failures {
+                    if let Some(file) = self.files.get_mut(idx) {
+                        file.track_result = None;
+                        file.status = FileStatus::Error(msg);
+                    }
+                }
+
+                self.album_info = Some(album_info);
+            }
+            WorkerEvent::AlbumAnalysisFailed(msg) => {
+                self.status_message = format!("Album analysis failed: {}", msg);
+            }
+            WorkerEvent::FileApplied { idx } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::Done;
+                }
+            }
+            WorkerEvent::FileApplyFailed { idx, message } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::Error(message);
+                }
+            }
+            WorkerEvent::Cancelled => {
+                self.status_message = "Cancelled".to_string();
+                self.total_progress = 0.0;
+            }
+            WorkerEvent::Done { message } => {
+                self.status_message = message;
+                self.total_progress = 1.0;
+            }
+        }
+    }
+
+    fn bump_progress(&mut self) {
+        if self.total_files_in_job == 0 {
+            return;
+        }
+        self.total_progress = (self.started_files as f32) / (self.total_files_in_job as f32);
     }
 
     /// Populate a file entry with track-level analysis results.
@@ -247,122 +444,15 @@ impl Mp3rgainApp {
         file.track_clip = Self::would_clip(result.peak(), gain);
     }
 
-    fn format_result_message(action: &str, count: usize, errors: usize) -> String {
-        if errors > 0 {
-            format!("{} {} file(s), {} error(s)", action, count, errors)
-        } else {
-            format!("{} {} file(s)", action, count)
-        }
-    }
-
     fn would_clip(peak: f64, gain_db: f64) -> bool {
         let gain_linear = 10.0_f64.powf(gain_db / 20.0);
         peak * gain_linear > 1.0
     }
-
-    pub fn apply_track_gain(&mut self) {
-        if self.files.is_empty() {
-            return;
-        }
-
-        self.is_processing = true;
-        self.total_progress = 0.0;
-
-        let total = self.files.len();
-        let mut applied = 0;
-        let mut errors = 0;
-
-        for (i, file) in self.files.iter_mut().enumerate() {
-            self.total_progress = i as f32 / total as f32;
-
-            let Some(gain_db) = file.track_gain else {
-                continue;
-            };
-            file.status = FileStatus::Applying;
-            // Track-only path: no album info, only the per-track RG result.
-            let opts = build_apply_options(db_to_steps(gain_db), file.track_result.clone(), None);
-            match apply_with_options(&file.path, &opts) {
-                Ok(_) => {
-                    file.status = FileStatus::Done;
-                    applied += 1;
-                }
-                Err(e) => {
-                    file.status = FileStatus::Error(e.to_string());
-                    errors += 1;
-                }
-            }
-        }
-
-        self.total_progress = 1.0;
-        self.is_processing = false;
-        self.status_message = Self::format_result_message("Applied track gain to", applied, errors);
-    }
-
-    pub fn apply_album_gain(&mut self) {
-        if self.files.is_empty() {
-            return;
-        }
-
-        self.is_processing = true;
-        self.total_progress = 0.0;
-
-        let total = self.files.len();
-        let mut applied = 0;
-        let mut errors = 0;
-
-        // Copy out so we can iterate `self.files` mutably without holding a
-        // borrow of `self`.
-        let album_info = self.album_info;
-
-        for (i, file) in self.files.iter_mut().enumerate() {
-            self.total_progress = i as f32 / total as f32;
-
-            let Some(gain_db) = file.album_gain else {
-                continue;
-            };
-            file.status = FileStatus::Applying;
-            let opts =
-                build_apply_options(db_to_steps(gain_db), file.track_result.clone(), album_info);
-            match apply_with_options(&file.path, &opts) {
-                Ok(_) => {
-                    file.status = FileStatus::Done;
-                    applied += 1;
-                }
-                Err(e) => {
-                    file.status = FileStatus::Error(e.to_string());
-                    errors += 1;
-                }
-            }
-        }
-
-        self.total_progress = 1.0;
-        self.is_processing = false;
-        self.status_message = Self::format_result_message("Applied album gain to", applied, errors);
-    }
-}
-
-/// Build `ApplyOptions` with the GUI's "safe defaults":
-///   - `write_undo`             — files can be reverted later (was missing pre-#153, A1)
-///   - `write_replaygain_tags`  — RG metadata is recorded so players see it (A2 for AAC)
-///   - `use_temp_file`          — atomic rename so a crash mid-apply can't corrupt (A4)
-///   - `preserve_timestamp`     — playlist sort order doesn't get jumbled (A5)
-fn build_apply_options(
-    steps: i32,
-    track_result: Option<ReplayGainResult>,
-    album_info: Option<AacAlbumInfo>,
-) -> ApplyOptions {
-    let mut opts = ApplyOptions::new(steps);
-    opts.track_result = track_result;
-    opts.album_info = album_info;
-    opts.write_undo = true;
-    opts.write_replaygain_tags = true;
-    opts.use_temp_file = true;
-    opts.preserve_timestamp = true;
-    opts
 }
 
 impl eframe::App for Mp3rgainApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.pump_worker_events();
         crate::ui::render(self, ctx);
     }
 }

--- a/mp3rgui/src/main.rs
+++ b/mp3rgui/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app;
 mod ui;
+mod worker;
 
 use app::Mp3rgainApp;
 

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -4,8 +4,8 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
         egui::menu::bar(ui, |ui| {
             file_menu(app, ui, ctx);
-            analysis_menu(app, ui);
-            modify_menu(app, ui);
+            analysis_menu(app, ui, ctx);
+            modify_menu(app, ui, ctx);
         });
     });
 }
@@ -45,30 +45,30 @@ fn file_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
     });
 }
 
-fn analysis_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
+fn analysis_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
     ui.menu_button("Analysis", |ui| {
         ui.add_enabled_ui(!app.files.is_empty() && !app.is_processing, |ui| {
             if ui.button("Track Analysis").clicked() {
-                app.analyze_tracks();
+                app.start_analyze_tracks(ctx);
                 ui.close_menu();
             }
             if ui.button("Album Analysis").clicked() {
-                app.analyze_album();
+                app.start_analyze_album(ctx);
                 ui.close_menu();
             }
         });
     });
 }
 
-fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
+fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
     ui.menu_button("Modify Gain", |ui| {
         ui.add_enabled_ui(!app.files.is_empty() && !app.is_processing, |ui| {
             if ui.button("Apply Track Gain").clicked() {
-                app.apply_track_gain();
+                app.start_apply_track_gain(ctx);
                 ui.close_menu();
             }
             if ui.button("Apply Album Gain").clicked() {
-                app.apply_album_gain();
+                app.start_apply_album_gain(ctx);
                 ui.close_menu();
             }
         });

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -1,4 +1,5 @@
 mod menu;
+mod options;
 mod status;
 mod table;
 mod toolbar;
@@ -9,6 +10,7 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     handle_dropped_files(app, ctx);
     menu::render(app, ctx);
     toolbar::render(app, ctx);
+    options::render(app, ctx);
     status::render(app, ctx);
     render_central_panel(app, ctx);
 }

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -14,17 +14,31 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
 }
 
 fn handle_dropped_files(app: &mut Mp3rgainApp, ctx: &egui::Context) {
-    ctx.input(|i| {
-        if !i.raw.dropped_files.is_empty() {
-            let paths: Vec<std::path::PathBuf> = i
-                .raw
-                .dropped_files
-                .iter()
-                .filter_map(|f| f.path.clone())
-                .collect();
-            app.add_files(paths);
-        }
+    let dropped: Vec<std::path::PathBuf> = ctx.input(|i| {
+        i.raw
+            .dropped_files
+            .iter()
+            .filter_map(|f| f.path.clone())
+            .collect()
     });
+    if dropped.is_empty() {
+        return;
+    }
+
+    // Expand directories recursively so dropping a folder behaves like
+    // "Add Folder (with subfolders)". `add_files` itself only keeps regular
+    // files, so directories would silently disappear without this.
+    let mut paths = Vec::new();
+    for path in dropped {
+        if path.is_dir() {
+            if let Ok(found) = mp3rgain::collect_audio_files(&path, true) {
+                paths.extend(found);
+            }
+        } else {
+            paths.push(path);
+        }
+    }
+    app.add_files(paths);
 }
 
 fn render_central_panel(app: &mut Mp3rgainApp, ctx: &egui::Context) {

--- a/mp3rgui/src/ui/options.rs
+++ b/mp3rgui/src/ui/options.rs
@@ -1,0 +1,41 @@
+use crate::app::Mp3rgainApp;
+
+/// Apply-options checkbox row, shown right below the toolbar.
+///
+/// All four toggles are disabled while a worker is running so a
+/// half-applied batch can't see its settings change mid-flight.
+pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
+    egui::TopBottomPanel::top("options_panel").show(ctx, |ui| {
+        ui.add_enabled_ui(!app.is_processing, |ui| {
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Options:");
+
+                ui.checkbox(&mut app.apply_options.prevent_clipping, "Prevent clipping")
+                    .on_hover_text(
+                        "Cap the applied gain at the available headroom so the \
+                         output cannot clip. Equivalent to the CLI's -k flag.",
+                    );
+
+                ui.checkbox(&mut app.apply_options.preserve_timestamp, "Preserve mtime")
+                    .on_hover_text(
+                        "Restore the file's last-modified timestamp after writing \
+                         so it doesn't jump to the top of playlists sorted by date. \
+                         CLI -p.",
+                    );
+
+                ui.checkbox(&mut app.apply_options.wrap, "Wrap mode")
+                    .on_hover_text(
+                        "Allow gain values to wrap around 0–255 instead of saturating. \
+                         Disables the clipping check. CLI -w. Rarely useful — leave off.",
+                    );
+
+                ui.checkbox(&mut app.apply_options.use_id3v2, "Use ID3v2 (MP3)")
+                    .on_hover_text(
+                        "MP3 only: store undo + ReplayGain tags in ID3v2 TXXX frames \
+                         instead of APE. Required for foobar2000 / Winamp / Rockbox \
+                         to see ReplayGain values on MP3. CLI -s i.",
+                    );
+            });
+        });
+    });
+}

--- a/mp3rgui/src/ui/toolbar.rs
+++ b/mp3rgui/src/ui/toolbar.rs
@@ -6,31 +6,32 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
             ui.spacing_mut().button_padding = egui::vec2(8.0, 4.0);
 
             // Add Files button
-            if ui.button("Add Files").clicked() {
-                if let Some(paths) = rfd::FileDialog::new()
-                    .add_filter("Audio files", &["mp3", "m4a", "aac"])
-                    .pick_files()
-                {
-                    app.add_files(paths);
+            ui.add_enabled_ui(!app.is_processing, |ui| {
+                if ui.button("Add Files").clicked() {
+                    if let Some(paths) = rfd::FileDialog::new()
+                        .add_filter("Audio files", &["mp3", "m4a", "aac"])
+                        .pick_files()
+                    {
+                        app.add_files(paths);
+                    }
                 }
-            }
 
-            // Add Folder button
-            if ui.button("Add Folder").clicked() {
-                if let Some(folder) = rfd::FileDialog::new().pick_folder() {
-                    app.add_folder(folder, true);
+                if ui.button("Add Folder").clicked() {
+                    if let Some(folder) = rfd::FileDialog::new().pick_folder() {
+                        app.add_folder(folder, true);
+                    }
                 }
-            }
+            });
 
             ui.separator();
 
             // Analysis buttons
             ui.add_enabled_ui(!app.files.is_empty() && !app.is_processing, |ui| {
                 if ui.button("Track Analysis").clicked() {
-                    app.analyze_tracks();
+                    app.start_analyze_tracks(ctx);
                 }
                 if ui.button("Album Analysis").clicked() {
-                    app.analyze_album();
+                    app.start_analyze_album(ctx);
                 }
             });
 
@@ -39,10 +40,10 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
             // Gain buttons
             ui.add_enabled_ui(!app.files.is_empty() && !app.is_processing, |ui| {
                 if ui.button("Track Gain").clicked() {
-                    app.apply_track_gain();
+                    app.start_apply_track_gain(ctx);
                 }
                 if ui.button("Album Gain").clicked() {
-                    app.apply_album_gain();
+                    app.start_apply_album_gain(ctx);
                 }
             });
 
@@ -66,9 +67,19 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
 
             ui.separator();
 
+            // Cancel — only enabled while a worker is running.
+            ui.add_enabled_ui(app.is_processing, |ui| {
+                if ui.button("Cancel").clicked() {
+                    app.cancel_current_work();
+                }
+            });
+
+            ui.separator();
+
             // Target volume
             ui.label("Target:");
-            ui.add(
+            ui.add_enabled(
+                !app.is_processing,
                 egui::DragValue::new(&mut app.target_volume)
                     .speed(0.1)
                     .range(75.0..=100.0)

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -80,6 +80,31 @@ pub struct ApplyJob {
     pub album_info: Option<AacAlbumInfo>,
 }
 
+/// User-facing apply toggles, captured at the moment the worker is
+/// spawned. Worker combines these with the per-job data to build the
+/// final `ApplyOptions`.
+#[derive(Debug, Clone, Copy)]
+pub struct ApplyOptionsUi {
+    pub prevent_clipping: bool,
+    pub wrap: bool,
+    pub preserve_timestamp: bool,
+    pub use_id3v2: bool,
+}
+
+impl Default for ApplyOptionsUi {
+    fn default() -> Self {
+        // Safe defaults: prevent clipping, keep mtime, no wrap, no
+        // ID3v2-on-MP3 (the existing APE undo path is still the more
+        // widely compatible option).
+        Self {
+            prevent_clipping: true,
+            wrap: false,
+            preserve_timestamp: true,
+            use_id3v2: false,
+        }
+    }
+}
+
 /// Spawn a serial track-analysis worker.
 ///
 /// Files are processed in order; cancel is checked between files.
@@ -241,6 +266,7 @@ pub fn spawn_apply(
     ctx: egui::Context,
     jobs: Vec<ApplyJob>,
     action_label: &'static str,
+    ui_opts: ApplyOptionsUi,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
@@ -257,7 +283,7 @@ pub fn spawn_apply(
             }
             send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-            let opts = build_apply_options(job.steps, job.track_result, job.album_info);
+            let opts = build_apply_options(job.steps, job.track_result, job.album_info, ui_opts);
             match apply_with_options(&job.path, &opts) {
                 Ok(_) => {
                     applied += 1;
@@ -294,19 +320,27 @@ pub fn spawn_apply(
     WorkerHandle { rx, cancel }
 }
 
-/// GUI defaults: undo + RG tags + atomic temp file + mtime preserve.
+/// Build the final `ApplyOptions` by combining always-on safety rails
+/// (undo, RG tag write, atomic temp file) with the user-toggleable
+/// flags from the Options panel.
 fn build_apply_options(
     steps: i32,
     track_result: Option<ReplayGainResult>,
     album_info: Option<AacAlbumInfo>,
+    ui_opts: ApplyOptionsUi,
 ) -> ApplyOptions {
     let mut opts = ApplyOptions::new(steps);
     opts.track_result = track_result;
     opts.album_info = album_info;
+    // Always-on safety rails.
     opts.write_undo = true;
     opts.write_replaygain_tags = true;
     opts.use_temp_file = true;
-    opts.preserve_timestamp = true;
+    // User-toggleable.
+    opts.prevent_clipping = ui_opts.prevent_clipping;
+    opts.wrap = ui_opts.wrap;
+    opts.preserve_timestamp = ui_opts.preserve_timestamp;
+    opts.use_id3v2 = ui_opts.use_id3v2;
     opts
 }
 

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -1,0 +1,324 @@
+//! Background workers for the four batch operations (analyze tracks,
+//! analyze album, apply track gain, apply album gain).
+//!
+//! The pre-#152 GUI ran these synchronously on the egui main thread, so
+//! the window froze and `total_progress` / `status_message` mutations
+//! were invisible until the loop finished. Workers now run on
+//! `std::thread::spawn`-ed threads and report progress through an
+//! `mpsc::channel`; the UI side drains it from `update()` and calls
+//! `ctx.request_repaint()` so egui actually redraws.
+
+use mp3rgain::apply::{apply_with_options, ApplyOptions};
+use mp3rgain::replaygain::{self, ReplayGainResult};
+use mp3rgain::AacAlbumInfo;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
+use std::thread;
+
+/// One message from a worker thread to the UI thread.
+pub enum WorkerEvent {
+    /// Worker is about to process `idx`. UI shows "Analyzing..." /
+    /// "Applying..." for that row.
+    FileStart {
+        idx: usize,
+    },
+
+    TrackAnalyzed {
+        idx: usize,
+        result: ReplayGainResult,
+    },
+    TrackAnalysisFailed {
+        idx: usize,
+        message: String,
+    },
+
+    /// Album analysis result, applied to many rows at once.
+    AlbumAnalysisDone {
+        successful: Vec<(usize, ReplayGainResult)>,
+        failures: Vec<(usize, String)>,
+        album_info: AacAlbumInfo,
+    },
+    AlbumAnalysisFailed(String),
+
+    FileApplied {
+        idx: usize,
+    },
+    FileApplyFailed {
+        idx: usize,
+        message: String,
+    },
+
+    /// Worker observed the cancel flag and stopped early.
+    Cancelled,
+
+    /// Final event. UI clears `is_processing` and sets `status_message`.
+    Done {
+        message: String,
+    },
+}
+
+/// UI-side handle to a running worker.
+pub struct WorkerHandle {
+    pub rx: Receiver<WorkerEvent>,
+    pub cancel: Arc<AtomicBool>,
+}
+
+impl WorkerHandle {
+    pub fn request_cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+/// A single apply job. Built by the UI side, consumed by the worker.
+pub struct ApplyJob {
+    pub idx: usize,
+    pub path: PathBuf,
+    pub steps: i32,
+    pub track_result: Option<ReplayGainResult>,
+    pub album_info: Option<AacAlbumInfo>,
+}
+
+/// Spawn a serial track-analysis worker.
+///
+/// Files are processed in order; cancel is checked between files.
+pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let mut analyzed = 0usize;
+        let mut errors = 0usize;
+
+        for (idx, path) in files {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx });
+
+            match replaygain::analyze_track(&path) {
+                Ok(result) => {
+                    analyzed += 1;
+                    send(&tx, &ctx, WorkerEvent::TrackAnalyzed { idx, result });
+                }
+                Err(e) => {
+                    errors += 1;
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::TrackAnalysisFailed {
+                            idx,
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: format_result_message("Analyzed", analyzed, errors),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+/// Spawn the album-analysis worker. Uses the parallel variant from the
+/// library (auto thread count) and reports per-file completion via the
+/// `on_complete` callback.
+pub fn spawn_album_analysis(
+    ctx: egui::Context,
+    indexed_paths: Vec<(usize, PathBuf)>,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let paths: Vec<PathBuf> = indexed_paths.iter().map(|(_, p)| p.clone()).collect();
+        let original_indices: Vec<usize> = indexed_paths.iter().map(|(i, _)| *i).collect();
+
+        let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+        let threads = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+
+        let tx_cb = tx.clone();
+        let ctx_cb = ctx.clone();
+        let indices_cb = original_indices.clone();
+        let cancel_cb = Arc::clone(&cancel_w);
+        let on_complete = move |idx_in_paths: usize, _path: &Path| {
+            // Cancellation is best-effort: parallel analysis can't be
+            // interrupted mid-file, but we can suppress further repaints
+            // and final events.
+            if cancel_cb.load(Ordering::Relaxed) {
+                return;
+            }
+            if let Some(&original_idx) = indices_cb.get(idx_in_paths) {
+                let _ = tx_cb.send(WorkerEvent::FileStart { idx: original_idx });
+                ctx_cb.request_repaint();
+            }
+        };
+
+        let result = replaygain::analyze_album_lenient_parallel_with_completion(
+            &path_refs,
+            None,
+            threads,
+            &on_complete,
+        );
+
+        if cancel_w.load(Ordering::Relaxed) {
+            send(&tx, &ctx, WorkerEvent::Cancelled);
+            return;
+        }
+
+        match result {
+            Ok(report) => {
+                let successful: Vec<(usize, ReplayGainResult)> = report
+                    .successful_indices
+                    .iter()
+                    .zip(report.album.tracks().iter())
+                    .map(|(&pos, track)| (original_indices[pos], track.clone()))
+                    .collect();
+                let failures: Vec<(usize, String)> = report
+                    .failures
+                    .iter()
+                    .map(|(pos, msg)| (original_indices[*pos], msg.clone()))
+                    .collect();
+                let album_info = AacAlbumInfo {
+                    album_gain_db: report.album.album_gain_db(),
+                    album_peak: report.album.album_peak(),
+                };
+                let analyzed = successful.len();
+                let skipped = failures.len();
+
+                send(
+                    &tx,
+                    &ctx,
+                    WorkerEvent::AlbumAnalysisDone {
+                        successful,
+                        failures,
+                        album_info,
+                    },
+                );
+
+                let message = if skipped > 0 {
+                    format!(
+                        "Album analysis complete ({} tracks, {} skipped)",
+                        analyzed, skipped
+                    )
+                } else {
+                    format!("Album analysis complete ({} tracks)", analyzed)
+                };
+                send(&tx, &ctx, WorkerEvent::Done { message });
+            }
+            Err(e) => {
+                send(&tx, &ctx, WorkerEvent::AlbumAnalysisFailed(e.to_string()));
+                send(
+                    &tx,
+                    &ctx,
+                    WorkerEvent::Done {
+                        message: format!("Album analysis failed: {}", e),
+                    },
+                );
+            }
+        }
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+/// Spawn the apply worker (used by both Track Gain and Album Gain). Each
+/// job is processed in turn; the cancel flag is checked between files.
+pub fn spawn_apply(
+    ctx: egui::Context,
+    jobs: Vec<ApplyJob>,
+    action_label: &'static str,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let mut applied = 0usize;
+        let mut errors = 0usize;
+
+        for job in jobs {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+
+            let opts = build_apply_options(job.steps, job.track_result, job.album_info);
+            match apply_with_options(&job.path, &opts) {
+                Ok(_) => {
+                    applied += 1;
+                    send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                }
+                Err(e) => {
+                    errors += 1;
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::FileApplyFailed {
+                            idx: job.idx,
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
+        let suffix = if errors > 0 {
+            format!(", {} error(s)", errors)
+        } else {
+            String::new()
+        };
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: format!("Applied {} to {} file(s){}", action_label, applied, suffix),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+/// GUI defaults: undo + RG tags + atomic temp file + mtime preserve.
+fn build_apply_options(
+    steps: i32,
+    track_result: Option<ReplayGainResult>,
+    album_info: Option<AacAlbumInfo>,
+) -> ApplyOptions {
+    let mut opts = ApplyOptions::new(steps);
+    opts.track_result = track_result;
+    opts.album_info = album_info;
+    opts.write_undo = true;
+    opts.write_replaygain_tags = true;
+    opts.use_temp_file = true;
+    opts.preserve_timestamp = true;
+    opts
+}
+
+fn send(tx: &Sender<WorkerEvent>, ctx: &egui::Context, event: WorkerEvent) {
+    let _ = tx.send(event);
+    ctx.request_repaint();
+}
+
+fn format_result_message(action: &str, count: usize, errors: usize) -> String {
+    if errors > 0 {
+        format!("{} {} file(s), {} error(s)", action, count, errors)
+    } else {
+        format!("{} {} file(s)", action, count)
+    }
+}

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,403 @@
+//! Unified apply-gain pipeline shared between the CLI and GUI frontends.
+//!
+//! Both `mp3rgain` (CLI) and `mp3rgui` (GUI) drive the same per-file
+//! work — clipping check, atomic temp-file write, undo & ReplayGain tag
+//! writing, mtime restoration — by populating an [`ApplyOptions`] and
+//! calling [`apply_with_options`].
+//!
+//! Frontend-specific concerns (output formatting, progress reporting,
+//! interactive cancellation, dry-run early-return) stay on the caller
+//! side; this module only does the file work.
+//!
+//! Lifted out of `src/processors/{apply,replaygain}.rs` for issue #153
+//! so the GUI no longer has to compose behavior out of low-level
+//! primitives and silently miss undo / ReplayGain tags (issue #149/#150
+//! / #151).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+#[cfg(feature = "aac")]
+use crate::aac;
+use crate::error::{Error, Result};
+use crate::gain::{db_to_steps, peak_to_headroom_db, steps_to_db, GainOptions, MAX_GAIN};
+use crate::replaygain::ReplayGainResult;
+use crate::{ape, id3v2, mp4meta};
+
+/// Per-process counter for `.mp3rgain_temp_*` filenames so parallel
+/// apply tasks operating on files in the same directory don't collide.
+/// Lifted from `src/processors/utils.rs`.
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Album-level ReplayGain info passed alongside per-track results.
+///
+/// Used to populate the album fields of the ReplayGain tags
+/// (`replaygain_album_gain` / `replaygain_album_peak`) when
+/// [`ApplyOptions::write_replaygain_tags`] is on.
+#[derive(Debug, Clone, Copy)]
+pub struct AacAlbumInfo {
+    pub album_gain_db: f64,
+    pub album_peak: f64,
+}
+
+/// Driver configuration for [`apply_with_options`].
+///
+/// Construct via [`ApplyOptions::new`] and tweak fields directly — this
+/// struct is data-only, no builder methods.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ApplyOptions {
+    /// Requested gain in MP3 gain steps (1 step = 1.5 dB).
+    pub steps: i32,
+
+    /// Per-track ReplayGain analysis. Provides `peak()` for the
+    /// ReplayGain-based clipping check and `gain_db()` / `peak()` for
+    /// ReplayGain tag writing.
+    pub track_result: Option<ReplayGainResult>,
+
+    /// Album-level info that feeds the album fields of the ReplayGain
+    /// tags.
+    pub album_info: Option<AacAlbumInfo>,
+
+    /// `-k`: if the requested gain would clip, cap it at the available
+    /// headroom instead of applying as-is.
+    pub prevent_clipping: bool,
+
+    /// `-w`: wrap around 0–255 instead of saturating. Also disables the
+    /// clipping check (wrap mode is intentionally lossy).
+    pub wrap: bool,
+
+    /// `-p`: restore the file's mtime after writing.
+    pub preserve_timestamp: bool,
+
+    /// `-t`: write through a sibling temp file and rename atomically.
+    pub use_temp_file: bool,
+
+    /// Record an undo tag (APE for MP3, MP4 freeform for AAC, ID3v2 TXXX
+    /// when [`Self::use_id3v2`] is on).
+    pub write_undo: bool,
+
+    /// Write ReplayGain metadata tags. Requires [`Self::track_result`] to
+    /// be set. AAC writes to mp4 freeform metadata; MP3 only writes when
+    /// [`Self::use_id3v2`] is also on (there is no APE-based ReplayGain
+    /// tag in this codebase).
+    pub write_replaygain_tags: bool,
+
+    /// `-s i`: MP3 only — use ID3v2 TXXX frames for undo and ReplayGain
+    /// instead of APE.
+    pub use_id3v2: bool,
+}
+
+impl ApplyOptions {
+    /// Construct with a requested step count and "safe" defaults
+    /// (undo on, no temp file, no clipping prevention, no tag writing).
+    pub fn new(steps: i32) -> Self {
+        Self {
+            steps,
+            track_result: None,
+            album_info: None,
+            prevent_clipping: false,
+            wrap: false,
+            preserve_timestamp: false,
+            use_temp_file: false,
+            write_undo: true,
+            write_replaygain_tags: false,
+            use_id3v2: false,
+        }
+    }
+}
+
+/// Outcome of an [`apply_with_options`] call.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ApplyReport {
+    /// MP3 frames or AAC gain fields actually modified.
+    pub modified: usize,
+
+    /// Steps actually applied (= [`ApplyOptions::steps`] unless
+    /// [`ApplyOptions::prevent_clipping`] capped it, or unless steps==0).
+    pub actual_steps: i32,
+
+    /// True when `actual_steps < requested_steps` due to clipping
+    /// prevention.
+    pub clipping_prevented: bool,
+
+    /// Clipping diagnostic the caller can format into a warning when
+    /// `prevent_clipping` is off. `None` if no check ran (steps<=0 or
+    /// wrap mode).
+    pub clipping_detected: Option<ClippingDetection>,
+}
+
+/// Per-strategy clipping signal.
+#[derive(Debug, Clone, Copy)]
+pub enum ClippingDetection {
+    /// `analyze()`-based: file's available headroom in gain steps.
+    Headroom(i32),
+    /// ReplayGain-based: peak that would result from the requested gain.
+    Peak(f64),
+}
+
+/// Apply gain to `file_path` according to `opts`.
+///
+/// Does, in order:
+/// 1. Optional clipping check (headroom-based for `-g`/`-l`, peak-based
+///    when [`ApplyOptions::track_result`] is set).
+/// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, with optional temp
+///    file + atomic rename.
+/// 3. ID3v2 undo tag write (MP3 + [`ApplyOptions::use_id3v2`]).
+/// 4. ReplayGain tag write (AAC, or MP3 + [`ApplyOptions::use_id3v2`]).
+/// 5. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
+pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
+    let is_aac = mp4meta::is_aac_file(file_path);
+
+    let original_mtime = if opts.preserve_timestamp {
+        std::fs::metadata(file_path)
+            .ok()
+            .and_then(|m| m.modified().ok())
+    } else {
+        None
+    };
+
+    // 1) Clipping check + cap.
+    //
+    // The MP3 branch caches its `analyze(file)` result so the ID3v2
+    // undo write below can reuse it instead of a second file scan
+    // (issue #135).
+    let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
+    let (actual_steps, clipping_prevented, clipping_detected) =
+        check_clipping(file_path, opts, is_aac, &mut mp3_analysis)?;
+
+    // 2) Apply gain to bytes.
+    let modified = if is_aac {
+        apply_aac_bytes(file_path, actual_steps, opts)?
+    } else if opts.use_id3v2 {
+        apply_mp3_id3v2_bytes(file_path, actual_steps, opts, &mut mp3_analysis)?
+    } else {
+        apply_mp3_ape_bytes(file_path, actual_steps, opts)?
+    };
+
+    // 3) ReplayGain tag write.
+    //
+    // AAC writes always (caller gates with `write_replaygain_tags`).
+    // MP3 only writes when also using ID3v2 — there is no APE-based RG
+    // path in this codebase.
+    if opts.write_replaygain_tags {
+        if let Some(track) = opts.track_result.as_ref() {
+            if is_aac {
+                let mut tags = mp4meta::ReplayGainTags::default();
+                tags.set_track(track.gain_db(), track.peak());
+                if let Some(album) = opts.album_info {
+                    tags.set_album(album.album_gain_db, album.album_peak);
+                }
+                mp4meta::write_replaygain_tags(file_path, &tags)?;
+            } else if opts.use_id3v2 {
+                let rg = id3v2::Id3v2ReplayGain {
+                    track_gain: Some(format!("{:+.2} dB", track.gain_db())),
+                    track_peak: Some(format!("{:.6}", track.peak())),
+                    album_gain: opts
+                        .album_info
+                        .map(|a| format!("{:+.2} dB", a.album_gain_db)),
+                    album_peak: opts.album_info.map(|a| format!("{:.6}", a.album_peak)),
+                    ..Default::default()
+                };
+                id3v2::write_id3v2_replaygain(file_path, &rg)?;
+            }
+        }
+    }
+
+    // 4) Restore mtime.
+    if let Some(mtime) = original_mtime {
+        restore_timestamp(file_path, mtime);
+    }
+
+    Ok(ApplyReport {
+        modified,
+        actual_steps,
+        clipping_prevented,
+        clipping_detected,
+    })
+}
+
+fn check_clipping(
+    file_path: &Path,
+    opts: &ApplyOptions,
+    is_aac: bool,
+    mp3_analysis: &mut Option<crate::Mp3Analysis>,
+) -> Result<(i32, bool, Option<ClippingDetection>)> {
+    let steps = opts.steps;
+    if steps <= 0 || opts.wrap {
+        return Ok((steps, false, None));
+    }
+
+    // ReplayGain-peak branch.
+    if let Some(track) = opts.track_result.as_ref() {
+        let gain_linear = 10.0_f64.powf(steps_to_db(steps) / 20.0);
+        let new_peak = track.peak() * gain_linear;
+        if new_peak > 1.0 {
+            if opts.prevent_clipping {
+                // `new_peak > 1.0` implies `peak > 0`, so headroom is
+                // well-defined here.
+                let max_safe_db = peak_to_headroom_db(track.peak()).unwrap_or(0.0);
+                let max_safe_steps = db_to_steps(max_safe_db).max(0);
+                return Ok((
+                    max_safe_steps,
+                    true,
+                    Some(ClippingDetection::Peak(new_peak)),
+                ));
+            }
+            return Ok((steps, false, Some(ClippingDetection::Peak(new_peak))));
+        }
+        return Ok((steps, false, None));
+    }
+
+    // Headroom-based branch (no ReplayGain analysis available).
+    let headroom = if is_aac {
+        #[cfg(feature = "aac")]
+        {
+            aac::analyze_aac_gains(file_path)
+                .ok()
+                .map(|a| (MAX_GAIN as i32).saturating_sub(a.max_gain() as i32))
+        }
+        #[cfg(not(feature = "aac"))]
+        {
+            let _ = file_path;
+            None
+        }
+    } else {
+        let info = crate::analyze(file_path).ok();
+        let headroom = info.as_ref().map(|i| i.headroom_steps());
+        *mp3_analysis = info;
+        headroom
+    };
+
+    if let Some(h) = headroom {
+        if steps > h {
+            if opts.prevent_clipping {
+                return Ok((h, true, Some(ClippingDetection::Headroom(h))));
+            }
+            return Ok((steps, false, Some(ClippingDetection::Headroom(h))));
+        }
+    }
+
+    Ok((steps, false, None))
+}
+
+#[cfg(feature = "aac")]
+fn apply_aac_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Result<usize> {
+    with_temp_file(file_path, opts.use_temp_file, |r, w| {
+        if opts.write_undo {
+            aac::apply_aac_gain_with_undo_to_path(r, w, steps)
+        } else {
+            aac::apply_aac_gain_to_path(r, w, steps)
+        }
+    })
+}
+
+#[cfg(not(feature = "aac"))]
+fn apply_aac_bytes(_file_path: &Path, _steps: i32, _opts: &ApplyOptions) -> Result<usize> {
+    Err(Error::FeatureNotAvailable {
+        feature: "AAC support",
+        feature_flag: "aac",
+    })
+}
+
+fn apply_mp3_ape_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Result<usize> {
+    with_temp_file(file_path, opts.use_temp_file, |r, w| {
+        GainOptions::new(steps)
+            .wrap(opts.wrap)
+            .undo(opts.write_undo)
+            .apply_to_path(r, w)
+    })
+}
+
+fn apply_mp3_id3v2_bytes(
+    file_path: &Path,
+    steps: i32,
+    opts: &ApplyOptions,
+    mp3_analysis: &mut Option<crate::Mp3Analysis>,
+) -> Result<usize> {
+    // Need pre-apply analysis if undo will be written. Reuse the cached
+    // one from the clipping-check pass when available (issue #135).
+    if opts.write_undo && mp3_analysis.is_none() {
+        *mp3_analysis = crate::analyze(file_path).ok();
+    }
+
+    // APE undo is never written in `-s i` mode; the undo goes into a
+    // TXXX:MP3GAIN_UNDO frame instead, written below.
+    let modified = with_temp_file(file_path, opts.use_temp_file, |r, w| {
+        GainOptions::new(steps)
+            .wrap(opts.wrap)
+            .undo(false)
+            .apply_to_path(r, w)
+    })?;
+
+    if opts.write_undo {
+        write_id3v2_undo_after_apply(file_path, steps, steps, opts.wrap, mp3_analysis.as_ref())?;
+    }
+    Ok(modified)
+}
+
+fn with_temp_file<F>(file: &Path, use_temp: bool, operation: F) -> Result<usize>
+where
+    F: FnOnce(&Path, &Path) -> Result<usize>,
+{
+    if !use_temp {
+        return operation(file, file);
+    }
+
+    let parent = file.parent().unwrap_or(Path::new("."));
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let temp_path = parent.join(format!(
+        ".mp3rgain_temp_{}_{}.mp3",
+        std::process::id(),
+        counter
+    ));
+
+    match operation(file, &temp_path) {
+        Ok(frames) => {
+            std::fs::rename(&temp_path, file).map_err(|e| Error::io_write(file, e))?;
+            Ok(frames)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(e)
+        }
+    }
+}
+
+fn restore_timestamp(file: &Path, mtime: SystemTime) {
+    let _ = std::fs::File::options()
+        .write(true)
+        .open(file)
+        .and_then(|f| f.set_times(std::fs::FileTimes::new().set_modified(mtime)));
+}
+
+fn write_id3v2_undo_after_apply(
+    file: &Path,
+    delta_left: i32,
+    delta_right: i32,
+    wrap: bool,
+    analysis: Option<&crate::Mp3Analysis>,
+) -> Result<()> {
+    let existing_rg = id3v2::read_id3v2_replaygain(file).unwrap_or_default();
+    let (existing_left, existing_right) = ape::parse_undo_values(existing_rg.undo.as_deref());
+
+    let owned;
+    let (min, max) = match analysis {
+        Some(a) => (a.min_gain(), a.max_gain()),
+        None => {
+            owned = crate::analyze(file)?;
+            (owned.min_gain(), owned.max_gain())
+        }
+    };
+
+    id3v2::write_id3v2_undo(
+        file,
+        existing_left + delta_left,
+        existing_right + delta_right,
+        wrap,
+        min,
+        max,
+    )
+}

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -20,12 +20,6 @@ pub enum StoredTagMode {
     UseApev2, // -s a: Use APEv2 tags (default)
 }
 
-/// Album gain info for AAC files
-pub struct AacAlbumInfo {
-    pub album_gain_db: f64,
-    pub album_peak: f64,
-}
-
 #[derive(Default)]
 pub struct Options {
     // Gain options

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use colored::*;
 use indicatif::MultiProgress;
 use mp3rgain::replaygain::{self, AlbumAnalysisReport, AlbumGainResult, REPLAYGAIN_REFERENCE_DB};
-use mp3rgain::steps_to_db;
+use mp3rgain::{steps_to_db, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::cli::options::{AacAlbumInfo, Options, OutputFormat};
+use crate::cli::options::{Options, OutputFormat};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ mod aac_codebooks;
 
 pub mod analysis;
 pub mod ape;
+pub mod apply;
 pub mod error;
 mod frame;
 pub mod gain;
@@ -80,6 +81,7 @@ pub use ape::{
     TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN,
     TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
+pub use apply::{apply_with_options, AacAlbumInfo, ApplyOptions, ApplyReport, ClippingDetection};
 pub use error::{Error, Result};
 pub use gain::{
     apply_gain, apply_gain_db, db_to_steps, peak_to_headroom_db, peak_to_pcm_sample, steps_to_db,

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::{aac, analyze, mp4meta, steps_to_db, Channel, GainOptions, Mp3Analysis};
+use mp3rgain::apply::{apply_with_options, ApplyOptions, ClippingDetection};
+use mp3rgain::{analyze, mp4meta, steps_to_db, Channel, GainOptions};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -9,8 +10,7 @@ use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
 use super::utils::{
-    apply_with_temp_file, restore_timestamp, save_original_mtime, warn_aac_multi_track,
-    write_id3v2_undo_after_apply,
+    restore_timestamp, save_original_mtime, warn_aac_multi_track, write_id3v2_undo_after_apply,
 };
 
 pub fn process_apply(file: &Path, steps: i32, opts: &Options) -> Result<(JsonFileResult, String)> {
@@ -28,79 +28,16 @@ fn process_apply_into(
     let filename = get_filename(file);
     let dry_run_prefix = opts.dry_run_prefix();
 
-    let original_mtime = save_original_mtime(file, opts);
-
     let is_aac = mp4meta::is_aac_file(file);
-
     if is_aac {
         warn_aac_multi_track(file, filename, opts, dry_run_prefix);
     }
 
-    // Check for clipping and possibly prevent it
-    let mut actual_steps = steps;
-    let mut warning_msg: Option<String> = None;
-
-    // For MP3, hold onto the pre-apply analysis so the ID3v2 undo write below
-    // can reuse it instead of triggering a second `analyze(file)` on the same
-    // bytes (issue #135).
-    let mut mp3_analysis: Option<Mp3Analysis> = None;
-
-    if steps > 0 && !opts.wrap_gain {
-        let headroom = if is_aac {
-            aac::analyze_aac_gains(file)
-                .ok()
-                .map(|a| (255u8.saturating_sub(a.max_gain())) as i32)
-        } else {
-            let info = analyze(file).ok();
-            let headroom = info.as_ref().map(|i| i.headroom_steps());
-            mp3_analysis = info;
-            headroom
-        };
-
-        if let Some(headroom_steps) = headroom {
-            if steps > headroom_steps {
-                if opts.prevent_clipping {
-                    let original_steps = steps;
-                    actual_steps = headroom_steps;
-                    if opts.output_format == OutputFormat::Text && !opts.quiet {
-                        eprintln!(
-                            "  {} {}{} - gain reduced from {} to {} steps to prevent clipping",
-                            "!".yellow(),
-                            dry_run_prefix,
-                            filename,
-                            original_steps,
-                            actual_steps
-                        );
-                    }
-                    warning_msg = Some(format!(
-                        "gain reduced from {} to {} steps to prevent clipping",
-                        original_steps, actual_steps
-                    ));
-                } else if !opts.ignore_clipping && !opts.quiet {
-                    if opts.output_format == OutputFormat::Text {
-                        eprintln!(
-                            "  {} {}{} - clipping warning: requested {} steps but only {} headroom",
-                            "!".yellow(),
-                            dry_run_prefix,
-                            filename,
-                            steps,
-                            headroom_steps
-                        );
-                        eprintln!(
-                            "      Use -c to ignore clipping warnings or -k to prevent clipping"
-                        );
-                    }
-                    warning_msg = Some(format!(
-                        "clipping warning: requested {} steps but only {} headroom",
-                        steps, headroom_steps
-                    ));
-                }
-            }
-        }
-    }
-
-    // Dry run: don't actually modify
+    // Dry run: don't touch the file. Headroom-based clipping prevention
+    // still needs to be reflected in the "would apply N steps" line.
     if opts.dry_run {
+        let (actual_steps, warning_msg) =
+            dry_run_clipping_summary(file, steps, opts, is_aac, dry_run_prefix, filename);
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
                 out,
@@ -121,68 +58,18 @@ fn process_apply_into(
         });
     }
 
-    // Apply gain
-    let apply_result = if is_aac {
-        if opts.stored_tag_mode == StoredTagMode::Skip {
-            apply_with_temp_file(
-                file,
-                |r, w| Ok(aac::apply_aac_gain_to_path(r, w, actual_steps)?),
-                opts,
-            )
-        } else {
-            apply_with_temp_file(
-                file,
-                |r, w| Ok(aac::apply_aac_gain_with_undo_to_path(r, w, actual_steps)?),
-                opts,
-            )
-        }
-    } else if opts.use_id3v2 {
-        // MP3 with -s i: apply gain without APE undo, write undo to ID3v2
-        let skip_undo = opts.stored_tag_mode == StoredTagMode::Skip;
-        // Materialize analysis lazily so unwrap-mode skip path stays free.
-        if !skip_undo && mp3_analysis.is_none() {
-            mp3_analysis = analyze(file).ok();
-        }
-        let result = apply_with_temp_file(
-            file,
-            |r, w| {
-                Ok(GainOptions::new(actual_steps)
-                    .wrap(opts.wrap_gain)
-                    .undo(false)
-                    .apply_to_path(r, w)?)
-            },
-            opts,
-        );
-        if !skip_undo && result.is_ok() {
-            write_id3v2_undo_after_apply(
-                file,
-                actual_steps,
-                actual_steps,
-                opts.wrap_gain,
-                mp3_analysis.as_ref(),
-            )?;
-        }
-        result
-    } else {
-        let use_undo = opts.stored_tag_mode != StoredTagMode::Skip;
-        apply_with_temp_file(
-            file,
-            |r, w| {
-                Ok(GainOptions::new(actual_steps)
-                    .wrap(opts.wrap_gain)
-                    .undo(use_undo)
-                    .apply_to_path(r, w)?)
-            },
-            opts,
-        )
-    };
+    let mut apply_opts = ApplyOptions::new(steps);
+    apply_opts.prevent_clipping = opts.prevent_clipping;
+    apply_opts.wrap = opts.wrap_gain;
+    apply_opts.preserve_timestamp = opts.preserve_timestamp;
+    apply_opts.use_temp_file = opts.use_temp_file;
+    apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
+    apply_opts.use_id3v2 = opts.use_id3v2;
 
-    match apply_result {
-        Ok(modified) => {
-            // Restore timestamp if needed
-            if let Some(mtime) = original_mtime {
-                restore_timestamp(file, mtime);
-            }
+    match apply_with_options(file, &apply_opts) {
+        Ok(report) => {
+            let warning_msg =
+                emit_clipping_warning_headroom(steps, &report, opts, dry_run_prefix, filename);
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 if is_aac {
@@ -191,19 +78,25 @@ fn process_apply_into(
                         "  {} {} ({} gains modified)",
                         "v".green(),
                         filename,
-                        modified
+                        report.modified
                     )?;
                 } else {
-                    writeln!(out, "  {} {} ({} frames)", "v".green(), filename, modified)?;
+                    writeln!(
+                        out,
+                        "  {} {} ({} frames)",
+                        "v".green(),
+                        filename,
+                        report.modified
+                    )?;
                 }
             }
 
             Ok(JsonFileResult {
                 file: file.display().to_string(),
                 status: Some(FileStatus::Success),
-                frames: Some(modified),
-                gain_applied_steps: Some(actual_steps),
-                gain_applied_db: Some(steps_to_db(actual_steps)),
+                frames: Some(report.modified),
+                gain_applied_steps: Some(report.actual_steps),
+                gain_applied_db: Some(steps_to_db(report.actual_steps)),
                 warning: warning_msg,
                 ..Default::default()
             })
@@ -221,6 +114,133 @@ fn process_apply_into(
             })
         }
     }
+}
+
+/// Recompute the headroom-based clipping cap purely for the dry-run
+/// branch. Mirrors [`mp3rgain::apply::apply_with_options`]'s check.
+fn dry_run_clipping_summary(
+    file: &Path,
+    steps: i32,
+    opts: &Options,
+    is_aac: bool,
+    dry_run_prefix: &str,
+    filename: &str,
+) -> (i32, Option<String>) {
+    if steps <= 0 || opts.wrap_gain {
+        return (steps, None);
+    }
+
+    let headroom = if is_aac {
+        #[cfg(feature = "aac")]
+        {
+            mp3rgain::aac::analyze_aac_gains(file)
+                .ok()
+                .map(|a| 255u8.saturating_sub(a.max_gain()) as i32)
+        }
+        #[cfg(not(feature = "aac"))]
+        {
+            let _ = file;
+            None
+        }
+    } else {
+        analyze(file).ok().map(|i| i.headroom_steps())
+    };
+
+    let Some(headroom_steps) = headroom else {
+        return (steps, None);
+    };
+    if steps <= headroom_steps {
+        return (steps, None);
+    }
+    if opts.prevent_clipping {
+        let actual = headroom_steps;
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            eprintln!(
+                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                steps,
+                actual
+            );
+        }
+        return (
+            actual,
+            Some(format!(
+                "gain reduced from {} to {} steps to prevent clipping",
+                steps, actual
+            )),
+        );
+    }
+    if !opts.ignore_clipping && !opts.quiet {
+        if opts.output_format == OutputFormat::Text {
+            eprintln!(
+                "  {} {}{} - clipping warning: requested {} steps but only {} headroom",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                steps,
+                headroom_steps
+            );
+            eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
+        }
+        return (
+            steps,
+            Some(format!(
+                "clipping warning: requested {} steps but only {} headroom",
+                steps, headroom_steps
+            )),
+        );
+    }
+    (steps, None)
+}
+
+/// Render the user-visible clipping warning after a real apply, using the
+/// headroom diagnostic from [`ApplyReport`].
+fn emit_clipping_warning_headroom(
+    requested_steps: i32,
+    report: &mp3rgain::ApplyReport,
+    opts: &Options,
+    dry_run_prefix: &str,
+    filename: &str,
+) -> Option<String> {
+    let Some(ClippingDetection::Headroom(headroom_steps)) = report.clipping_detected else {
+        return None;
+    };
+    if report.clipping_prevented {
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            eprintln!(
+                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                requested_steps,
+                report.actual_steps
+            );
+        }
+        return Some(format!(
+            "gain reduced from {} to {} steps to prevent clipping",
+            requested_steps, report.actual_steps
+        ));
+    }
+    if opts.ignore_clipping || opts.quiet {
+        return None;
+    }
+    if opts.output_format == OutputFormat::Text {
+        eprintln!(
+            "  {} {}{} - clipping warning: requested {} steps but only {} headroom",
+            "!".yellow(),
+            dry_run_prefix,
+            filename,
+            requested_steps,
+            headroom_steps
+        );
+        eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
+    }
+    Some(format!(
+        "clipping warning: requested {} steps but only {} headroom",
+        requested_steps, headroom_steps
+    ))
 }
 
 pub fn process_apply_channel(

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -1,20 +1,18 @@
 use anyhow::Result;
 use colored::*;
 use indicatif::ProgressBar;
+use mp3rgain::apply::{apply_with_options, ApplyOptions, ClippingDetection};
 use mp3rgain::replaygain::{self, AudioFileType, ReplayGainResult};
-use mp3rgain::{aac, db_to_steps, id3v2, mp4meta, peak_to_headroom_db, steps_to_db, GainOptions};
+use mp3rgain::{mp4meta, steps_to_db, AacAlbumInfo};
 use std::fmt::Write as _;
 use std::path::Path;
 
-use crate::cli::options::{AacAlbumInfo, Options, OutputFormat};
+use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::progress::update_analysis_progress;
 use crate::util::get_filename;
 
-use super::utils::{
-    apply_with_temp_file, restore_timestamp, save_original_mtime, warn_aac_multi_track,
-    write_id3v2_undo_after_apply,
-};
+use super::utils::warn_aac_multi_track;
 
 pub fn process_track_gain(
     file: &Path,
@@ -130,63 +128,14 @@ fn apply_replaygain_with_album_into(
 ) -> Result<JsonFileResult> {
     let filename = get_filename(file);
     let dry_run_prefix = opts.dry_run_prefix();
+    let is_aac = result.file_type() == AudioFileType::Aac;
 
-    let original_mtime = save_original_mtime(file, opts);
-
-    let mut actual_steps = steps;
-    let mut warning_msg: Option<String> = None;
-
-    if steps > 0 && !opts.wrap_gain {
-        // Check if applying this gain would cause clipping
-        let gain_linear = 10.0_f64.powf(result.gain_db() / 20.0);
-        let new_peak = result.peak() * gain_linear;
-        if new_peak > 1.0 {
-            if opts.prevent_clipping {
-                // Calculate the maximum safe gain. The outer `new_peak > 1.0`
-                // guard implies peak > 0, so headroom is always defined here.
-                let max_safe_db = peak_to_headroom_db(result.peak()).unwrap_or(0.0);
-                let max_safe_steps = db_to_steps(max_safe_db);
-                actual_steps = max_safe_steps.max(0);
-
-                if opts.output_format == OutputFormat::Text && !opts.quiet {
-                    eprintln!(
-                        "  {} {}{} - gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
-                        "!".yellow(),
-                        dry_run_prefix,
-                        filename,
-                        steps,
-                        actual_steps,
-                        result.peak()
-                    );
-                }
-                warning_msg = Some(format!(
-                    "gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
-                    steps,
-                    actual_steps,
-                    result.peak()
-                ));
-            } else if !opts.ignore_clipping && !opts.quiet {
-                if opts.output_format == OutputFormat::Text {
-                    eprintln!(
-                        "  {} {}{} - clipping warning: peak would be {:.2} (>{:.2})",
-                        "!".yellow(),
-                        dry_run_prefix,
-                        filename,
-                        new_peak,
-                        1.0
-                    );
-                    eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
-                }
-                warning_msg = Some(format!(
-                    "clipping warning: peak would be {:.2} (>1.00)",
-                    new_peak
-                ));
-            }
-        }
-    }
-
-    // Dry run: don't actually modify
+    // Dry run: don't actually modify. Clipping prevention still needs to
+    // be reflected in the "would apply N steps" message, so mirror the
+    // ReplayGain-peak cap here without touching the file.
     if opts.dry_run {
+        let (actual_steps, warning_msg) =
+            dry_run_clipping_summary(steps, result, opts, &dry_run_prefix, filename);
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
                 out,
@@ -210,63 +159,39 @@ fn apply_replaygain_with_album_into(
         });
     }
 
-    // Handle AAC/M4A files differently - only write ReplayGain tags
-    if result.file_type() == AudioFileType::Aac {
-        let ctx = AacApplyContext {
-            warning_msg,
-            original_mtime,
+    // AAC keeps a fail-soft tag-writing path: bitstream gain failures
+    // print a warning but still let us record ReplayGain tags. Branch
+    // before calling into the unified pipeline so we can apply that
+    // policy.
+    if is_aac {
+        return apply_replaygain_aac_with_album_into(
+            file,
+            steps,
+            result,
+            opts,
             album_info,
-        };
-        return apply_replaygain_aac_with_album_into(file, actual_steps, result, opts, ctx, out);
+            &dry_run_prefix,
+            out,
+        );
     }
 
-    // MP3: Apply gain to audio frames
-    let use_id3v2_undo = opts.use_id3v2;
-    // Pre-apply analysis is reused for the ID3v2 undo write below so we don't
-    // re-read the file just to fetch min/max (issue #135).
-    let pre_analysis = if use_id3v2_undo {
-        mp3rgain::analyze(file).ok()
-    } else {
-        None
-    };
-    let apply_result = apply_with_temp_file(
-        file,
-        |r, w| {
-            Ok(GainOptions::new(actual_steps)
-                .wrap(opts.wrap_gain)
-                .undo(!use_id3v2_undo) // APE undo only when not using ID3v2
-                .apply_to_path(r, w)?)
-        },
-        opts,
-    );
+    // MP3 path: hand the whole pipeline to apply_with_options.
+    let mut apply_opts = ApplyOptions::new(steps);
+    apply_opts.track_result = Some(result.clone());
+    apply_opts.album_info = album_info.copied();
+    apply_opts.prevent_clipping = opts.prevent_clipping;
+    apply_opts.wrap = opts.wrap_gain;
+    apply_opts.preserve_timestamp = opts.preserve_timestamp;
+    apply_opts.use_temp_file = opts.use_temp_file;
+    // RG path writes undo unless -s s.
+    apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
+    apply_opts.write_replaygain_tags = opts.use_id3v2;
+    apply_opts.use_id3v2 = opts.use_id3v2;
 
-    match apply_result {
-        Ok(frames) => {
-            // Write ID3v2 tags if -s i mode
-            if opts.use_id3v2 {
-                write_id3v2_undo_after_apply(
-                    file,
-                    actual_steps,
-                    actual_steps,
-                    opts.wrap_gain,
-                    pre_analysis.as_ref(),
-                )?;
-
-                // Write ReplayGain metadata tags
-                let rg = mp3rgain::Id3v2ReplayGain {
-                    track_gain: Some(format!("{:+.2} dB", result.gain_db())),
-                    track_peak: Some(format!("{:.6}", result.peak())),
-                    album_gain: album_info.map(|a| format!("{:+.2} dB", a.album_gain_db)),
-                    album_peak: album_info.map(|a| format!("{:.6}", a.album_peak)),
-                    ..Default::default()
-                };
-                id3v2::write_id3v2_replaygain(file, &rg)?;
-            }
-
-            // Restore timestamp if needed
-            if let Some(mtime) = original_mtime {
-                restore_timestamp(file, mtime);
-            }
+    match apply_with_options(file, &apply_opts) {
+        Ok(report) => {
+            let warning_msg =
+                emit_clipping_warning_peak(steps, result, &report, opts, &dry_run_prefix, filename);
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(
@@ -274,19 +199,19 @@ fn apply_replaygain_with_album_into(
                     "  {} {} ({} frames, {:+.1} dB)",
                     "v".green(),
                     filename,
-                    frames,
-                    steps_to_db(actual_steps)
+                    report.modified,
+                    steps_to_db(report.actual_steps)
                 )?;
             }
 
             Ok(JsonFileResult {
                 file: file.display().to_string(),
                 status: Some(FileStatus::Success),
-                frames: Some(frames),
+                frames: Some(report.modified),
                 loudness_db: Some(result.loudness_db()),
                 peak: Some(result.peak()),
-                gain_applied_steps: Some(actual_steps),
-                gain_applied_db: Some(steps_to_db(actual_steps)),
+                gain_applied_steps: Some(report.actual_steps),
+                gain_applied_db: Some(steps_to_db(report.actual_steps)),
                 warning: warning_msg,
                 ..Default::default()
             })
@@ -306,66 +231,197 @@ fn apply_replaygain_with_album_into(
     }
 }
 
-struct AacApplyContext<'a> {
-    warning_msg: Option<String>,
-    original_mtime: Option<std::time::SystemTime>,
-    album_info: Option<&'a AacAlbumInfo>,
-}
-
-/// Apply ReplayGain to AAC/M4A files with optional album info
-fn apply_replaygain_aac_with_album_into(
-    file: &Path,
-    actual_steps: i32,
+/// Recompute the ReplayGain-peak clipping cap purely for the dry-run
+/// branch (no file writes). Mirrors [`mp3rgain::apply::apply_with_options`]
+/// for the same inputs so the displayed "would apply N steps" matches what
+/// a real apply would do.
+fn dry_run_clipping_summary(
+    steps: i32,
     result: &ReplayGainResult,
     opts: &Options,
-    ctx: AacApplyContext<'_>,
+    dry_run_prefix: &str,
+    filename: &str,
+) -> (i32, Option<String>) {
+    if steps <= 0 || opts.wrap_gain {
+        return (steps, None);
+    }
+    let gain_linear = 10.0_f64.powf(steps_to_db(steps) / 20.0);
+    let new_peak = result.peak() * gain_linear;
+    if new_peak <= 1.0 {
+        return (steps, None);
+    }
+    if opts.prevent_clipping {
+        let max_safe_db = mp3rgain::peak_to_headroom_db(result.peak()).unwrap_or(0.0);
+        let actual = mp3rgain::db_to_steps(max_safe_db).max(0);
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            eprintln!(
+                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                steps,
+                actual,
+                result.peak()
+            );
+        }
+        return (
+            actual,
+            Some(format!(
+                "gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
+                steps,
+                actual,
+                result.peak()
+            )),
+        );
+    }
+    if !opts.ignore_clipping && !opts.quiet {
+        if opts.output_format == OutputFormat::Text {
+            eprintln!(
+                "  {} {}{} - clipping warning: peak would be {:.2} (>{:.2})",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                new_peak,
+                1.0
+            );
+            eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
+        }
+        return (
+            steps,
+            Some(format!(
+                "clipping warning: peak would be {:.2} (>1.00)",
+                new_peak
+            )),
+        );
+    }
+    (steps, None)
+}
+
+/// Render the user-visible clipping warning after a real apply, using the
+/// ReplayGain-peak diagnostic from [`ApplyReport`].
+fn emit_clipping_warning_peak(
+    requested_steps: i32,
+    result: &ReplayGainResult,
+    report: &mp3rgain::ApplyReport,
+    opts: &Options,
+    dry_run_prefix: &str,
+    filename: &str,
+) -> Option<String> {
+    let Some(ClippingDetection::Peak(new_peak)) = report.clipping_detected else {
+        return None;
+    };
+    if report.clipping_prevented {
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            eprintln!(
+                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                requested_steps,
+                report.actual_steps,
+                result.peak()
+            );
+        }
+        return Some(format!(
+            "gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
+            requested_steps,
+            report.actual_steps,
+            result.peak()
+        ));
+    }
+    if opts.ignore_clipping || opts.quiet {
+        return None;
+    }
+    if opts.output_format == OutputFormat::Text {
+        eprintln!(
+            "  {} {}{} - clipping warning: peak would be {:.2} (>{:.2})",
+            "!".yellow(),
+            dry_run_prefix,
+            filename,
+            new_peak,
+            1.0
+        );
+        eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
+    }
+    Some(format!(
+        "clipping warning: peak would be {:.2} (>1.00)",
+        new_peak
+    ))
+}
+
+/// Apply ReplayGain to AAC/M4A files with optional album info.
+///
+/// Differs from the MP3 path in two ways the unified API can't model
+/// directly:
+///   - bitstream gain failures are logged and swallowed so we still
+///     write the ReplayGain tags (matches pre-issue-#153 behavior),
+///   - tag writing always runs (independent of `--stored-tag-mode`).
+///
+/// We therefore drive the apply step with `write_replaygain_tags=false`
+/// and call `mp4meta::write_replaygain_tags` afterwards directly.
+fn apply_replaygain_aac_with_album_into(
+    file: &Path,
+    requested_steps: i32,
+    result: &ReplayGainResult,
+    opts: &Options,
+    album_info: Option<&AacAlbumInfo>,
+    dry_run_prefix: &str,
     out: &mut String,
 ) -> Result<JsonFileResult> {
-    let AacApplyContext {
-        warning_msg,
-        original_mtime,
-        album_info,
-    } = ctx;
     let filename = get_filename(file);
 
     warn_aac_multi_track(file, filename, opts, "");
 
-    let gain_modified = if actual_steps != 0 {
-        match aac::apply_aac_gain_with_undo(file, actual_steps) {
-            Ok(n) => n,
-            Err(e) => {
-                if opts.output_format == OutputFormat::Text && !opts.quiet {
-                    eprintln!(
-                        "  {} {} - bitstream gain failed: {} (tags still written)",
-                        "!".yellow(),
-                        filename,
-                        e
-                    );
-                }
-                0
+    let mut apply_opts = ApplyOptions::new(requested_steps);
+    apply_opts.track_result = Some(result.clone());
+    apply_opts.album_info = album_info.copied();
+    apply_opts.prevent_clipping = opts.prevent_clipping;
+    apply_opts.wrap = opts.wrap_gain;
+    apply_opts.preserve_timestamp = opts.preserve_timestamp;
+    apply_opts.use_temp_file = opts.use_temp_file;
+    // AAC tag writing is fail-soft, so we drive it ourselves below.
+    apply_opts.write_replaygain_tags = false;
+
+    let mut actual_steps = requested_steps;
+    let mut warning_msg: Option<String> = None;
+    let mut gain_modified: usize = 0;
+
+    // apply_with_options handles temp file, mtime restore, and the
+    // clipping check. We only swallow bitstream errors so we can still
+    // record the ReplayGain tags afterwards.
+    match apply_with_options(file, &apply_opts) {
+        Ok(report) => {
+            actual_steps = report.actual_steps;
+            gain_modified = report.modified;
+            warning_msg = emit_clipping_warning_peak(
+                requested_steps,
+                result,
+                &report,
+                opts,
+                dry_run_prefix,
+                filename,
+            );
+        }
+        Err(e) => {
+            if opts.output_format == OutputFormat::Text && !opts.quiet {
+                eprintln!(
+                    "  {} {} - bitstream gain failed: {} (tags still written)",
+                    "!".yellow(),
+                    filename,
+                    e
+                );
             }
         }
-    } else {
-        0
-    };
+    }
 
-    // Create ReplayGain tags for AAC
     let mut tags = mp4meta::ReplayGainTags::default();
     tags.set_track(result.gain_db(), result.peak());
-
-    // Add album tags if available
     if let Some(album) = album_info {
         tags.set_album(album.album_gain_db, album.album_peak);
     }
 
-    // Write tags to file
     match mp4meta::write_replaygain_tags(file, &tags) {
         Ok(()) => {
-            // Restore timestamp if needed
-            if let Some(mtime) = original_mtime {
-                restore_timestamp(file, mtime);
-            }
-
             let tag_type = if album_info.is_some() {
                 "track+album tags"
             } else {

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -135,7 +135,7 @@ fn apply_replaygain_with_album_into(
     // ReplayGain-peak cap here without touching the file.
     if opts.dry_run {
         let (actual_steps, warning_msg) =
-            dry_run_clipping_summary(steps, result, opts, &dry_run_prefix, filename);
+            dry_run_clipping_summary(steps, result, opts, dry_run_prefix, filename);
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
                 out,
@@ -170,7 +170,7 @@ fn apply_replaygain_with_album_into(
             result,
             opts,
             album_info,
-            &dry_run_prefix,
+            dry_run_prefix,
             out,
         );
     }
@@ -191,7 +191,7 @@ fn apply_replaygain_with_album_into(
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
             let warning_msg =
-                emit_clipping_warning_peak(steps, result, &report, opts, &dry_run_prefix, filename);
+                emit_clipping_warning_peak(steps, result, &report, opts, dry_run_prefix, filename);
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -12,7 +12,7 @@ use crate::json_output::{FileStatus, JsonFileResult};
 use crate::progress::update_analysis_progress;
 use crate::util::get_filename;
 
-use super::utils::warn_aac_multi_track;
+use super::utils::{restore_timestamp, save_original_mtime, warn_aac_multi_track};
 
 pub fn process_track_gain(
     file: &Path,
@@ -372,12 +372,18 @@ fn apply_replaygain_aac_with_album_into(
 
     warn_aac_multi_track(file, filename, opts, "");
 
+    // mtime must be restored AFTER the ReplayGain tag write, not after the
+    // apply step alone — otherwise `mp4meta::write_replaygain_tags` below
+    // bumps the timestamp again. So we keep mtime handling on this side
+    // and tell apply_with_options to leave it alone.
+    let original_mtime = save_original_mtime(file, opts);
+
     let mut apply_opts = ApplyOptions::new(requested_steps);
     apply_opts.track_result = Some(result.clone());
     apply_opts.album_info = album_info.copied();
     apply_opts.prevent_clipping = opts.prevent_clipping;
     apply_opts.wrap = opts.wrap_gain;
-    apply_opts.preserve_timestamp = opts.preserve_timestamp;
+    apply_opts.preserve_timestamp = false;
     apply_opts.use_temp_file = opts.use_temp_file;
     // AAC tag writing is fail-soft, so we drive it ourselves below.
     apply_opts.write_replaygain_tags = false;
@@ -422,6 +428,10 @@ fn apply_replaygain_aac_with_album_into(
 
     match mp4meta::write_replaygain_tags(file, &tags) {
         Ok(()) => {
+            if let Some(mtime) = original_mtime {
+                restore_timestamp(file, mtime);
+            }
+
             let tag_type = if album_info.is_some() {
                 "track+album tags"
             } else {

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -1,54 +1,10 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::{analyze, ape, id3v2, mp4meta, Mp3Analysis};
-use std::fs;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
 use crate::cli::options::{Options, OutputFormat};
-
-// Per-process counter so that parallel apply tasks operating on files in the
-// same parent directory don't collide on a shared temp filename. The previous
-// `.mp3rgain_temp_{pid}.mp3` template was racy under rayon parallelism.
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Run a gain operation, optionally going through a sibling temp file.
-///
-/// The closure receives `(read_from, write_to)`. When `-t` is in effect they
-/// differ (read original, write temp file, rename) — when it isn't, both are
-/// the original path and the operation works in place.
-///
-/// Compared with the old "copy original to temp, then operate on temp" flow,
-/// the split-path variant saves one full-file pass on the `-t` apply path
-/// (issue #135).
-pub fn apply_with_temp_file<F>(file: &Path, operation: F, opts: &Options) -> Result<usize>
-where
-    F: FnOnce(&Path, &Path) -> Result<usize>,
-{
-    if opts.use_temp_file {
-        let parent = file.parent().unwrap_or(Path::new("."));
-        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let temp_path = parent.join(format!(
-            ".mp3rgain_temp_{}_{}.mp3",
-            std::process::id(),
-            counter
-        ));
-
-        match operation(file, &temp_path) {
-            Ok(frames) => {
-                fs::rename(&temp_path, file)?;
-                Ok(frames)
-            }
-            Err(e) => {
-                let _ = fs::remove_file(&temp_path);
-                Err(e)
-            }
-        }
-    } else {
-        operation(file, file)
-    }
-}
 
 pub fn restore_timestamp(file: &Path, mtime: SystemTime) {
     let _ = std::fs::File::options()


### PR DESCRIPTION
## Summary

Restructures both frontends around a unified apply pipeline so the GUI no longer composes behavior out of low-level primitives (the root cause of #149 / #151), and moves all batch work off the egui main thread (#152).

### Steps covered

- **Step 1** (`e3ce1df`) — new `mp3rgain::apply` module: `ApplyOptions`, `ApplyReport`, `ClippingDetection`, `AacAlbumInfo`, `apply_with_options`. CLI now uses it; behavior preserved (text output, JSON output, warning messages, AAC fail-soft tag policy).
- **Step 2** (`5f2cee8`) — GUI port to `apply_with_options`. Closes #153 A1 (undo), A2 for AAC (ReplayGain tags), A4 (atomic write), A5 (mtime).
- **Step 3** (`eb531a5`) — GUI batch ops moved to a worker thread, mpsc progress channel, `ctx.request_repaint()`, Cancel button. Closes #152.
- **Step 4** (`89fcc7a`) — Options panel with `Prevent clipping` / `Preserve mtime` / `Wrap mode` / `Use ID3v2` checkboxes. Closes #153 A3 and A2 for MP3 (user opt-in).

Plus two follow-ups:
- `53ad676` — mtime regression fix on CLI AAC RG apply uncovered by real-file testing.
- `a3e591c` — folder drag-drop, which was already broken pre-#153.

### Not closing #153

The umbrella issue stays open for Step 5: missing menu commands (`-u`, `-x`, `-s c/d/r`, `-g`/`-m`, `-l`, `-n`, `-j`). See the issue for the running breakdown.

### Verification

- `cargo test --all-features` — 96/96 pass.
- Real-file parity via CLI (`-r -t -p` and `-r -t -p -s i`) on MP3 + M4A: undo round-trips to byte-identical content; mtime preserved; ID3v2 RG tags written under `-s i`; no stray temp files.
- GUI smoke test (manual, on macOS): Add Folder works, status text updates as files complete, Cancel mid-batch works, folder drag-drop now works.

## Test plan

- [ ] CI: release build + tests
- [ ] GUI manual: drop a folder, run Album Analysis, run Apply Album Gain — UI stays responsive, status text updates per file.
- [ ] GUI manual: Cancel mid-apply — worker stops on next file boundary.
- [ ] GUI manual: toggle Use ID3v2 on, apply to an MP3, confirm `mp3rgain -s c -s i` shows REPLAYGAIN_TRACK_GAIN / TRACK_PEAK.
- [ ] GUI manual: confirm Preserve mtime keeps the file's modification date.