### PR TITLE
GUI Step 5: surface remaining CLI commands (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ See **[docs/migrating-from-mp3gain.md](docs/migrating-from-mp3gain.md)** for the
 
 A native GUI application (`mp3rgui`) is available for users who prefer a graphical interface.
 
-**Features:** Drag-and-drop, track/album analysis, one-click gain application, clipping warnings, progress indicators.
+**Features:**
+
+- Drag-and-drop file / folder loading (recurses subfolders)
+- Track and Album ReplayGain analysis (parallel, with Cancel)
+- Apply Track / Album Gain — shares the same `apply_with_options` pipeline as the CLI
+- **Options panel:** Prevent clipping (`-k`), Preserve mtime (`-p`), Wrap mode (`-w`), Use ID3v2 (`-s i`), Dry run (`-n`)
+- **Modify Gain menu:** Apply Track / Album / Manual (`-g`) / Channel (`-l`) Gain, Undo (`-u`), Delete Stored Tags (`-s d`)
+- **Analysis menu:** Track / Album Analysis, Find Max Amplitude (`-x`), Check Stored Tags (`-s c`)
+- **Stored RG** table column shows existing ReplayGain / undo tags (APE / ID3v2 / MP4 freeform) with a per-tag breakdown on hover
+- Responsive UI: all batch work runs on a worker thread with per-file progress and a Cancel button
 
 **Install:** See [Installation](#installation) above for Homebrew, Winget, and AUR options. Binaries are also available from [GitHub Releases](https://github.com/M-Igashi/mp3rgain/releases):
 - `mp3rgui-*-macos-universal.dmg` (macOS)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # mp3rgain Roadmap
 
-## Current Status: v2.3.0 (Production Ready)
+## Current Status: v2.6.3 (Production Ready)
 
 **Positioning:** mp3rgain is the only actively maintained CLI that performs lossless `global_gain` rewrite on AAC/M4A files (aacgain has been abandoned since ~2009; foobar2000's "Apply ReplayGain to file content" offers a comparable scalefactor-based AAC rewrite but is Windows GUI only with no undo). For MP3 it's a modern drop-in replacement for mp3gain; for AAC on the command line it has no equivalent.
 
@@ -138,6 +138,35 @@ All core functionality complete:
   - `linux/amd64` + `linux/arm64`, native build per arch
   - `FROM scratch` + musl static binary, ~2 MB
   - Drop-in replacement for `mp3gain` containers in cron / Plex pipelines
+
+### v2.4.0 - Parallel ReplayGain Analysis (Issues #125, #126)
+
+- [x] `-j` / `--threads` flag + `MP3RGAIN_THREADS` env var
+- [x] Parallel album analysis via `analyze_album_lenient_parallel_with_completion`
+- [x] Auto-tune via `std::thread::available_parallelism`; `-j 1` reproduces the legacy serial path
+- [x] CLI structure refactor (`processors/` per-file work, `commands/` dispatchers)
+
+### v2.5.0 - Robustness
+
+- [x] `--skip-errors` keeps album analysis going past unreadable files (#145)
+- [x] Default-features gate for the binary so library-only consumers stay lean
+
+### v2.6.x - Bug Fixes (Issues #147, #149)
+
+- [x] v2.6.2: apply the `-d` dB modifier during `-a` / `-r` gain application (#147 / #148)
+- [x] v2.6.3: fix GUI corrupting M4A files when applying gain — the dispatcher now routes MP4 files to the AAC path instead of the MP3 sync-word scanner (#149 / #150)
+
+### v2.7.0 (in progress) - Apply Pipeline Refactor & GUI Feature Parity (Issue #153, closes #152)
+
+- [x] `mp3rgain::apply::apply_with_options` — unified pipeline shared by CLI and GUI (Step 1-2, PR #154)
+- [x] GUI worker threads + mpsc progress channel + Cancel button (Step 3, closes #152, PR #154)
+- [x] GUI Options panel: Prevent clipping / Preserve mtime / Wrap / Use ID3v2 (Step 4, PR #154)
+- [x] GUI Step 5 menus (PR #155):
+  - Undo, Check Stored Tags (+ Stored RG table column), Delete Stored Tags (with confirm modal)
+  - Find Max Amplitude, Dry Run toggle
+  - Apply Manual Gain, Apply Channel Gain
+- [x] `mp3rgain::apply::predict_apply` — dry-run companion to `apply_with_options`
+- [x] Channel gain routed through the unified pipeline; CLI `processors/utils::write_id3v2_undo_after_apply` removed
 
 ## Upcoming Goals
 

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,4 +1,4 @@
-use crate::worker::{self, ApplyJob, ApplyOptionsUi, WorkerEvent, WorkerHandle};
+use crate::worker::{self, ApplyJob, ApplyOptionsUi, UndoJob, WorkerEvent, WorkerHandle};
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_steps, AacAlbumInfo};
 use std::path::{Path, PathBuf};
@@ -11,7 +11,9 @@ pub enum FileStatus {
     Analyzing,
     Analyzed,
     Applying,
+    Undoing,
     Done,
+    NoChangesToUndo,
     Error(String),
 }
 
@@ -22,7 +24,9 @@ impl FileStatus {
             FileStatus::Analyzing => "Analyzing...",
             FileStatus::Analyzed => "OK",
             FileStatus::Applying => "Applying...",
+            FileStatus::Undoing => "Undoing...",
             FileStatus::Done => "Done",
+            FileStatus::NoChangesToUndo => "Nothing to undo",
             FileStatus::Error(_) => "Error",
         }
     }
@@ -54,6 +58,7 @@ enum WorkerKind {
     AlbumAnalysis,
     TrackApply,
     AlbumApply,
+    Undo,
 }
 
 pub struct Mp3rgainApp {
@@ -266,6 +271,48 @@ impl Mp3rgainApp {
         );
     }
 
+    /// Undo gain changes on selected files (or all files when no selection).
+    /// Library calls dispatch internally on file format and `use_id3v2`.
+    pub fn start_undo(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+
+        let indices: Vec<usize> = if self.selected_indices.is_empty() {
+            (0..self.files.len()).collect()
+        } else {
+            let mut v = self.selected_indices.clone();
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+
+        let jobs: Vec<UndoJob> = indices
+            .iter()
+            .filter_map(|&idx| {
+                self.files.get(idx).map(|f| UndoJob {
+                    idx,
+                    path: f.path.clone(),
+                })
+            })
+            .collect();
+
+        if jobs.is_empty() {
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        let ui_opts = self.apply_options;
+        self.begin_worker(
+            WorkerKind::Undo,
+            count,
+            worker::spawn_undo(ctx.clone(), jobs, ui_opts),
+        );
+    }
+
     pub fn start_apply_album_gain(&mut self, ctx: &egui::Context) {
         if self.files.is_empty() || self.is_processing {
             return;
@@ -314,6 +361,7 @@ impl Mp3rgainApp {
             WorkerKind::AlbumAnalysis => "Analyzing album...".to_string(),
             WorkerKind::TrackApply => "Applying track gain...".to_string(),
             WorkerKind::AlbumApply => "Applying album gain...".to_string(),
+            WorkerKind::Undo => "Undoing gain changes...".to_string(),
         };
         self.started_files = 0;
         self.total_files_in_job = total;
@@ -355,6 +403,7 @@ impl Mp3rgainApp {
                         Some(WorkerKind::TrackApply) | Some(WorkerKind::AlbumApply) => {
                             FileStatus::Applying
                         }
+                        Some(WorkerKind::Undo) => FileStatus::Undoing,
                         _ => FileStatus::Analyzing,
                     };
                 }
@@ -415,6 +464,16 @@ impl Mp3rgainApp {
             WorkerEvent::FileApplyFailed { idx, message } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Error(message);
+                }
+            }
+            WorkerEvent::FileUndone { idx } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::Done;
+                }
+            }
+            WorkerEvent::FileUndoSkipped { idx } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::NoChangesToUndo;
                 }
             }
             WorkerEvent::Cancelled => {

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -107,6 +107,20 @@ impl Default for ChannelGainModal {
     }
 }
 
+/// Modifier-combo classification for a table-row click.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClickMode {
+    /// Plain click. Replaces the selection with `idx`.
+    Replace,
+    /// Cmd / Ctrl + click. Toggles `idx` in/out of the selection.
+    Toggle,
+    /// Shift + click. Selects the inclusive range anchor..=idx, replacing.
+    Range,
+    /// Shift + Cmd / Ctrl + click. Adds the inclusive range to the existing
+    /// selection (set union).
+    RangeAdd,
+}
+
 /// What kind of work the active worker is doing — drives messaging and
 /// final-event handling.
 #[derive(Clone, Copy, PartialEq)]
@@ -145,6 +159,12 @@ pub struct Mp3rgainApp {
     /// Channel-gain modal state.
     pub channel_gain_modal: ChannelGainModal,
 
+    /// Last row the user clicked on (without Shift). Acts as the anchor for
+    /// subsequent Shift+click range selections, the way Finder / Explorer
+    /// behave. `None` when no anchor has been set yet (fresh table, or after
+    /// a full clear).
+    pub selection_anchor: Option<usize>,
+
     /// Active worker thread + its mpsc receiver and cancel flag.
     /// `None` when nothing is running.
     worker: Option<WorkerHandle>,
@@ -172,6 +192,7 @@ impl Mp3rgainApp {
             confirm_delete_tags: false,
             manual_gain_modal: ManualGainModal::default(),
             channel_gain_modal: ChannelGainModal::default(),
+            selection_anchor: None,
             worker: None,
             worker_kind: None,
             started_files: 0,
@@ -245,7 +266,75 @@ impl Mp3rgainApp {
         }
         self.files.clear();
         self.selected_indices.clear();
+        self.selection_anchor = None;
         self.album_info = None;
+    }
+
+    /// Replace the current selection with every file in the table. Used by
+    /// the Cmd+A / Ctrl+A shortcut.
+    pub fn select_all(&mut self) {
+        if self.is_processing || self.files.is_empty() {
+            return;
+        }
+        self.selected_indices = (0..self.files.len()).collect();
+        // Anchor at the first row so a follow-up Shift+click extends a sane
+        // range. (Without this, an Esc-then-Cmd-A flow would lose the
+        // anchor and Shift+click would behave like a plain click.)
+        self.selection_anchor = Some(0);
+    }
+
+    /// Drop the current selection. Used by Escape (when no modal is open).
+    pub fn clear_selection(&mut self) {
+        self.selected_indices.clear();
+        self.selection_anchor = None;
+    }
+
+    /// Apply a click on `idx` with the given modifier combination. Anchor
+    /// management follows Finder: a plain click moves the anchor, a Shift
+    /// click extends from the anchor without moving it, a Cmd/Ctrl click
+    /// toggles a single row and updates the anchor.
+    pub fn click_row(&mut self, idx: usize, mode: ClickMode) {
+        if idx >= self.files.len() {
+            return;
+        }
+        match mode {
+            ClickMode::Replace => {
+                self.selected_indices.clear();
+                self.selected_indices.push(idx);
+                self.selection_anchor = Some(idx);
+            }
+            ClickMode::Toggle => {
+                if let Some(pos) = self.selected_indices.iter().position(|&i| i == idx) {
+                    self.selected_indices.remove(pos);
+                } else {
+                    self.selected_indices.push(idx);
+                }
+                self.selection_anchor = Some(idx);
+            }
+            ClickMode::Range => {
+                let anchor = self.selection_anchor.unwrap_or(idx);
+                let (lo, hi) = if anchor <= idx {
+                    (anchor, idx)
+                } else {
+                    (idx, anchor)
+                };
+                self.selected_indices = (lo..=hi).collect();
+                // Anchor stays put.
+            }
+            ClickMode::RangeAdd => {
+                let anchor = self.selection_anchor.unwrap_or(idx);
+                let (lo, hi) = if anchor <= idx {
+                    (anchor, idx)
+                } else {
+                    (idx, anchor)
+                };
+                for i in lo..=hi {
+                    if !self.selected_indices.contains(&i) {
+                        self.selected_indices.push(i);
+                    }
+                }
+            }
+        }
     }
 
     pub fn cancel_current_work(&mut self) {

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -3,7 +3,7 @@ use crate::worker::{
     WorkerEvent, WorkerHandle,
 };
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
-use mp3rgain::{db_to_steps, AacAlbumInfo};
+use mp3rgain::{db_to_steps, AacAlbumInfo, Channel};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::TryRecvError;
 
@@ -90,6 +90,23 @@ impl Default for ManualGainModal {
     }
 }
 
+/// State for the "Apply Channel Gain" modal (`-l`).
+pub struct ChannelGainModal {
+    pub open: bool,
+    pub channel: Channel,
+    pub steps: i32,
+}
+
+impl Default for ChannelGainModal {
+    fn default() -> Self {
+        Self {
+            open: false,
+            channel: Channel::Left,
+            steps: 0,
+        }
+    }
+}
+
 /// What kind of work the active worker is doing — drives messaging and
 /// final-event handling.
 #[derive(Clone, Copy, PartialEq)]
@@ -125,6 +142,9 @@ pub struct Mp3rgainApp {
     /// the same value across runs.
     pub manual_gain_modal: ManualGainModal,
 
+    /// Channel-gain modal state.
+    pub channel_gain_modal: ChannelGainModal,
+
     /// Active worker thread + its mpsc receiver and cancel flag.
     /// `None` when nothing is running.
     worker: Option<WorkerHandle>,
@@ -151,6 +171,7 @@ impl Mp3rgainApp {
             apply_options: ApplyOptionsUi::default(),
             confirm_delete_tags: false,
             manual_gain_modal: ManualGainModal::default(),
+            channel_gain_modal: ChannelGainModal::default(),
             worker: None,
             worker_kind: None,
             started_files: 0,
@@ -303,6 +324,7 @@ impl Mp3rgainApp {
                     steps: db_to_steps(gain_db),
                     track_result: f.track_result.clone(),
                     album_info: None,
+                    channel: None,
                 })
             })
             .collect();
@@ -447,6 +469,7 @@ impl Mp3rgainApp {
                     steps,
                     track_result: None,
                     album_info: None,
+                    channel: None,
                 })
             })
             .collect();
@@ -463,6 +486,58 @@ impl Mp3rgainApp {
             WorkerKind::TrackApply,
             count,
             worker::spawn_apply(ctx.clone(), jobs, "manual gain", ui_opts),
+        );
+    }
+
+    /// `-l`: apply gain to a single channel of the targeted files. AAC files
+    /// are silently skipped (channel gain is MP3-only).
+    pub fn start_apply_channel_gain(
+        &mut self,
+        ctx: &egui::Context,
+        channel: Channel,
+        steps: i32,
+    ) {
+        if self.files.is_empty() || self.is_processing || steps == 0 {
+            return;
+        }
+
+        let indices: Vec<usize> = if self.selected_indices.is_empty() {
+            (0..self.files.len()).collect()
+        } else {
+            let mut v = self.selected_indices.clone();
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+
+        let jobs: Vec<ApplyJob> = indices
+            .iter()
+            .filter_map(|&idx| self.files.get(idx).map(|f| (idx, f)))
+            .filter(|(_, f)| !mp3rgain::mp4meta::is_aac_file(&f.path))
+            .map(|(idx, f)| ApplyJob {
+                idx,
+                path: f.path.clone(),
+                steps,
+                track_result: None,
+                album_info: None,
+                channel: Some(channel),
+            })
+            .collect();
+        if jobs.is_empty() {
+            self.status_message =
+                "Channel gain only applies to MP3 — selection had no eligible files".into();
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        let ui_opts = self.apply_options;
+        self.begin_worker(
+            WorkerKind::TrackApply,
+            count,
+            worker::spawn_apply(ctx.clone(), jobs, "channel gain", ui_opts),
         );
     }
 
@@ -525,6 +600,7 @@ impl Mp3rgainApp {
                     steps: db_to_steps(gain_db),
                     track_result: f.track_result.clone(),
                     album_info,
+                    channel: None,
                 })
             })
             .collect();

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -74,6 +74,22 @@ pub struct FileEntry {
     pub stored_tags: Option<StoredTagsView>,
 }
 
