### PR TITLE
GUI: Sortable table columns (#167)

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -126,6 +126,17 @@ pub enum ClickMode {
     RangeAdd,
 }
 
+/// Which table column the rows are currently sorted by (issue #167).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortColumn {
+    Filename,
+    Volume,
+    TrackGain,
+    AlbumVolume,
+    AlbumGain,
+    Status,
+}
+
 /// What kind of work the active worker is doing — drives messaging and
 /// final-event handling.
 #[derive(Clone, Copy, PartialEq)]
@@ -186,6 +197,11 @@ pub struct Mp3rgainApp {
     /// `recompute_targets_if_changed` to detect Target edits and refresh
     /// the gain columns without rerunning analysis (issue #161 item 1).
     last_target_volume: f64,
+
+    /// Active sort column, or `None` for insertion order (issue #167).
+    pub sort_column: Option<SortColumn>,
+    /// Direction of the active sort. Ignored when `sort_column` is `None`.
+    pub sort_descending: bool,
 }
 
 impl Mp3rgainApp {
@@ -208,7 +224,51 @@ impl Mp3rgainApp {
             started_files: 0,
             total_files_in_job: 0,
             last_target_volume: 89.0,
+            sort_column: None,
+            sort_descending: false,
         }
+    }
+
+    /// Toggle the sort state when the given header is clicked. First click on
+    /// a column sorts ascending; subsequent clicks cycle desc → unsorted.
+    pub fn toggle_sort(&mut self, column: SortColumn) {
+        match self.sort_column {
+            Some(active) if active == column => {
+                if !self.sort_descending {
+                    self.sort_descending = true;
+                } else {
+                    self.sort_column = None;
+                    self.sort_descending = false;
+                }
+            }
+            _ => {
+                self.sort_column = Some(column);
+                self.sort_descending = false;
+            }
+        }
+    }
+
+    /// Indices into `self.files` in current display (sort) order. Returned
+    /// fresh every call — cheap relative to the per-frame render cost.
+    pub fn compute_display_order(&self) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..self.files.len()).collect();
+        let Some(col) = self.sort_column else {
+            return order;
+        };
+        let desc = self.sort_descending;
+        order.sort_by(|&a, &b| {
+            let fa = &self.files[a];
+            let fb = &self.files[b];
+            match col {
+                SortColumn::Filename => cmp_str(&fa.filename, &fb.filename, desc),
+                SortColumn::Volume => cmp_opt_f64(fa.volume, fb.volume, desc),
+                SortColumn::TrackGain => cmp_opt_f64(fa.track_gain, fb.track_gain, desc),
+                SortColumn::AlbumVolume => cmp_opt_f64(fa.album_volume, fb.album_volume, desc),
+                SortColumn::AlbumGain => cmp_opt_f64(fa.album_gain, fb.album_gain, desc),
+                SortColumn::Status => cmp_str(&fa.status.label(), &fb.status.label(), desc),
+            }
+        });
+        order
     }
 
     /// Detect Target edits and shift each row's track_gain / album_gain by
@@ -355,27 +415,37 @@ impl Mp3rgainApp {
             }
             ClickMode::Range => {
                 let anchor = self.selection_anchor.unwrap_or(idx);
-                let (lo, hi) = if anchor <= idx {
-                    (anchor, idx)
-                } else {
-                    (idx, anchor)
-                };
-                self.selected_indices = (lo..=hi).collect();
+                // Range must follow visible (display) order so that a sorted
+                // table still extends "between these two visible rows"
+                // (issue #167).
+                self.selected_indices = self.range_in_display_order(anchor, idx);
                 // Anchor stays put.
             }
             ClickMode::RangeAdd => {
                 let anchor = self.selection_anchor.unwrap_or(idx);
-                let (lo, hi) = if anchor <= idx {
-                    (anchor, idx)
-                } else {
-                    (idx, anchor)
-                };
-                for i in lo..=hi {
+                for i in self.range_in_display_order(anchor, idx) {
                     if !self.selected_indices.contains(&i) {
                         self.selected_indices.push(i);
                     }
                 }
             }
+        }
+    }
+
+    /// File indices spanning the visible range between two file indices,
+    /// inclusive. The two endpoints are translated to display positions via
+    /// `compute_display_order`, the inclusive range is collected in display
+    /// order, then mapped back to file indices.
+    fn range_in_display_order(&self, anchor: usize, idx: usize) -> Vec<usize> {
+        let order = self.compute_display_order();
+        let anchor_pos = order.iter().position(|&i| i == anchor);
+        let idx_pos = order.iter().position(|&i| i == idx);
+        match (anchor_pos, idx_pos) {
+            (Some(a), Some(b)) => {
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                order[lo..=hi].to_vec()
+            }
+            _ => vec![idx],
         }
     }
 
