### PR TITLE
Fix #159: treat each folder as a separate album in Album Analysis

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -69,6 +69,11 @@ pub struct FileEntry {
     /// for the peak-based clipping check and for writing
     /// `replaygain_track_*` tags on apply.
     pub track_result: Option<ReplayGainResult>,
+    /// Album-level ReplayGain summary for the folder this file belongs to,
+    /// populated by Album Analysis. Used to write `replaygain_album_*` tags
+    /// on Apply Album Gain. Per-file (not global) so adding multiple folders
+    /// treats each as its own album (issue #159).
+    pub album_info: Option<AacAlbumInfo>,
     /// Pre-existing ReplayGain / undo tags read from the file, populated by
     /// the "Check Stored Tags" action. `None` = not scanned yet.
     pub stored_tags: Option<StoredTagsView>,
@@ -356,6 +361,7 @@ impl Mp3rgainApp {
         self.album_info = None;
         for file in &mut self.files {
             file.status = FileStatus::Pending;
+            file.album_info = None;
         }
 
         let jobs: Vec<(usize, PathBuf)> = self
@@ -382,18 +388,30 @@ impl Mp3rgainApp {
         self.album_info = None;
         for file in &mut self.files {
             file.status = FileStatus::Pending;
+            file.album_info = None;
         }
 
-        let jobs: Vec<(usize, PathBuf)> = self
-            .files
-            .iter()
-            .enumerate()
-            .map(|(i, f)| (i, f.path.clone()))
-            .collect();
+        // Group by parent directory so each folder is treated as its own
+        // album, matching classic MP3GainGUI behavior (issue #159). Files
+        // without a parent (e.g. root paths) fall back to a single anonymous
+        // group keyed by empty string.
+        let mut groups: std::collections::BTreeMap<PathBuf, Vec<(usize, PathBuf)>> =
+            std::collections::BTreeMap::new();
+        for (i, f) in self.files.iter().enumerate() {
+            let parent = f
+                .path
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(PathBuf::new);
+            groups.entry(parent).or_default().push((i, f.path.clone()));
+        }
+        let group_jobs: Vec<Vec<(usize, PathBuf)>> = groups.into_values().collect();
+        let total: usize = group_jobs.iter().map(|g| g.len()).sum();
+
         self.begin_worker(
             WorkerKind::AlbumAnalysis,
-            jobs.len(),
-            worker::spawn_album_analysis(ctx.clone(), jobs),
+            total,
+            worker::spawn_album_analysis(ctx.clone(), group_jobs),
         );
     }
 
@@ -648,7 +666,8 @@ impl Mp3rgainApp {
             return;
         }
 
-        let album_info = self.album_info;
+        // Use the per-file album_info (issue #159) so files from different
+        // folders get the album RG tags computed for their own album.
         let jobs: Vec<ApplyJob> = self
             .files
             .iter()
@@ -659,7 +678,7 @@ impl Mp3rgainApp {
                     path: f.path.clone(),
                     steps: db_to_steps(gain_db),
                     track_result: f.track_result.clone(),
-                    album_info,
+                    album_info: f.album_info,
                     channel: None,
                 })
             })
@@ -785,6 +804,7 @@ impl Mp3rgainApp {
                         file.album_volume = Some(album_volume);
                         file.album_gain = Some(album_gain);
                         file.album_clip = album_clip;
+                        file.album_info = Some(album_info);
                         file.status = FileStatus::Analyzed;
                     }
                 }
@@ -795,6 +815,10 @@ impl Mp3rgainApp {
                     }
                 }
 
+                // Keep the last group's summary as the legacy global field.
+                // Per-file album_info above is now the source of truth for
+                // Apply Album Gain (issue #159); this assignment is kept so
+                // any code still reading the global sees a consistent value.
                 self.album_info = Some(album_info);
             }
             WorkerEvent::AlbumAnalysisFailed(msg) => {

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -252,103 +252,130 @@ pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) ->
 /// Spawn the album-analysis worker. Uses the parallel variant from the
 /// library (auto thread count) and reports per-file completion via the
 /// `on_complete` callback.