+/// State for the "Apply Manual Gain" modal. `open` toggles visibility;
+/// `steps` is preserved across closes so the next open shows the same value.
+pub struct ManualGainModal {
+    pub open: bool,
+    pub steps: i32,
+}
+
+impl Default for ManualGainModal {
+    fn default() -> Self {
+        Self {
+            open: false,
+            steps: 0,
+        }
+    }
+}
+
 /// What kind of work the active worker is doing — drives messaging and
 /// final-event handling.
 #[derive(Clone, Copy, PartialEq)]
@@ -105,6 +121,10 @@ pub struct Mp3rgainApp {
     /// The destructive worker is only spawned after the user confirms.
     pub confirm_delete_tags: bool,
 
+    /// Manual-gain modal state. Lives across opens so the user can tweak
+    /// the same value across runs.
+    pub manual_gain_modal: ManualGainModal,
+
     /// Active worker thread + its mpsc receiver and cancel flag.
     /// `None` when nothing is running.
     worker: Option<WorkerHandle>,
@@ -130,6 +150,7 @@ impl Mp3rgainApp {
             album_info: None,
             apply_options: ApplyOptionsUi::default(),
             confirm_delete_tags: false,
+            manual_gain_modal: ManualGainModal::default(),
             worker: None,
             worker_kind: None,
             started_files: 0,
@@ -396,6 +417,52 @@ impl Mp3rgainApp {
             WorkerKind::CheckTags,
             count,
             worker::spawn_check_stored_tags(ctx.clone(), jobs, use_id3v2),
+        );
+    }
+
+    /// `-g`: apply a fixed step count to the selected files (or all when no
+    /// selection). Bypasses ReplayGain — `track_result` / `album_info` are
+    /// left None so `apply_with_options` uses the headroom-based clipping
+    /// check.
+    pub fn start_apply_manual_gain(&mut self, ctx: &egui::Context, steps: i32) {
+        if self.files.is_empty() || self.is_processing || steps == 0 {
+            return;
+        }
+
+        let indices: Vec<usize> = if self.selected_indices.is_empty() {
+            (0..self.files.len()).collect()
+        } else {
+            let mut v = self.selected_indices.clone();
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+
+        let jobs: Vec<ApplyJob> = indices
+            .iter()
+            .filter_map(|&idx| {
+                self.files.get(idx).map(|f| ApplyJob {
+                    idx,
+                    path: f.path.clone(),
+                    steps,
+                    track_result: None,
+                    album_info: None,
+                })
+            })
+            .collect();
+        if jobs.is_empty() {
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        let ui_opts = self.apply_options;
+        self.begin_worker(
+            WorkerKind::TrackApply,
+            count,
+            worker::spawn_apply(ctx.clone(), jobs, "manual gain", ui_opts),
         );
     }
 

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,4 +1,7 @@
-use crate::worker::{self, ApplyJob, ApplyOptionsUi, UndoJob, WorkerEvent, WorkerHandle};
+use crate::worker::{
+    self, ApplyJob, ApplyOptionsUi, CheckTagsJob, StoredTagsView, UndoJob, WorkerEvent,
+    WorkerHandle,
+};
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_steps, AacAlbumInfo};
 use std::path::{Path, PathBuf};
@@ -48,6 +51,9 @@ pub struct FileEntry {
     /// for the peak-based clipping check and for writing
     /// `replaygain_track_*` tags on apply.
     pub track_result: Option<ReplayGainResult>,
+    /// Pre-existing ReplayGain / undo tags read from the file, populated by
+    /// the "Check Stored Tags" action. `None` = not scanned yet.
+    pub stored_tags: Option<StoredTagsView>,
 }
 
 /// What kind of work the active worker is doing — drives messaging and
@@ -59,6 +65,7 @@ enum WorkerKind {
     TrackApply,
     AlbumApply,
     Undo,
+    CheckTags,
 }
 
 pub struct Mp3rgainApp {
@@ -271,6 +278,31 @@ impl Mp3rgainApp {
         );
     }
 
+    /// Scan every loaded file for existing ReplayGain / undo tags and
+    /// populate `FileEntry::stored_tags`. Read-only.
+    pub fn start_check_stored_tags(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+
+        let jobs: Vec<CheckTagsJob> = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(idx, f)| CheckTagsJob {
+                idx,
+                path: f.path.clone(),
+            })
+            .collect();
+        let count = jobs.len();
+        let use_id3v2 = self.apply_options.use_id3v2;
+        self.begin_worker(
+            WorkerKind::CheckTags,
+            count,
+            worker::spawn_check_stored_tags(ctx.clone(), jobs, use_id3v2),
+        );
+    }
+
     /// Undo gain changes on selected files (or all files when no selection).
     /// Library calls dispatch internally on file format and `use_id3v2`.
     pub fn start_undo(&mut self, ctx: &egui::Context) {
@@ -362,6 +394,7 @@ impl Mp3rgainApp {
             WorkerKind::TrackApply => "Applying track gain...".to_string(),
             WorkerKind::AlbumApply => "Applying album gain...".to_string(),
             WorkerKind::Undo => "Undoing gain changes...".to_string(),
+            WorkerKind::CheckTags => "Checking stored tags...".to_string(),
         };
         self.started_files = 0;
         self.total_files_in_job = total;
@@ -399,13 +432,18 @@ impl Mp3rgainApp {
         match event {
             WorkerEvent::FileStart { idx } => {
                 if let Some(file) = self.files.get_mut(idx) {
-                    file.status = match self.worker_kind {
+                    match self.worker_kind {
                         Some(WorkerKind::TrackApply) | Some(WorkerKind::AlbumApply) => {
-                            FileStatus::Applying
+                            file.status = FileStatus::Applying;
                         }
-                        Some(WorkerKind::Undo) => FileStatus::Undoing,
-                        _ => FileStatus::Analyzing,
-                    };
+                        Some(WorkerKind::Undo) => {
+                            file.status = FileStatus::Undoing;
+                        }
+                        // Tag scan is read-only; don't disturb the
+                        // user-visible status (e.g. Analyzed) for the row.
+                        Some(WorkerKind::CheckTags) => {}
+                        _ => file.status = FileStatus::Analyzing,
+                    }
                 }
                 self.started_files = self.started_files.saturating_add(1);
                 self.bump_progress();
@@ -459,6 +497,8 @@ impl Mp3rgainApp {
             WorkerEvent::FileApplied { idx } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Done;
+                    // File contents changed; cached tag snapshot is stale.
+                    file.stored_tags = None;
                 }
             }
             WorkerEvent::FileApplyFailed { idx, message } => {
@@ -469,11 +509,17 @@ impl Mp3rgainApp {
             WorkerEvent::FileUndone { idx } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Done;
+                    file.stored_tags = None;
                 }
             }
             WorkerEvent::FileUndoSkipped { idx } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::NoChangesToUndo;
+                }
+            }
+            WorkerEvent::StoredTagsRead { idx, view } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.stored_tags = Some(view);
                 }
             }
             WorkerEvent::Cancelled => {

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1,6 +1,6 @@
 use crate::worker::{
-    self, ApplyJob, ApplyOptionsUi, CheckTagsJob, StoredTagsView, UndoJob, WorkerEvent,
-    WorkerHandle,
+    self, ApplyJob, ApplyOptionsUi, CheckTagsJob, DeleteTagsJob, StoredTagsView, UndoJob,
+    WorkerEvent, WorkerHandle,
 };
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_steps, AacAlbumInfo};
@@ -85,6 +85,7 @@ enum WorkerKind {
     Undo,
     CheckTags,
     MaxAmplitude,
+    DeleteTags,
 }
 
 pub struct Mp3rgainApp {
@@ -99,6 +100,10 @@ pub struct Mp3rgainApp {
     pub album_info: Option<AacAlbumInfo>,
     /// User-toggleable apply flags surfaced in the Options panel.
     pub apply_options: ApplyOptionsUi,
+
+    /// Set true while the "Delete stored tags" confirmation modal is up.
+    /// The destructive worker is only spawned after the user confirms.
+    pub confirm_delete_tags: bool,
 
     /// Active worker thread + its mpsc receiver and cancel flag.
     /// `None` when nothing is running.
@@ -124,6 +129,7 @@ impl Mp3rgainApp {
             status_message: String::new(),
             album_info: None,
             apply_options: ApplyOptionsUi::default(),
+            confirm_delete_tags: false,
             worker: None,
             worker_kind: None,
             started_files: 0,
@@ -297,6 +303,54 @@ impl Mp3rgainApp {
         );
     }
 
+    /// Selected (or all, if no selection) files chosen for stored-tag
+    /// deletion. Pure read; used by the confirmation modal to show a count.
+    pub fn delete_target_indices(&self) -> Vec<usize> {
+        if self.selected_indices.is_empty() {
+            (0..self.files.len()).collect()
+        } else {
+            let mut v = self.selected_indices.clone();
+            v.sort_unstable();
+            v.dedup();
+            v
+        }
+    }
+
+    /// `-s d`: delete stored RG / undo tags from selected files. Destructive,
+    /// so the UI funnels the click through `confirm_delete_tags` first and
+    /// this is only called after the user confirms.
+    pub fn start_delete_tags(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+
+        let indices = self.delete_target_indices();
+        let jobs: Vec<DeleteTagsJob> = indices
+            .iter()
+            .filter_map(|&idx| {
+                self.files.get(idx).map(|f| DeleteTagsJob {
+                    idx,
+                    path: f.path.clone(),
+                })
+            })
+            .collect();
+        if jobs.is_empty() {
+            return;
+        }
+
+        for &job_idx in jobs.iter().map(|j| &j.idx) {
+            self.files[job_idx].status = FileStatus::Pending;
+        }
+        let count = jobs.len();
+        let use_id3v2 = self.apply_options.use_id3v2;
+        let preserve = self.apply_options.preserve_timestamp;
+        self.begin_worker(
+            WorkerKind::DeleteTags,
+            count,
+            worker::spawn_delete_tags(ctx.clone(), jobs, use_id3v2, preserve),
+        );
+    }
+
     /// `-x`: scan each file for its max amplitude / headroom without any
     /// ReplayGain decoding. Faster than Track Analysis.
     pub fn start_find_max_amplitude(&mut self, ctx: &egui::Context) {
@@ -438,6 +492,7 @@ impl Mp3rgainApp {
             WorkerKind::Undo => "Undoing gain changes...".to_string(),
             WorkerKind::CheckTags => "Checking stored tags...".to_string(),
             WorkerKind::MaxAmplitude => "Finding max amplitude...".to_string(),
+            WorkerKind::DeleteTags => "Deleting stored tags...".to_string(),
         };
         self.started_files = 0;
         self.total_files_in_job = total;
@@ -476,7 +531,9 @@ impl Mp3rgainApp {
             WorkerEvent::FileStart { idx } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     match self.worker_kind {
-                        Some(WorkerKind::TrackApply) | Some(WorkerKind::AlbumApply) => {
+                        Some(WorkerKind::TrackApply)
+                        | Some(WorkerKind::AlbumApply)
+                        | Some(WorkerKind::DeleteTags) => {
                             file.status = FileStatus::Applying;
                         }
                         Some(WorkerKind::Undo) => {

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -17,20 +17,38 @@ pub enum FileStatus {
     Undoing,
     Done,
     NoChangesToUndo,
+    /// Dry-run apply finished without touching the file. `steps` is what
+    /// would have been applied; `clipping_prevented` indicates the cap.
+    DryRunPredicted {
+        steps: i32,
+        clipping_prevented: bool,
+    },
     Error(String),
 }
 
 impl FileStatus {
-    pub fn as_str(&self) -> &str {
+    /// Short label for the Status column. For dynamic variants only the
+    /// category is returned; the detail goes in a tooltip / extra label.
+    pub fn label(&self) -> String {
         match self {
-            FileStatus::Pending => "",
-            FileStatus::Analyzing => "Analyzing...",
-            FileStatus::Analyzed => "OK",
-            FileStatus::Applying => "Applying...",
-            FileStatus::Undoing => "Undoing...",
-            FileStatus::Done => "Done",
-            FileStatus::NoChangesToUndo => "Nothing to undo",
-            FileStatus::Error(_) => "Error",
+            FileStatus::Pending => "".into(),
+            FileStatus::Analyzing => "Analyzing...".into(),
+            FileStatus::Analyzed => "OK".into(),
+            FileStatus::Applying => "Applying...".into(),
+            FileStatus::Undoing => "Undoing...".into(),
+            FileStatus::Done => "Done".into(),
+            FileStatus::NoChangesToUndo => "Nothing to undo".into(),
+            FileStatus::DryRunPredicted {
+                steps,
+                clipping_prevented,
+            } => {
+                if *clipping_prevented {
+                    format!("Dry run: +{} steps (capped)", steps)
+                } else {
+                    format!("Dry run: {:+} steps", steps)
+                }
+            }
+            FileStatus::Error(_) => "Error".into(),
         }
     }
 }
@@ -66,6 +84,7 @@ enum WorkerKind {
     AlbumApply,
     Undo,
     CheckTags,
+    MaxAmplitude,
 }
 
 pub struct Mp3rgainApp {
@@ -278,6 +297,29 @@ impl Mp3rgainApp {
         );
     }
 
+    /// `-x`: scan each file for its max amplitude / headroom without any
+    /// ReplayGain decoding. Faster than Track Analysis.
+    pub fn start_find_max_amplitude(&mut self, ctx: &egui::Context) {
+        if self.files.is_empty() || self.is_processing {
+            return;
+        }
+        for file in &mut self.files {
+            file.status = FileStatus::Pending;
+        }
+        let jobs: Vec<(usize, PathBuf)> = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (i, f.path.clone()))
+            .collect();
+        let count = jobs.len();
+        self.begin_worker(
+            WorkerKind::MaxAmplitude,
+            count,
+            worker::spawn_find_max_amplitude(ctx.clone(), jobs),
+        );
+    }
+
     /// Scan every loaded file for existing ReplayGain / undo tags and
     /// populate `FileEntry::stored_tags`. Read-only.
     pub fn start_check_stored_tags(&mut self, ctx: &egui::Context) {
@@ -395,6 +437,7 @@ impl Mp3rgainApp {
             WorkerKind::AlbumApply => "Applying album gain...".to_string(),
             WorkerKind::Undo => "Undoing gain changes...".to_string(),
             WorkerKind::CheckTags => "Checking stored tags...".to_string(),
+            WorkerKind::MaxAmplitude => "Finding max amplitude...".to_string(),
         };
         self.started_files = 0;
         self.total_files_in_job = total;
@@ -442,6 +485,9 @@ impl Mp3rgainApp {
                         // Tag scan is read-only; don't disturb the
                         // user-visible status (e.g. Analyzed) for the row.
                         Some(WorkerKind::CheckTags) => {}
+                        Some(WorkerKind::MaxAmplitude) => {
+                            file.status = FileStatus::Analyzing;
+                        }
                         _ => file.status = FileStatus::Analyzing,
                     }
                 }
@@ -501,6 +547,18 @@ impl Mp3rgainApp {
                     file.stored_tags = None;
                 }
             }
+            WorkerEvent::FileApplyDryRun {
+                idx,
+                actual_steps,
+                clipping_prevented,
+            } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::DryRunPredicted {
+                        steps: actual_steps,
+                        clipping_prevented,
+                    };
+                }
+            }
             WorkerEvent::FileApplyFailed { idx, message } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Error(message);
@@ -520,6 +578,32 @@ impl Mp3rgainApp {
             WorkerEvent::StoredTagsRead { idx, view } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.stored_tags = Some(view);
+                }
+            }
+            WorkerEvent::MaxAmplitudeFound {
+                idx,
+                peak,
+                headroom_db,
+            } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    // Reuse the existing Volume column to show headroom.
+                    // ReplayGain volume and max-amp headroom are different
+                    // measures but both express "loudness ceiling"; the
+                    // Volume column header tooltip explains both.
+                    file.volume = headroom_db;
+                    file.clipping = peak >= 1.0;
+                    // Max amplitude is not a ReplayGain analysis — clear
+                    // any prior RG-derived gain so the row doesn't claim
+                    // an out-of-date target.
+                    file.track_gain = None;
+                    file.track_clip = false;
+                    file.track_result = None;
+                    file.status = FileStatus::Analyzed;
+                }
+            }
+            WorkerEvent::MaxAmplitudeFailed { idx, message } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::Error(message);
                 }
             }
             WorkerEvent::Cancelled => {

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -80,6 +80,10 @@ fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
                 app.start_apply_album_gain(ctx);
                 ui.close_menu();
             }