@@ -458,7 +528,10 @@ impl Mp3rgainApp {
                     .parent()
                     .map(|p| p.to_path_buf())
                     .unwrap_or_else(PathBuf::new);
-                groups.entry(parent).or_default().push((idx, f.path.clone()));
+                groups
+                    .entry(parent)
+                    .or_default()
+                    .push((idx, f.path.clone()));
             }
         }
         let group_jobs: Vec<Vec<(usize, PathBuf)>> = groups.into_values().collect();
@@ -1026,6 +1099,43 @@ impl Mp3rgainApp {
                 .map(|g| new_peak * 10.0_f64.powf(g / 20.0) > 1.0)
                 .unwrap_or(false);
         }
+    }
+}
+
+/// Compare two `Option<f64>` values, putting `None` always at the bottom
+/// regardless of direction (spreadsheet-style empty-cell handling).
+fn cmp_opt_f64(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (Some(x), Some(y)) => {
+            let o = x.partial_cmp(&y).unwrap_or(Ordering::Equal);
+            if desc {
+                o.reverse()
+            } else {
+                o
+            }
+        }
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+/// Case-insensitive string compare with empty-strings-last semantics.
+fn cmp_str(a: &str, b: &str, desc: bool) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a.is_empty(), b.is_empty()) {
+        (false, false) => {
+            let o = a.to_lowercase().cmp(&b.to_lowercase());
+            if desc {
+                o.reverse()
+            } else {
+                o
+            }
+        }
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        (true, true) => Ordering::Equal,
     }
 }
 

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -1,4 +1,4 @@
-use crate::app::{ClickMode, Mp3rgainApp};
+use crate::app::{ClickMode, Mp3rgainApp, SortColumn};
 use crate::worker::StoredTagsView;
 
 /// Render the "Stored RG" column for one row.
@@ -34,7 +34,41 @@ fn render_stored_tags_cell(ui: &mut egui::Ui, tags: Option<&StoredTagsView>) {
     });
 }
 
+/// Clickable sort-header. Shows ▴ / ▾ on the active column and toggles
+/// `app.sort_column` / `app.sort_descending` on click (issue #167).
+/// `hover_text` is the tooltip shown when the header is hovered; pass an
+/// empty string for the default "Click to sort" hint.
+fn sort_header(
+    ui: &mut egui::Ui,
+    app: &mut Mp3rgainApp,
+    label: &str,
+    column: SortColumn,
+    hover_text: &str,
+) {
+    let active = app.sort_column == Some(column);
+    let arrow = if active {
+        if app.sort_descending {
+            " ▾"
+        } else {
+            " ▴"
+        }
+    } else {
+        ""
+    };
+    let text = egui::RichText::new(format!("{}{}", label, arrow)).strong();
+    let resp = ui.add(egui::Button::new(text).frame(false));
+    let resp = if hover_text.is_empty() {
+        resp.on_hover_text("Click to sort")
+    } else {
+        resp.on_hover_text(hover_text)
+    };
+    if resp.clicked() {
+        app.toggle_sort(column);
+    }
+}
+
 pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
