### PR TITLE
Fix #160: refresh table values after Apply Gain (no rescan needed)

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -800,11 +800,17 @@ impl Mp3rgainApp {
             WorkerEvent::AlbumAnalysisFailed(msg) => {
                 self.status_message = format!("Album analysis failed: {}", msg);
             }
-            WorkerEvent::FileApplied { idx } => {
+            WorkerEvent::FileApplied { idx, actual_steps } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Done;
                     // File contents changed; cached tag snapshot is stale.
                     file.stored_tags = None;
+                    // Shift the displayed volume / gain columns by the gain
+                    // that was actually written so the user sees the
+                    // post-apply state without rescanning (issue #160).
+                    if actual_steps != 0 {
+                        Self::shift_displayed_values(file, actual_steps);
+                    }
                 }
             }
             WorkerEvent::FileApplyDryRun {
@@ -901,6 +907,41 @@ impl Mp3rgainApp {
     fn would_clip(peak: f64, gain_db: f64) -> bool {
         let gain_linear = 10.0_f64.powf(gain_db / 20.0);
         peak * gain_linear > 1.0
+    }
+
+    /// Shift the row's cached display values by the dB that was actually
+    /// applied. Lets the user see the post-apply state without rerunning
+    /// analysis (issue #160). Subsequent prevent-clipping checks still
+    /// consult the pre-apply `track_result.peak`; that is left as a noted
+    /// approximation — re-analysis after apply gives the exact peak.
+    fn shift_displayed_values(file: &mut FileEntry, actual_steps: i32) {
+        let db_applied = mp3rgain::steps_to_db(actual_steps);
+        let gain_linear = 10.0_f64.powf(db_applied / 20.0);
+
+        if let Some(v) = file.volume {
+            file.volume = Some(v + db_applied);
+        }
+        if let Some(g) = file.track_gain {
+            file.track_gain = Some(g - db_applied);
+        }
+        if let Some(v) = file.album_volume {
+            file.album_volume = Some(v + db_applied);
+        }
+        if let Some(g) = file.album_gain {
+            file.album_gain = Some(g - db_applied);
+        }
+        if let Some(track) = file.track_result.as_ref() {
+            let new_peak = track.peak() * gain_linear;
+            file.clipping = new_peak >= 1.0;
+            file.track_clip = file
+                .track_gain
+                .map(|g| new_peak * 10.0_f64.powf(g / 20.0) > 1.0)
+                .unwrap_or(false);
+            file.album_clip = file
+                .album_gain
+                .map(|g| new_peak * 10.0_f64.powf(g / 20.0) > 1.0)
+                .unwrap_or(false);
+        }
     }
 }
 

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -72,8 +72,14 @@ pub enum WorkerEvent {
     },
     AlbumAnalysisFailed(String),
 
+    /// Apply succeeded for `idx`. `actual_steps` is what `apply_with_options`
+    /// actually wrote (may differ from the requested steps when prevent_clipping
+    /// capped the gain). The UI uses it to refresh the row's volume / gain
+    /// columns in place, so the user sees the post-apply numbers without
+    /// having to re-analyze (issue #160).
     FileApplied {
         idx: usize,
+        actual_steps: i32,
     },
     /// Dry-run analog of `FileApplied`: predict_apply succeeded, no bytes
     /// changed. UI shows "Would apply N steps" in the row status.
@@ -403,7 +409,14 @@ pub fn spawn_apply(
                             },
                         );
                     } else {
-                        send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplied {
+                                idx: job.idx,
+                                actual_steps: report.actual_steps,
+                            },
+                        );
                     }
                 }
                 Err(e) => {
@@ -568,7 +581,17 @@ pub fn spawn_delete_tags(
                         restore_mtime(&job.path, m);
                     }
                     deleted += 1;
-                    send(&tx, &ctx, WorkerEvent::FileApplied { idx: job.idx });
+                    // Tag deletion doesn't change audio levels, so the row's
+                    // volume/gain columns stay valid — pass 0 steps so the UI
+                    // doesn't shift them.
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::FileApplied {
+                            idx: job.idx,
+                            actual_steps: 0,
+                        },
+                    );
                 }
                 Err(e) => {
                     errors += 1;


### PR DESCRIPTION
Fixes #160.

## Cause

After Apply Track / Album / Manual / Channel Gain succeeded, the row's
status flipped to **Done** but the Volume and Gain columns kept showing
the pre-apply numbers. The only way to see the new state was to re-run
Track / Album Analysis.

## Fix

Carry the actually-applied step count (\`ApplyReport::actual_steps\`,
which already accounts for prevent-clipping caps) through
\`WorkerEvent::FileApplied\` and shift the row's cached display values by
that delta:

- \`volume += steps_to_db(actual_steps)\`
- \`track_gain -= steps_to_db(actual_steps)\` (gain still needed to hit target — now 0 after a normal apply)
- \`album_volume / album_gain\` analogously
- \`clipping\` / \`track_clip\` / \`album_clip\` recomputed from the post-apply peak

The cached \`track_result\` is left as-is — the displayed values are now
authoritative for the row, and a re-analysis is still the correct path
if the user wants exact post-apply RG numbers.

Tag-deletion still emits \`FileApplied\` (so the row shows Done) but with
\`actual_steps = 0\` since deleting tags doesn't change audio levels.

## Test plan
- [x] \`cargo test --lib\` — 34 passed
- [x] \`cargo fmt\` clean
- [x] CLI and GUI both build
- [x] Manually verify in the GUI on files from \`/Volumes/JPHFA/Music/Crossfader Music Pack\`