+            if ui.button("Apply Manual Gain...").clicked() {
+                app.manual_gain_modal.open = true;
+                ui.close_menu();
+            }
             ui.separator();
             let undo_label = if app.selected_indices.is_empty() {
                 "Undo All"

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -90,6 +90,15 @@ fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
                 app.start_undo(ctx);
                 ui.close_menu();
             }
+            let delete_label = if app.selected_indices.is_empty() {
+                "Delete Stored Tags (All)..."
+            } else {
+                "Delete Stored Tags (Selected)..."
+            };
+            if ui.button(delete_label).clicked() {
+                app.confirm_delete_tags = true;
+                ui.close_menu();
+            }
         });
     });
 }

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -56,6 +56,10 @@ fn analysis_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) 
                 app.start_analyze_album(ctx);
                 ui.close_menu();
             }
+            if ui.button("Find Max Amplitude").clicked() {
+                app.start_find_max_amplitude(ctx);
+                ui.close_menu();
+            }
             ui.separator();
             if ui.button("Check Stored Tags").clicked() {
                 app.start_check_stored_tags(ctx);

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -56,6 +56,11 @@ fn analysis_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) 
                 app.start_analyze_album(ctx);
                 ui.close_menu();
             }
+            ui.separator();
+            if ui.button("Check Stored Tags").clicked() {
+                app.start_check_stored_tags(ctx);
+                ui.close_menu();
+            }
         });
     });
 }

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -71,6 +71,16 @@ fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
                 app.start_apply_album_gain(ctx);
                 ui.close_menu();
             }