+    let display_order = app.compute_display_order();
     egui::ScrollArea::both().show(ui, |ui| {
         egui_extras::TableBuilder::new(ui)
             .striped(true)
@@ -52,28 +86,33 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
             .column(egui_extras::Column::remainder()) // Status
             .header(20.0, |mut header| {
                 header.col(|ui| {
-                    ui.strong("Path/File");
+                    sort_header(ui, app, "Path/File", SortColumn::Filename, "");
                 });
                 header.col(|ui| {
-                    ui.strong("Volume").on_hover_text(
+                    sort_header(
+                        ui,
+                        app,
+                        "Volume",
+                        SortColumn::Volume,
                         "Track Analysis: current loudness relative to ReplayGain reference (89 dB). \
-                         Find Max Amplitude: available headroom in dB before clipping.",
+                         Find Max Amplitude: available headroom in dB before clipping. \
+                         Click to sort.",
                     );
                 });
                 header.col(|ui| {
                     ui.strong("Clip");
                 });
                 header.col(|ui| {
-                    ui.strong("Track Gain");
+                    sort_header(ui, app, "Track Gain", SortColumn::TrackGain, "");
                 });
                 header.col(|ui| {
                     ui.strong("Clip(T)");
                 });
                 header.col(|ui| {
-                    ui.strong("Album Vol");
+                    sort_header(ui, app, "Album Vol", SortColumn::AlbumVolume, "");
                 });
                 header.col(|ui| {
-                    ui.strong("Album Gain");
+                    sort_header(ui, app, "Album Gain", SortColumn::AlbumGain, "");
                 });
                 header.col(|ui| {
                     ui.strong("Clip(A)");
@@ -86,7 +125,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                     );
                 });
                 header.col(|ui| {
-                    ui.strong("Status");
+                    sort_header(ui, app, "Status", SortColumn::Status, "");
                 });
             })
             .body(|mut body| {
@@ -96,7 +135,10 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                 // the loop.
                 let mut pending_click: Option<(usize, ClickMode)> = None;
                 let mut pending_reveal: Option<std::path::PathBuf> = None;
-                for (idx, file) in app.files.iter().enumerate() {
+                for &idx in &display_order {
+                    let Some(file) = app.files.get(idx) else {
+                        continue;
+                    };
                     let is_selected = app.selected_indices.contains(&idx);
                     body.row(18.0, |mut row| {
                         row.set_selected(is_selected);

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -456,7 +456,11 @@ pub fn spawn_apply(
     thread::spawn(move || {
         let total = jobs.len();
         if total == 0 {
-            let verb = if ui_opts.dry_run { "Dry-ran" } else { "Applied" };
+            let verb = if ui_opts.dry_run {
+                "Dry-ran"
+            } else {
+                "Applied"
+            };
             send(
                 &tx,
                 &ctx,
@@ -554,7 +558,11 @@ pub fn spawn_apply(
         } else {
             String::new()
         };
-        let verb = if ui_opts.dry_run { "Dry-ran" } else { "Applied" };
+        let verb = if ui_opts.dry_run {
+            "Dry-ran"
+        } else {
+            "Applied"
+        };
         send(
             &tx,
             &ctx,


### PR DESCRIPTION
## Summary

Closes #167 — implements Boyd's GUI improvement #2 (item 2 of #161).

- Clicking a column header toggles ascending → descending → unsorted.
- Sortable columns: Path/File, Volume, Track Gain, Album Vol, Album Gain, Status.
- Active sort column shows a ▴ / ▾ arrow.
- Empty cells (`None` numeric values, empty status) always sort to the bottom regardless of direction (spreadsheet-style).
- Shift+click range selection now operates in display order: anchor and clicked row are translated to display positions, the range is built in display space, then mapped back to file indices. `selected_indices` stays as absolute file indices so it survives sort changes.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo build --release` (workspace)
- [x] `cargo test` (21 passed)
- [x] `cargo clippy` (no new warnings)
- [x] Manual: load files, click each sortable header, confirm asc/desc/unsorted cycle and arrow rendering
- [x] Manual: sort by Volume after track analysis; confirm rows with `None` volume go to bottom both ways
- [x] Manual: click row A, Shift+click row B in a sorted view; selection should span the visible range A..B
- [x] Manual: Cmd/Ctrl+click toggles individual rows; Shift+Cmd/Ctrl+click adds the visible range to existing selection