+/// Spawn an album-analysis worker for one or more groups of files.
+///
+/// Each inner Vec is treated as its own album, so loading files from
+/// multiple folders no longer collapses them into a single album with
+/// the wrong gain (issue #159). Groups are analyzed sequentially; the
+/// per-group call still fans out across cores via the library's
+/// rayon-backed parallel analyzer, so a single-group invocation is
+/// behavior-identical to the pre-fix code.
 pub fn spawn_album_analysis(
     ctx: egui::Context,
-    indexed_paths: Vec<(usize, PathBuf)>,
+    groups: Vec<Vec<(usize, PathBuf)>>,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let paths: Vec<PathBuf> = indexed_paths.iter().map(|(_, p)| p.clone()).collect();
-        let original_indices: Vec<usize> = indexed_paths.iter().map(|(i, _)| *i).collect();
-
-        let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+        let group_count = groups.len();
         let threads = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1);
 
-        let tx_cb = tx.clone();
-        let ctx_cb = ctx.clone();
-        let indices_cb = original_indices.clone();
-        let cancel_cb = Arc::clone(&cancel_w);
-        let on_complete = move |idx_in_paths: usize, _path: &Path| {
-            // Cancellation is best-effort: parallel analysis can't be
-            // interrupted mid-file, but we can suppress further repaints
-            // and final events.
-            if cancel_cb.load(Ordering::Relaxed) {
+        let mut analyzed_total = 0usize;
+        let mut skipped_total = 0usize;
+        let mut error_groups = 0usize;
+
+        for group in groups {
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
                 return;
             }
-            if let Some(&original_idx) = indices_cb.get(idx_in_paths) {
-                let _ = tx_cb.send(WorkerEvent::FileStart { idx: original_idx });
-                ctx_cb.request_repaint();
+            if group.is_empty() {
+                continue;
             }
+
+            let paths: Vec<PathBuf> = group.iter().map(|(_, p)| p.clone()).collect();
+            let original_indices: Vec<usize> = group.iter().map(|(i, _)| *i).collect();
+            let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+
+            let tx_cb = tx.clone();
+            let ctx_cb = ctx.clone();
+            let indices_cb = original_indices.clone();
+            let cancel_cb = Arc::clone(&cancel_w);
+            let on_complete = move |idx_in_paths: usize, _path: &Path| {
+                if cancel_cb.load(Ordering::Relaxed) {
+                    return;
+                }
+                if let Some(&original_idx) = indices_cb.get(idx_in_paths) {
+                    let _ = tx_cb.send(WorkerEvent::FileStart { idx: original_idx });
+                    ctx_cb.request_repaint();
+                }
+            };
+
+            let result = replaygain::analyze_album_lenient_parallel_with_completion(
+                &path_refs,
+                None,
+                threads,
+                &on_complete,
+            );
+
+            if cancel_w.load(Ordering::Relaxed) {
+                send(&tx, &ctx, WorkerEvent::Cancelled);
+                return;
+            }
+
+            match result {
+                Ok(report) => {
+                    let successful: Vec<(usize, ReplayGainResult)> = report
+                        .successful_indices
+                        .iter()
+                        .zip(report.album.tracks().iter())
+                        .map(|(&pos, track)| (original_indices[pos], track.clone()))
+                        .collect();
+                    let failures: Vec<(usize, String)> = report
+                        .failures
+                        .iter()
+                        .map(|(pos, msg)| (original_indices[*pos], msg.clone()))
+                        .collect();
+                    let album_info = AacAlbumInfo {
+                        album_gain_db: report.album.album_gain_db(),
+                        album_peak: report.album.album_peak(),
+                    };
+                    analyzed_total += successful.len();
+                    skipped_total += failures.len();
+
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::AlbumAnalysisDone {
+                            successful,
+                            failures,
+                            album_info,
+                        },
+                    );
+                }
+                Err(e) => {
+                    error_groups += 1;
+                    send(&tx, &ctx, WorkerEvent::AlbumAnalysisFailed(e.to_string()));
+                }
+            }
+        }
+
+        let message = match (group_count, error_groups) {
+            (1, 0) if skipped_total == 0 => {
+                format!("Album analysis complete ({} tracks)", analyzed_total)
+            }
+            (1, 0) => format!(
+                "Album analysis complete ({} tracks, {} skipped)",
+                analyzed_total, skipped_total
+            ),
+            (_, 0) if skipped_total == 0 => format!(
+                "Album analysis complete ({} albums, {} tracks)",
+                group_count, analyzed_total
+            ),
+            (_, 0) => format!(
+                "Album analysis complete ({} albums, {} tracks, {} skipped)",
+                group_count, analyzed_total, skipped_total
+            ),
+            (_, n) => format!(
+                "Album analysis: {} tracks analyzed, {} skipped, {} album(s) failed",
+                analyzed_total, skipped_total, n
+            ),
         };
-
-        let result = replaygain::analyze_album_lenient_parallel_with_completion(
-            &path_refs,
-            None,
-            threads,
-            &on_complete,
-        );
-
-        if cancel_w.load(Ordering::Relaxed) {
-            send(&tx, &ctx, WorkerEvent::Cancelled);
-            return;
-        }
-
-        match result {
-            Ok(report) => {
-                let successful: Vec<(usize, ReplayGainResult)> = report
-                    .successful_indices
-                    .iter()
-                    .zip(report.album.tracks().iter())
-                    .map(|(&pos, track)| (original_indices[pos], track.clone()))
-                    .collect();
-                let failures: Vec<(usize, String)> = report
-                    .failures
-                    .iter()
-                    .map(|(pos, msg)| (original_indices[*pos], msg.clone()))
-                    .collect();
-                let album_info = AacAlbumInfo {
-                    album_gain_db: report.album.album_gain_db(),
-                    album_peak: report.album.album_peak(),
-                };
-                let analyzed = successful.len();
-                let skipped = failures.len();
-
-                send(
-                    &tx,
-                    &ctx,
-                    WorkerEvent::AlbumAnalysisDone {
-                        successful,
-                        failures,
-                        album_info,
-                    },
-                );
-
-                let message = if skipped > 0 {
-                    format!(
-                        "Album analysis complete ({} tracks, {} skipped)",
-                        analyzed, skipped
-                    )
-                } else {
-                    format!("Album analysis complete ({} tracks)", analyzed)
-                };
-                send(&tx, &ctx, WorkerEvent::Done { message });
-            }
-            Err(e) => {
-                send(&tx, &ctx, WorkerEvent::AlbumAnalysisFailed(e.to_string()));
-                send(
-                    &tx,
-                    &ctx,
-                    WorkerEvent::Done {
-                        message: format!("Album analysis failed: {}", e),
-                    },
-                );
-            }
-        }
+        send(&tx, &ctx, WorkerEvent::Done { message });
     });
 
     WorkerHandle { rx, cancel }


### PR DESCRIPTION
Fixes #159.

## Cause

Album Analysis collapsed every loaded file into one big album, so when
the user added tracks from multiple folders the album gain came out
wrong for every track. The classic MP3GainGUI treats each folder as its
own album.

## Fix

\`start_analyze_album\` now groups files by parent directory (BTreeMap
keyed by \`Path::parent\`) and hands a \`Vec<Vec<(usize, PathBuf)>>\` to
\`spawn_album_analysis\`. The worker iterates the groups sequentially,
each one going through \`analyze_album_lenient_parallel_with_completion\`,
and emits a separate \`AlbumAnalysisDone\` per group. \`FileEntry\` grows a
new \`album_info: Option<AacAlbumInfo>\` field so each file remembers the
album summary for its own folder, and \`start_apply_album_gain\` reads
that per-file instead of the global \`self.album_info\`.

Single-folder behavior is unchanged (one group → one AlbumAnalysisDone).

## Test plan
- [x] \`cargo test --lib\` — 34 passed
- [x] \`cargo fmt\` clean
- [x] CLI and GUI both build
- [ ] Manually verify with two folders from \`/Volumes/JPHFA/Music/Crossfader Music Pack\` that each folder gets its own album gain