+            ui.separator();
+            let undo_label = if app.selected_indices.is_empty() {
+                "Undo All"
+            } else {
+                "Undo Selected"
+            };
+            if ui.button(undo_label).clicked() {
+                app.start_undo(ctx);
+                ui.close_menu();
+            }
         });
     });
 }

--- a/mp3rgui/src/ui/menu.rs
+++ b/mp3rgui/src/ui/menu.rs
@@ -84,6 +84,10 @@ fn modify_menu(app: &mut Mp3rgainApp, ui: &mut egui::Ui, ctx: &egui::Context) {
                 app.manual_gain_modal.open = true;
                 ui.close_menu();
             }
+            if ui.button("Apply Channel Gain (MP3)...").clicked() {
+                app.channel_gain_modal.open = true;
+                ui.close_menu();
+            }
             ui.separator();
             let undo_label = if app.selected_indices.is_empty() {
                 "Undo All"

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -14,6 +14,63 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     status::render(app, ctx);
     render_central_panel(app, ctx);
     render_delete_confirm(app, ctx);
+    render_manual_gain_modal(app, ctx);
+}
+
+/// Modal for the `-g`-equivalent "Apply Manual Gain" action.
+fn render_manual_gain_modal(app: &mut Mp3rgainApp, ctx: &egui::Context) {
+    if !app.manual_gain_modal.open {
+        return;
+    }
+    let count = if app.selected_indices.is_empty() {
+        app.files.len()
+    } else {
+        app.selected_indices.len()
+    };
+    let mut open = true;
+    let mut close_via_cancel = false;
+    let mut close_via_apply = false;
+    egui::Window::new("Apply manual gain")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.label(format!("Target: {} file(s)", count));
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                ui.label("Steps:");
+                ui.add(
+                    egui::DragValue::new(&mut app.manual_gain_modal.steps)
+                        .range(-64..=64)
+                        .speed(1),
+                );
+                let db = mp3rgain::steps_to_db(app.manual_gain_modal.steps);
+                ui.label(format!("= {:+.2} dB", db));
+            });
+            ui.label("1 step = 1.5 dB. Negative values lower the volume.");
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    close_via_cancel = true;
+                }
+                let can_apply = app.manual_gain_modal.steps != 0;
+                if ui
+                    .add_enabled(can_apply, egui::Button::new("Apply"))
+                    .clicked()
+                {
+                    close_via_apply = true;
+                }
+            });
+        });
+    if !open || close_via_cancel {
+        app.manual_gain_modal.open = false;
+    }
+    if close_via_apply {
+        let steps = app.manual_gain_modal.steps;
+        app.manual_gain_modal.open = false;
+        app.start_apply_manual_gain(ctx, steps);
+    }
 }
 
 /// Modal dialog gating the destructive Delete Stored Tags worker.

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -13,6 +13,49 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     options::render(app, ctx);
     status::render(app, ctx);
     render_central_panel(app, ctx);
+    render_delete_confirm(app, ctx);
+}
+
+/// Modal dialog gating the destructive Delete Stored Tags worker.
+fn render_delete_confirm(app: &mut Mp3rgainApp, ctx: &egui::Context) {
+    if !app.confirm_delete_tags {
+        return;
+    }
+    let count = app.delete_target_indices().len();
+    let mut open = true;
+    let mut close_via_cancel = false;
+    let mut close_via_confirm = false;
+    egui::Window::new("Delete stored tags")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.label(format!(
+                "Delete stored ReplayGain / undo tags from {} file(s)?",
+                count
+            ));
+            ui.label("This cannot be undone.");
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    close_via_cancel = true;
+                }
+                if ui
+                    .add(egui::Button::new("Delete").fill(egui::Color32::DARK_RED))
+                    .clicked()
+                {
+                    close_via_confirm = true;
+                }
+            });
+        });
+    if !open || close_via_cancel {
+        app.confirm_delete_tags = false;
+    }
+    if close_via_confirm {
+        app.confirm_delete_tags = false;
+        app.start_delete_tags(ctx);
+    }
 }
 
 fn handle_dropped_files(app: &mut Mp3rgainApp, ctx: &egui::Context) {

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -8,6 +8,7 @@ use crate::app::Mp3rgainApp;
 
 pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     handle_dropped_files(app, ctx);
+    handle_selection_shortcuts(app, ctx);
     menu::render(app, ctx);
     toolbar::render(app, ctx);
     options::render(app, ctx);
@@ -184,6 +185,31 @@ fn render_delete_confirm(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     if close_via_confirm {
         app.confirm_delete_tags = false;
         app.start_delete_tags(ctx);
+    }
+}
+
+/// Global keyboard shortcuts for the file table.
+///
+/// - Cmd/Ctrl+A: select every loaded file
+/// - Esc: clear the current selection
+///
+/// Both use `consume_key`, so egui text-edit widgets (e.g. the modal
+/// numeric inputs) get first shot at the keys — Cmd+A in a DragValue's
+/// edit mode selects the text inside, not the file table. We also skip
+/// the Esc handler while any modal is up so the user can dismiss it
+/// without also losing their selection underneath.
+fn handle_selection_shortcuts(app: &mut Mp3rgainApp, ctx: &egui::Context) {
+    if ctx.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::A)) {
+        app.select_all();
+    }
+
+    let modal_open = app.confirm_delete_tags
+        || app.manual_gain_modal.open
+        || app.channel_gain_modal.open;
+    if !modal_open
+        && ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
+    {
+        app.clear_selection();
     }
 }
 

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -15,6 +15,78 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     render_central_panel(app, ctx);
     render_delete_confirm(app, ctx);
     render_manual_gain_modal(app, ctx);
+    render_channel_gain_modal(app, ctx);
+}
+
+/// Modal for the `-l`-equivalent "Apply Channel Gain" action. MP3 only
+/// (the apply pipeline rejects AAC files with `Error::ChannelGainOnAac`).
+fn render_channel_gain_modal(app: &mut Mp3rgainApp, ctx: &egui::Context) {
+    if !app.channel_gain_modal.open {
+        return;
+    }
+    let count = if app.selected_indices.is_empty() {
+        app.files.len()
+    } else {
+        app.selected_indices.len()
+    };
+    let mut open = true;
+    let mut close_via_cancel = false;
+    let mut close_via_apply = false;
+    egui::Window::new("Apply channel gain")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.label(format!("Target: {} file(s) (MP3 only)", count));
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                ui.label("Channel:");
+                ui.selectable_value(
+                    &mut app.channel_gain_modal.channel,
+                    mp3rgain::Channel::Left,
+                    "Left",
+                );
+                ui.selectable_value(
+                    &mut app.channel_gain_modal.channel,
+                    mp3rgain::Channel::Right,
+                    "Right",
+                );
+            });
+            ui.horizontal(|ui| {
+                ui.label("Steps:");
+                ui.add(
+                    egui::DragValue::new(&mut app.channel_gain_modal.steps)
+                        .range(-64..=64)
+                        .speed(1),
+                );
+                let db = mp3rgain::steps_to_db(app.channel_gain_modal.steps);
+                ui.label(format!("= {:+.2} dB", db));
+            });
+            ui.label("Stereo / Dual Channel MP3s only. Joint-Stereo files will warn.");
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    close_via_cancel = true;
+                }
+                let can_apply = app.channel_gain_modal.steps != 0;
+                if ui
+                    .add_enabled(can_apply, egui::Button::new("Apply"))
+                    .clicked()
+                {
+                    close_via_apply = true;
+                }
+            });
+        });
+    if !open || close_via_cancel {
+        app.channel_gain_modal.open = false;
+    }
+    if close_via_apply {
+        let channel = app.channel_gain_modal.channel;
+        let steps = app.channel_gain_modal.steps;
+        app.channel_gain_modal.open = false;
+        app.start_apply_channel_gain(ctx, channel, steps);
+    }
 }
 
 /// Modal for the `-g`-equivalent "Apply Manual Gain" action.

--- a/mp3rgui/src/ui/options.rs
+++ b/mp3rgui/src/ui/options.rs
@@ -35,6 +35,15 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                          instead of APE. Required for foobar2000 / Winamp / Rockbox \
                          to see ReplayGain values on MP3. CLI -s i.",
                     );
+
+                ui.separator();
+
+                ui.checkbox(&mut app.apply_options.dry_run, "Dry run")
+                    .on_hover_text(
+                        "Preview Apply Track / Album Gain without modifying any file. \
+                         The Status column shows the steps that would be applied. \
+                         CLI -n.",
+                    );
             });
         });
     });

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -1,4 +1,38 @@
 use crate::app::Mp3rgainApp;
+use crate::worker::StoredTagsView;
+
+/// Render the "Stored RG" column for one row.
+///
+/// `None` → not scanned yet. `Some(empty)` → scanned, file has no tags.
+/// Otherwise → show a short summary (track gain) and reveal the full
+/// per-field dump on hover.
+fn render_stored_tags_cell(ui: &mut egui::Ui, tags: Option<&StoredTagsView>) {
+    let Some(view) = tags else { return };
+    if view.is_empty() {
+        ui.weak("none").on_hover_text(format!(
+            "No stored tags found ({} container)",
+            view.format.unwrap_or("?")
+        ));
+        return;
+    }
+    let label = view.track_gain.as_deref().unwrap_or("—");
+    ui.label(label).on_hover_ui(|ui| {
+        ui.label(format!("Container: {}", view.format.unwrap_or("?")));
+        ui.separator();
+        for (name, value) in [
+            ("REPLAYGAIN_TRACK_GAIN", view.track_gain.as_deref()),
+            ("REPLAYGAIN_TRACK_PEAK", view.track_peak.as_deref()),
+            ("REPLAYGAIN_ALBUM_GAIN", view.album_gain.as_deref()),
+            ("REPLAYGAIN_ALBUM_PEAK", view.album_peak.as_deref()),
+            ("MP3GAIN_UNDO", view.undo.as_deref()),
+            ("MP3GAIN_MINMAX", view.minmax.as_deref()),
+        ] {
+            if let Some(v) = value {
+                ui.label(format!("{}: {}", name, v));
+            }
+        }
+    });
+}
 
 pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
     egui::ScrollArea::both().show(ui, |ui| {
@@ -14,6 +48,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
             .column(egui_extras::Column::auto().at_least(80.0)) // Album Volume
             .column(egui_extras::Column::auto().at_least(80.0)) // Album Gain
             .column(egui_extras::Column::auto().at_least(50.0)) // Clip (Album)
+            .column(egui_extras::Column::auto().at_least(90.0)) // Stored RG
             .column(egui_extras::Column::remainder()) // Status
             .header(20.0, |mut header| {
                 header.col(|ui| {
@@ -39,6 +74,13 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                 });
                 header.col(|ui| {
                     ui.strong("Clip(A)");
+                });
+                header.col(|ui| {
+                    ui.strong("Stored RG").on_hover_text(
+                        "Existing ReplayGain/undo tags read from the file. \
+                         Run Analysis > Check Stored Tags to populate. \
+                         Hover a cell for full tag details.",
+                    );
                 });
                 header.col(|ui| {
                     ui.strong("Status");
@@ -108,6 +150,9 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                             if file.album_clip {
                                 ui.colored_label(egui::Color32::RED, "Y");
                             }
+                        });
+                        row.col(|ui| {
+                            render_stored_tags_cell(ui, file.stored_tags.as_ref());
                         });
                         row.col(|ui| {
                             ui.label(file.status.as_str());

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -55,7 +55,10 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                     ui.strong("Path/File");
                 });
                 header.col(|ui| {
-                    ui.strong("Volume");
+                    ui.strong("Volume").on_hover_text(
+                        "Track Analysis: current loudness relative to ReplayGain reference (89 dB). \
+                         Find Max Amplitude: available headroom in dB before clipping.",
+                    );
                 });
                 header.col(|ui| {
                     ui.strong("Clip");
@@ -155,7 +158,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                             render_stored_tags_cell(ui, file.stored_tags.as_ref());
                         });
                         row.col(|ui| {
-                            ui.label(file.status.as_str());
+                            ui.label(file.status.label());
                         });
                     });
                 }

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -1,4 +1,4 @@
-use crate::app::Mp3rgainApp;
+use crate::app::{ClickMode, Mp3rgainApp};
 use crate::worker::StoredTagsView;
 
 /// Render the "Stored RG" column for one row.
@@ -90,6 +90,11 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                 });
             })
             .body(|mut body| {
+                // Defer click handling: the row closure borrows `app.files`,
+                // so it can't also mutate `app.selected_indices` during the
+                // iteration. Capture the requested action and apply it after
+                // the loop.
+                let mut pending_click: Option<(usize, ClickMode)> = None;
                 for (idx, file) in app.files.iter().enumerate() {
                     let is_selected = app.selected_indices.contains(&idx);
                     body.row(18.0, |mut row| {
@@ -97,16 +102,17 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
 
                         row.col(|ui| {
                             if ui.selectable_label(is_selected, &file.filename).clicked() {
-                                if ui.input(|i| i.modifiers.ctrl || i.modifiers.command) {
-                                    if is_selected {
-                                        app.selected_indices.retain(|&i| i != idx);
-                                    } else {
-                                        app.selected_indices.push(idx);
+                                let mode = ui.input(|i| {
+                                    let toggle = i.modifiers.ctrl || i.modifiers.command;
+                                    let shift = i.modifiers.shift;
+                                    match (shift, toggle) {
+                                        (true, true) => ClickMode::RangeAdd,
+                                        (true, false) => ClickMode::Range,
+                                        (false, true) => ClickMode::Toggle,
+                                        (false, false) => ClickMode::Replace,
                                     }
-                                } else {
-                                    app.selected_indices.clear();
-                                    app.selected_indices.push(idx);
-                                }
+                                });
+                                pending_click = Some((idx, mode));
                             }
                         });
                         row.col(|ui| {
@@ -161,6 +167,9 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                             ui.label(file.status.label());
                         });
                     });
+                }
+                if let Some((idx, mode)) = pending_click {
+                    app.click_row(idx, mode);
                 }
             });
     });

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -10,12 +10,13 @@
 
 use mp3rgain::apply::{apply_with_options, ApplyOptions};
 use mp3rgain::replaygain::{self, ReplayGainResult};
-use mp3rgain::AacAlbumInfo;
+use mp3rgain::{mp4meta, AacAlbumInfo};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::thread;
+use std::time::SystemTime;
 
 /// One message from a worker thread to the UI thread.
 pub enum WorkerEvent {
@@ -50,6 +51,18 @@ pub enum WorkerEvent {
         message: String,
     },
 
+    /// Undo succeeded on `idx`. Distinct from `FileApplied` so the UI can
+    /// restore the row to its post-analyze state instead of marking it Done.
+    FileUndone {
+        idx: usize,
+    },
+    /// `frames == 0` outcome: undo ran but the file had no recorded changes
+    /// to roll back. Kept separate so the row status reads "no changes" rather
+    /// than "Done" or "Error".
+    FileUndoSkipped {
+        idx: usize,
+    },
+
     /// Worker observed the cancel flag and stopped early.
     Cancelled,
 
@@ -78,6 +91,12 @@ pub struct ApplyJob {
     pub steps: i32,
     pub track_result: Option<ReplayGainResult>,
     pub album_info: Option<AacAlbumInfo>,
+}
+
+/// A single undo job.
+pub struct UndoJob {
+    pub idx: usize,
+    pub path: PathBuf,
 }
 
 /// User-facing apply toggles, captured at the moment the worker is
@@ -318,6 +337,105 @@ pub fn spawn_apply(
     });
 
     WorkerHandle { rx, cancel }
+}
+
+/// Spawn the undo worker. Iterates jobs serially, checks cancel between
+/// files. Dispatches per file to the correct undo path:
+///   - AAC: `mp3rgain::aac::undo_aac_gain`
+///   - MP3 + `use_id3v2`: `mp3rgain::undo_gain_id3v2`
+///   - MP3 (default APE): `mp3rgain::undo_gain`
+///
+/// Mirrors the CLI's `process_undo` dispatch so behavior matches.
+pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsUi) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let mut undone = 0usize;
+        let mut skipped = 0usize;
+        let mut errors = 0usize;
+
+        for job in jobs {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+
+            let original_mtime = if ui_opts.preserve_timestamp {
+                read_mtime(&job.path)
+            } else {
+                None
+            };
+
+            let result = run_undo(&job.path, ui_opts.use_id3v2);
+            match result {
+                Ok(0) => {
+                    skipped += 1;
+                    send(&tx, &ctx, WorkerEvent::FileUndoSkipped { idx: job.idx });
+                }
+                Ok(_) => {
+                    if let Some(mtime) = original_mtime {
+                        restore_mtime(&job.path, mtime);
+                    }
+                    undone += 1;
+                    send(&tx, &ctx, WorkerEvent::FileUndone { idx: job.idx });
+                }
+                Err(e) => {
+                    errors += 1;
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::FileApplyFailed {
+                            idx: job.idx,
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        parts.push(format!("Undone {} file(s)", undone));
+        if skipped > 0 {
+            parts.push(format!("{} had no changes to undo", skipped));
+        }
+        if errors > 0 {
+            parts.push(format!("{} error(s)", errors));
+        }
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: parts.join(", "),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+fn run_undo(path: &Path, use_id3v2: bool) -> mp3rgain::error::Result<usize> {
+    if mp4meta::is_aac_file(path) {
+        return mp3rgain::aac::undo_aac_gain(path);
+    }
+    if use_id3v2 {
+        mp3rgain::undo_gain_id3v2(path)
+    } else {
+        mp3rgain::gain::undo_gain(path)
+    }
+}
+
+fn read_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
+}
+
+fn restore_mtime(path: &Path, mtime: SystemTime) {
+    let _ = std::fs::File::options()
+        .write(true)
+        .open(path)
+        .and_then(|f| f.set_times(std::fs::FileTimes::new().set_modified(mtime)));
 }
 
 /// Build the final `ApplyOptions` by combining always-on safety rails

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -8,7 +8,7 @@
 //! `mpsc::channel`; the UI side drains it from `update()` and calls
 //! `ctx.request_repaint()` so egui actually redraws.
 
-use mp3rgain::apply::{apply_with_options, ApplyOptions};
+use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions};
 use mp3rgain::replaygain::{self, ReplayGainResult};
 use mp3rgain::{
     id3v2, mp4meta, read_ape_tag_from_file, AacAlbumInfo, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
@@ -75,6 +75,13 @@ pub enum WorkerEvent {
     FileApplied {
         idx: usize,
     },
+    /// Dry-run analog of `FileApplied`: predict_apply succeeded, no bytes
+    /// changed. UI shows "Would apply N steps" in the row status.
+    FileApplyDryRun {
+        idx: usize,
+        actual_steps: i32,
+        clipping_prevented: bool,
+    },
     FileApplyFailed {
         idx: usize,
         message: String,
@@ -86,6 +93,18 @@ pub enum WorkerEvent {
     StoredTagsRead {
         idx: usize,
         view: StoredTagsView,
+    },
+
+    /// `-x` Find Max Amplitude result for `idx`. Light alternative to
+    /// `TrackAnalyzed`: only walks MP3 frame headers, no decoding.
+    MaxAmplitudeFound {
+        idx: usize,
+        peak: f64,
+        headroom_db: Option<f64>,
+    },
+    MaxAmplitudeFailed {
+        idx: usize,
+        message: String,
     },
 
     /// Undo succeeded on `idx`. Distinct from `FileApplied` so the UI can
@@ -151,6 +170,10 @@ pub struct ApplyOptionsUi {
     pub wrap: bool,
     pub preserve_timestamp: bool,
     pub use_id3v2: bool,
+    /// When true, Apply Track / Album Gain runs in dry-run mode: the worker
+    /// reports what `apply_with_options` *would* do but doesn't touch the
+    /// file. Equivalent to the CLI's -n flag.
+    pub dry_run: bool,
 }
 
 impl Default for ApplyOptionsUi {
@@ -163,6 +186,7 @@ impl Default for ApplyOptionsUi {
             wrap: false,
             preserve_timestamp: true,
             use_id3v2: false,
+            dry_run: false,
         }
     }
 }
@@ -346,10 +370,27 @@ pub fn spawn_apply(
             send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
             let opts = build_apply_options(job.steps, job.track_result, job.album_info, ui_opts);
-            match apply_with_options(&job.path, &opts) {
-                Ok(_) => {
+            let result = if ui_opts.dry_run {
+                predict_apply(&job.path, &opts)
+            } else {
+                apply_with_options(&job.path, &opts)
+            };
+            match result {
+                Ok(report) => {
                     applied += 1;
-                    send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                    if ui_opts.dry_run {
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplyDryRun {
+                                idx: job.idx,
+                                actual_steps: report.actual_steps,
+                                clipping_prevented: report.clipping_prevented,
+                            },
+                        );
+                    } else {
+                        send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                    }
                 }
                 Err(e) => {
                     errors += 1;
@@ -370,11 +411,16 @@ pub fn spawn_apply(
         } else {
             String::new()
         };
+        let verb = if ui_opts.dry_run {
+            "Dry-ran"
+        } else {
+            "Applied"
+        };
         send(
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!("Applied {} to {} file(s){}", action_label, applied, suffix),
+                message: format!("{} {} on {} file(s){}", verb, action_label, applied, suffix),
             },
         );
     });
@@ -452,6 +498,73 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
             &ctx,
             WorkerEvent::Done {
                 message: parts.join(", "),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+/// Spawn the max-amplitude scanner. Mirrors the CLI's `-x` /
+/// `cmd_max_amplitude`: walks MP3 frame headers (and AAC `global_gain`
+/// fields) to compute peak amplitude + headroom, no audio decoding,
+/// no ReplayGain machinery.
+pub fn spawn_find_max_amplitude(
+    ctx: egui::Context,
+    files: Vec<(usize, PathBuf)>,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let mut found = 0usize;
+        let mut errors = 0usize;
+        for (idx, path) in files {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx });
+
+            match mp3rgain::find_max_amplitude(&path) {
+                Ok(amp) => {
+                    found += 1;
+                    let peak = amp.max_amplitude();
+                    let headroom_db = mp3rgain::peak_to_headroom_db(peak);
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::MaxAmplitudeFound {
+                            idx,
+                            peak,
+                            headroom_db,
+                        },
+                    );
+                }
+                Err(e) => {
+                    errors += 1;
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::MaxAmplitudeFailed {
+                            idx,
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+        let suffix = if errors > 0 {
+            format!(", {} error(s)", errors)
+        } else {
+            String::new()
+        };
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: format!("Max amplitude scanned on {} file(s){}", found, suffix),
             },
         );
     });

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -11,9 +11,9 @@
 use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions};
 use mp3rgain::replaygain::{self, ReplayGainResult};
 use mp3rgain::{
-    id3v2, mp4meta, read_ape_tag_from_file, AacAlbumInfo, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
-    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
-    TAG_REPLAYGAIN_TRACK_PEAK,
+    id3v2, mp4meta, read_ape_tag_from_file, AacAlbumInfo, Channel, TAG_MP3GAIN_MINMAX,
+    TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
+    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -147,6 +147,8 @@ pub struct ApplyJob {
     pub steps: i32,
     pub track_result: Option<ReplayGainResult>,
     pub album_info: Option<AacAlbumInfo>,
+    /// Per-channel gain (`-l`). `None` means the gain hits all channels.
+    pub channel: Option<Channel>,
 }
 
 /// A single undo job.
@@ -375,7 +377,13 @@ pub fn spawn_apply(
             }
             send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-            let opts = build_apply_options(job.steps, job.track_result, job.album_info, ui_opts);
+            let opts = build_apply_options(
+                job.steps,
+                job.track_result,
+                job.album_info,
+                job.channel,
+                ui_opts,
+            );
             let result = if ui_opts.dry_run {
                 predict_apply(&job.path, &opts)
             } else {
@@ -780,14 +788,16 @@ fn build_apply_options(
     steps: i32,
     track_result: Option<ReplayGainResult>,
     album_info: Option<AacAlbumInfo>,
+    channel: Option<Channel>,
     ui_opts: ApplyOptionsUi,
 ) -> ApplyOptions {
     let mut opts = ApplyOptions::new(steps);
     opts.track_result = track_result;
     opts.album_info = album_info;
+    opts.channel = channel;
     // Always-on safety rails.
     opts.write_undo = true;
-    opts.write_replaygain_tags = true;
+    opts.write_replaygain_tags = channel.is_none();
     opts.use_temp_file = true;
     // User-toggleable.
     opts.prevent_clipping = ui_opts.prevent_clipping;

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -161,6 +161,12 @@ pub struct CheckTagsJob {
     pub path: PathBuf,
 }
 
+/// A single stored-tag deletion job.
+pub struct DeleteTagsJob {
+    pub idx: usize,
+    pub path: PathBuf,
+}
+
 /// User-facing apply toggles, captured at the moment the worker is
 /// spawned. Worker combines these with the per-job data to build the
 /// final `ApplyOptions`.
@@ -498,6 +504,88 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
             &ctx,
             WorkerEvent::Done {
                 message: parts.join(", "),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+/// Spawn the stored-tag deletion worker. Destructive: removes APE /
+/// ID3v2 RG / MP4 freeform RG+undo tags from each file in order.
+///
+/// Dispatch mirrors the CLI's `process_delete_tags`:
+///   - AAC: `mp4meta::delete_replaygain_tags` + `delete_undo_tags`
+///   - MP3 + `use_id3v2`: `mp3rgain::delete_id3v2_replaygain`
+///   - MP3 (default APE): `mp3rgain::delete_ape_tag`
+pub fn spawn_delete_tags(
+    ctx: egui::Context,
+    jobs: Vec<DeleteTagsJob>,
+    use_id3v2: bool,
+    preserve_timestamp: bool,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let mut deleted = 0usize;
+        let mut errors = 0usize;
+
+        for job in jobs {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+
+            let original_mtime = if preserve_timestamp {
+                read_mtime(&job.path)
+            } else {
+                None
+            };
+
+            let result = if mp4meta::is_aac_file(&job.path) {
+                mp4meta::delete_replaygain_tags(&job.path)
+                    .and_then(|()| mp4meta::delete_undo_tags(&job.path))
+            } else if use_id3v2 {
+                mp3rgain::delete_id3v2_replaygain(&job.path)
+            } else {
+                mp3rgain::delete_ape_tag(&job.path)
+            };
+
+            match result {
+                Ok(()) => {
+                    if let Some(m) = original_mtime {
+                        restore_mtime(&job.path, m);
+                    }
+                    deleted += 1;
+                    send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                }
+                Err(e) => {
+                    errors += 1;
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::FileApplyFailed {
+                            idx: job.idx,
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
+        let suffix = if errors > 0 {
+            format!(", {} error(s)", errors)
+        } else {
+            String::new()
+        };
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: format!("Deleted stored tags from {} file(s){}", deleted, suffix),
             },
         );
     });

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -10,13 +10,42 @@
 
 use mp3rgain::apply::{apply_with_options, ApplyOptions};
 use mp3rgain::replaygain::{self, ReplayGainResult};
-use mp3rgain::{mp4meta, AacAlbumInfo};
+use mp3rgain::{
+    id3v2, mp4meta, read_ape_tag_from_file, AacAlbumInfo, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
+    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
+    TAG_REPLAYGAIN_TRACK_PEAK,
+};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::thread;
 use std::time::SystemTime;
+
+/// Stored-tag snapshot for one file, populated by `spawn_check_stored_tags`.
+/// All fields are pre-formatted strings so the UI can render them verbatim.
+/// `None` means the tag was absent (not an error).
+#[derive(Default, Clone)]
+pub struct StoredTagsView {
+    pub format: Option<&'static str>,
+    pub track_gain: Option<String>,
+    pub track_peak: Option<String>,
+    pub album_gain: Option<String>,
+    pub album_peak: Option<String>,
+    pub undo: Option<String>,
+    pub minmax: Option<String>,
+}
+
+impl StoredTagsView {
+    pub fn is_empty(&self) -> bool {
+        self.track_gain.is_none()
+            && self.track_peak.is_none()
+            && self.album_gain.is_none()
+            && self.album_peak.is_none()
+            && self.undo.is_none()
+            && self.minmax.is_none()
+    }
+}
 
 /// One message from a worker thread to the UI thread.
 pub enum WorkerEvent {
@@ -49,6 +78,14 @@ pub enum WorkerEvent {
     FileApplyFailed {
         idx: usize,
         message: String,
+    },
+
+    /// Stored-tag scan completed for `idx`. `view` carries pre-formatted
+    /// strings; `view.is_empty()` distinguishes "no tags" from "all tags
+    /// read successfully and present".
+    StoredTagsRead {
+        idx: usize,
+        view: StoredTagsView,
     },
 
     /// Undo succeeded on `idx`. Distinct from `FileApplied` so the UI can
@@ -95,6 +132,12 @@ pub struct ApplyJob {
 
 /// A single undo job.
 pub struct UndoJob {
+    pub idx: usize,
+    pub path: PathBuf,
+}
+
+/// A single stored-tag scan job.
+pub struct CheckTagsJob {
     pub idx: usize,
     pub path: PathBuf,
 }
@@ -414,6 +457,97 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
     });
 
     WorkerHandle { rx, cancel }
+}
+
+/// Spawn the stored-tag scanner. Iterates files serially (tag reads are
+/// I/O-light) and emits `StoredTagsRead` for each.
+///
+/// Dispatch mirrors the CLI's `process_check_tags`:
+///   - AAC: MP4 freeform RG + undo
+///   - MP3 + `use_id3v2`: ID3v2 TXXX RG
+///   - MP3: APE
+pub fn spawn_check_stored_tags(
+    ctx: egui::Context,
+    jobs: Vec<CheckTagsJob>,
+    use_id3v2: bool,
+) -> WorkerHandle {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_w = Arc::clone(&cancel);
+
+    thread::spawn(move || {
+        let total = jobs.len();
+        for job in jobs {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+            let view = read_stored_tags(&job.path, use_id3v2);
+            send(
+                &tx,
+                &ctx,
+                WorkerEvent::StoredTagsRead {
+                    idx: job.idx,
+                    view,
+                },
+            );
+        }
+
+        send(
+            &tx,
+            &ctx,
+            WorkerEvent::Done {
+                message: format!("Checked stored tags for {} file(s)", total),
+            },
+        );
+    });
+
+    WorkerHandle { rx, cancel }
+}
+
+fn read_stored_tags(path: &Path, use_id3v2: bool) -> StoredTagsView {
+    if mp4meta::is_aac_file(path) {
+        let undo_tags = mp4meta::read_undo_tags(path).unwrap_or_default();
+        let rg_tags = mp4meta::read_replaygain_tags(path).unwrap_or_default();
+        return StoredTagsView {
+            format: Some("MP4"),
+            track_gain: rg_tags.track_gain().map(str::to_string),
+            track_peak: rg_tags.track_peak().map(str::to_string),
+            album_gain: rg_tags.album_gain().map(str::to_string),
+            album_peak: rg_tags.album_peak().map(str::to_string),
+            undo: undo_tags.undo().map(str::to_string),
+            minmax: undo_tags.minmax().map(str::to_string),
+        };
+    }
+    if use_id3v2 {
+        let rg = id3v2::read_id3v2_replaygain(path).unwrap_or_default();
+        return StoredTagsView {
+            format: Some("ID3v2"),
+            track_gain: rg.track_gain,
+            track_peak: rg.track_peak,
+            album_gain: rg.album_gain,
+            album_peak: rg.album_peak,
+            undo: rg.undo,
+            minmax: rg.minmax,
+        };
+    }
+    // APE
+    if let Ok(Some(tag)) = read_ape_tag_from_file(path) {
+        return StoredTagsView {
+            format: Some("APE"),
+            track_gain: tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string),
+            track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK).map(str::to_string),
+            album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN).map(str::to_string),
+            album_peak: tag.get(TAG_REPLAYGAIN_ALBUM_PEAK).map(str::to_string),
+            undo: tag.get(TAG_MP3GAIN_UNDO).map(str::to_string),
+            minmax: tag.get(TAG_MP3GAIN_MINMAX).map(str::to_string),
+        };
+    }
+    StoredTagsView {
+        format: Some("APE"),
+        ..Default::default()
+    }
 }
 
 fn run_undo(path: &Path, use_id3v2: bool) -> mp3rgain::error::Result<usize> {

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 #[cfg(feature = "aac")]
 use crate::aac;
 use crate::error::{Error, Result};
-use crate::gain::{db_to_steps, peak_to_headroom_db, steps_to_db, GainOptions, MAX_GAIN};
+use crate::gain::{db_to_steps, peak_to_headroom_db, steps_to_db, Channel, GainOptions, MAX_GAIN};
 use crate::replaygain::ReplayGainResult;
 use crate::{ape, id3v2, mp4meta};
 
@@ -87,6 +87,11 @@ pub struct ApplyOptions {
     /// `-s i`: MP3 only — use ID3v2 TXXX frames for undo and ReplayGain
     /// instead of APE.
     pub use_id3v2: bool,
+
+    /// `-l`: MP3 only — apply gain to a single channel (Stereo / Dual
+    /// Channel) instead of all channels. AAC has no per-channel apply
+    /// path; setting this on an AAC file is an error.
+    pub channel: Option<Channel>,
 }
 
 impl ApplyOptions {
@@ -104,6 +109,7 @@ impl ApplyOptions {
             write_undo: true,
             write_replaygain_tags: false,
             use_id3v2: false,
+            channel: None,
         }
     }
 }
@@ -150,6 +156,10 @@ pub enum ClippingDetection {
 /// 5. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
 pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
     let is_aac = mp4meta::is_aac_file(file_path);
+
+    if is_aac && opts.channel.is_some() {
+        return Err(Error::ChannelGainOnAac);
+    }
 
     let original_mtime = if opts.preserve_timestamp {
         std::fs::metadata(file_path)
@@ -324,10 +334,13 @@ fn apply_aac_bytes(_file_path: &Path, _steps: i32, _opts: &ApplyOptions) -> Resu
 
 fn apply_mp3_ape_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Result<usize> {
     with_temp_file(file_path, opts.use_temp_file, |r, w| {
-        GainOptions::new(steps)
+        let mut gain = GainOptions::new(steps)
             .wrap(opts.wrap)
-            .undo(opts.write_undo)
-            .apply_to_path(r, w)
+            .undo(opts.write_undo);
+        if let Some(ch) = opts.channel {
+            gain = gain.channel(ch);
+        }
+        gain.apply_to_path(r, w)
     })
 }
 
@@ -346,14 +359,26 @@ fn apply_mp3_id3v2_bytes(
     // APE undo is never written in `-s i` mode; the undo goes into a
     // TXXX:MP3GAIN_UNDO frame instead, written below.
     let modified = with_temp_file(file_path, opts.use_temp_file, |r, w| {
-        GainOptions::new(steps)
-            .wrap(opts.wrap)
-            .undo(false)
-            .apply_to_path(r, w)
+        let mut gain = GainOptions::new(steps).wrap(opts.wrap).undo(false);
+        if let Some(ch) = opts.channel {
+            gain = gain.channel(ch);
+        }
+        gain.apply_to_path(r, w)
     })?;
 
     if opts.write_undo {
-        write_id3v2_undo_after_apply(file_path, steps, steps, opts.wrap, mp3_analysis.as_ref())?;
+        let (delta_left, delta_right) = match opts.channel {
+            Some(Channel::Left) => (steps, 0),
+            Some(Channel::Right) => (0, steps),
+            None => (steps, steps),
+        };
+        write_id3v2_undo_after_apply(
+            file_path,
+            delta_left,
+            delta_right,
+            opts.wrap,
+            mp3_analysis.as_ref(),
+        )?;
     }
     Ok(modified)
 }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -219,6 +219,26 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     })
 }
 
+/// Dry-run companion to [`apply_with_options`]: runs the same clipping
+/// check (headroom-based or ReplayGain-peak based depending on `opts`)
+/// without touching the file. `report.modified` is always 0.
+///
+/// Frontends drive `-n` / a "Dry run" toggle through this so the
+/// "would apply N steps" message lines up with what a real apply
+/// would do.
+pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
+    let is_aac = mp4meta::is_aac_file(file_path);
+    let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
+    let (actual_steps, clipping_prevented, clipping_detected) =
+        check_clipping(file_path, opts, is_aac, &mut mp3_analysis)?;
+    Ok(ApplyReport {
+        modified: 0,
+        actual_steps,
+        clipping_prevented,
+        clipping_detected,
+    })
+}
+
 fn check_clipping(
     file_path: &Path,
     opts: &ApplyOptions,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     #[error("Cannot apply channel-specific gain to mono file. Use -g for mono files.")]
     ChannelGainOnMono,
 
+    #[error("Channel-specific gain is not supported for AAC/M4A files")]
+    ChannelGainOnAac,
+
     #[error("No APE tag found - cannot undo")]
     NoApeTag,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,9 @@ pub use ape::{
     TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN,
     TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
-pub use apply::{apply_with_options, AacAlbumInfo, ApplyOptions, ApplyReport, ClippingDetection};
+pub use apply::{
+    apply_with_options, predict_apply, AacAlbumInfo, ApplyOptions, ApplyReport, ClippingDetection,
+};
 pub use error::{Error, Result};
 pub use gain::{
     apply_gain, apply_gain_db, db_to_steps, peak_to_headroom_db, peak_to_pcm_sample, steps_to_db,

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::apply::{apply_with_options, ApplyOptions, ClippingDetection};
-use mp3rgain::{analyze, mp4meta, steps_to_db, Channel, GainOptions};
+use mp3rgain::{analyze, mp4meta, steps_to_db, Channel};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -9,9 +9,7 @@ use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
-use super::utils::{
-    restore_timestamp, save_original_mtime, warn_aac_multi_track, write_id3v2_undo_after_apply,
-};
+use super::utils::warn_aac_multi_track;
 
 pub fn process_apply(file: &Path, steps: i32, opts: &Options) -> Result<(JsonFileResult, String)> {
     let mut out = String::new();
@@ -278,8 +276,6 @@ fn process_apply_channel_into(
         }
     }
 
-    let original_mtime = save_original_mtime(file, opts);
-
     if opts.dry_run {
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
@@ -301,51 +297,22 @@ fn process_apply_channel_into(
         });
     }
 
-    let apply_result = if opts.use_id3v2 {
-        // Apply gain without APE undo, then write undo to ID3v2.
-        // Capture the pre-apply analysis so the undo write can reuse min/max
-        // without a second file scan (issue #135).
-        let pre_analysis = analyze(file).ok();
-        let result = GainOptions::new(steps)
-            .channel(channel)
-            .undo(false)
-            .apply(file);
-        if result.is_ok() {
-            let (delta_left, delta_right) = match channel {
-                Channel::Left => (steps, 0),
-                Channel::Right => (0, steps),
-                _ => unreachable!(),
-            };
-            write_id3v2_undo_after_apply(
-                file,
-                delta_left,
-                delta_right,
-                false,
-                pre_analysis.as_ref(),
-            )?;
-        }
-        result
-    } else {
-        GainOptions::new(steps)
-            .channel(channel)
-            .undo(true)
-            .apply(file)
-    };
+    let mut apply_opts = ApplyOptions::new(steps);
+    apply_opts.channel = Some(channel);
+    apply_opts.preserve_timestamp = opts.preserve_timestamp;
+    apply_opts.use_temp_file = opts.use_temp_file;
+    apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
+    apply_opts.use_id3v2 = opts.use_id3v2;
 
-    match apply_result {
-        Ok(frames) => {
-            // Restore timestamp if needed
-            if let Some(mtime) = original_mtime {
-                restore_timestamp(file, mtime);
-            }
-
+    match apply_with_options(file, &apply_opts) {
+        Ok(report) => {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(
                     out,
                     "  {} {} ({} frames, {} channel)",
                     "v".green(),
                     filename,
-                    frames,
+                    report.modified,
                     channel_name
                 )?;
             }
@@ -353,7 +320,7 @@ fn process_apply_channel_into(
             Ok(JsonFileResult {
                 file: file.display().to_string(),
                 status: Some(FileStatus::Success),
-                frames: Some(frames),
+                frames: Some(report.modified),
                 gain_applied_steps: Some(steps),
                 gain_applied_db: Some(steps_to_db(steps)),
                 ..Default::default()

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
 use colored::*;
-use mp3rgain::{analyze, ape, id3v2, mp4meta, Mp3Analysis};
+use mp3rgain::mp4meta;
 use std::path::Path;
 use std::time::SystemTime;
 
@@ -19,42 +18,6 @@ pub fn save_original_mtime(file: &Path, opts: &Options) -> Option<SystemTime> {
     } else {
         None
     }
-}
-
-/// Write ID3v2 undo metadata after a gain has been applied.
-///
-/// Reads the existing undo values, accumulates the deltas, and writes the
-/// combined left/right values back as a TXXX:MP3GAIN_UNDO frame along with
-/// the supplied min/max global_gain (`analysis` is taken pre-apply so callers
-/// can reuse the result they already have, avoiding a redundant file read).
-pub fn write_id3v2_undo_after_apply(
-    file: &Path,
-    delta_left: i32,
-    delta_right: i32,
-    wrap: bool,
-    analysis: Option<&Mp3Analysis>,
-) -> Result<()> {
-    let existing_rg = id3v2::read_id3v2_replaygain(file).unwrap_or_default();
-    let (existing_left, existing_right) = ape::parse_undo_values(existing_rg.undo.as_deref());
-
-    let owned;
-    let (min, max) = match analysis {
-        Some(a) => (a.min_gain(), a.max_gain()),
-        None => {
-            owned = analyze(file)?;
-            (owned.min_gain(), owned.max_gain())
-        }
-    };
-
-    id3v2::write_id3v2_undo(
-        file,
-        existing_left + delta_left,
-        existing_right + delta_right,
-        wrap,
-        min,
-        max,
-    )?;
-    Ok(())
 }
 
 pub fn warn_aac_multi_track(file: &Path, filename: &str, opts: &Options, dry_run_prefix: &str) {


### PR DESCRIPTION
## Summary

Closes the Step 5 punch list from #153 — every CLI flag that didn't already have a GUI counterpart now has one. Six small commits, each scoped to one feature.

### What's new in the GUI

- **`-u` Undo** — Modify Gain menu: "Undo Selected" / "Undo All". Dispatches to AAC / ID3v2 / APE library calls based on Use ID3v2 toggle. Mtime preserved when the option is on.
- **`-s c` Check Stored Tags** — Analysis menu. Reads existing RG / undo tags from every file on a worker thread; results appear in a new "Stored RG" column with full per-tag breakdown on hover.
- **`-n` Dry Run** — Options panel toggle. Apply Track / Album Gain go through the new `mp3rgain::predict_apply` library entry; the Status column shows "Dry run: +N steps" (with "(capped)" appended when -k would cut).
- **`-x` Find Max Amplitude** — Analysis menu. Lighter than Track Analysis: walks frame headers, no decoding. Results populate Volume + Clip columns.
- **`-s d` Delete Stored Tags** — Modify Gain menu, gated by a center-anchored confirmation modal (destructive).
- **`-g` Apply Manual Gain** — Modify Gain menu opens a modal with a Steps drag value and live "= X.X dB" preview.
- **`-l` Apply Channel Gain** — Modify Gain menu opens a Left / Right + Steps modal. MP3-only; AAC entries are filtered from the worker job list.

### Library / CLI changes that fell out

- `ApplyOptions` gains a `channel: Option<Channel>` field, and `apply_with_options` is now the single entry point for MP3 channel gain (CLI `process_apply_channel` was rewritten on top of it). That lets the duplicate `write_id3v2_undo_after_apply` helper in `processors/utils.rs` go away.
- New `mp3rgain::predict_apply` is the dry-run companion to `apply_with_options`; same clipping check, no file writes.
- New `Error::ChannelGainOnAac` for the AAC + `-l` combination.


### Selection shortcuts (added in 470078d)

- **Cmd+A / Ctrl+A** — select all loaded files
- **Esc** — clear selection (no-op while a modal is open)
- **Shift+click** — range-select from the anchor; **Shift+Cmd/Ctrl+click** adds the range to the existing selection. Plain and Cmd/Ctrl-toggle clicks update the anchor; Shift+click does not (matches Finder).
### Intentionally **not** done

- `-s r` Recalc — current Track / Album Analysis already overwrites prior values, so the CLI mode has no separate GUI counterpart.
- `-j` Threads — `replaygain::analyze_album_lenient_parallel_with_completion` already auto-tunes via `available_parallelism`; no UI knob.

## Test plan

- [x] `cargo test --all-features` — 96/96 library + integration tests pass.
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] **GUI manual (recommended on real files):**
  - [x] Undo: Apply Track Gain on an MP3 + an M4A, then Undo Selected → both files round-trip to byte-identical content.
  - [ ] Check Stored Tags: hover the Stored RG cell — full tag dump is visible.
  - [ ] Dry run: toggle on, hit Apply Track Gain → Status column reads "Dry run: +N steps" and the file mtime is unchanged.
  - [ ] Find Max Amplitude: Volume column populates with `+X.X` headroom values.
  - [ ] Delete Stored Tags: Cancel button leaves files untouched; Delete button removes APE / ID3v2 / MP4 tags depending on container.
  - [x] Apply Manual Gain: -2 steps → file gets -3 dB; status reads Done.
  - [x] Apply Channel Gain: Left only, +3 steps → ID3v2 undo records `+003,+000,N` on next Check Stored Tags.


Closes #153.

