### PR TITLE
Fix #173: allow negative prevent-clipping cap and AAC Find Max Amplitude

### DIFF
--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -746,9 +746,9 @@ pub fn spawn_delete_tags(
 }
 
 /// Spawn the max-amplitude scanner. Mirrors the CLI's `-x` /
-/// `cmd_max_amplitude`: walks MP3 frame headers (and AAC `global_gain`
-/// fields) to compute peak amplitude + headroom, no audio decoding,
-/// no ReplayGain machinery.
+/// `cmd_max_amplitude`: walks MP3 frame headers (or AAC `global_gain`
+/// fields) for the gain range and decodes the audio peak via
+/// `find_peak_amplitude` (no ReplayGain machinery).
 pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -233,10 +233,18 @@ pub fn analyze(file_path: &Path) -> Result<Mp3Analysis> {
     ))
 }
 
-/// Find maximum amplitude in an MP3 file by decoding the audio.
+/// Find maximum amplitude in an MP3 or AAC file.
 ///
-/// When the replaygain feature is enabled, this decodes the audio to measure
-/// actual PCM sample values. Otherwise, it falls back to estimation from global_gain.
+/// MP3 files use [`scan_gain_range`] for the global_gain min/max and
+/// `replaygain::find_peak_amplitude` for the decoded peak.
+/// AAC files use `aac::analyze_aac_gains` for the gain range and the same
+/// `find_peak_amplitude` call for the peak (issue #173: previously the
+/// function would `Error::NoMp3Frames` on AAC inputs because the
+/// MP3-frame scanner found nothing).
+///
+/// Without the `replaygain` feature, the peak is estimated from
+/// `global_gain` headroom (MP3 only) — AAC inputs return an error in
+/// that build.
 ///
 /// Note: The max_amplitude is normalized (0.0 to 1.0+), where values > 1.0 indicate clipping.
 /// To get the value in 16-bit PCM scale (like mp3gain), multiply by 32768.
@@ -244,10 +252,8 @@ pub fn analyze(file_path: &Path) -> Result<Mp3Analysis> {
 pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
     use crate::replaygain;
 
-    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
-    let (min_gain, max_gain) = scan_gain_range(&data)?;
-
     let peak_result = replaygain::find_peak_amplitude(file_path)?;
+    let (min_gain, max_gain) = read_gain_range(file_path)?;
 
     Ok(MaxAmplitudeResult::new(
         peak_result.peak(),
@@ -259,14 +265,35 @@ pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
 /// Find maximum amplitude in an MP3 file (fallback without replaygain feature)
 #[cfg(not(feature = "replaygain"))]
 pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
-    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
-    let (min_gain, max_gain) = scan_gain_range(&data)?;
+    let (min_gain, max_gain) = read_gain_range(file_path)?;
 
     let headroom_steps = (MAX_GAIN - max_gain) as i32;
     let headroom_db = headroom_steps as f64 * GAIN_STEP_DB;
     let max_amplitude = 10.0_f64.powf(-headroom_db / 20.0);
 
     Ok(MaxAmplitudeResult::new(max_amplitude, max_gain, min_gain))
+}
+
+/// Read the min/max gain values from a file, dispatching by format.
+/// MP3 uses the frame scanner; AAC uses the per-frame `global_gain` scan
+/// from [`crate::aac::analyze_aac_gains`].
+fn read_gain_range(file_path: &Path) -> Result<(u8, u8)> {
+    if crate::mp4meta::is_aac_file(file_path) {
+        #[cfg(feature = "aac")]
+        {
+            let analysis = crate::aac::analyze_aac_gains(file_path)?;
+            return Ok((analysis.min_gain(), analysis.max_gain()));
+        }
+        #[cfg(not(feature = "aac"))]
+        {
+            return Err(Error::FeatureNotAvailable {
+                feature: "AAC support",
+                feature_flag: "aac",
+            });
+        }
+    }
+    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+    scan_gain_range(&data)
 }
 
 /// Check if an MP3 file is mono

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -271,9 +271,13 @@ fn check_clipping(
                 let max_safe_db = peak_to_headroom_db(track.peak()).unwrap_or(0.0);
                 // Floor (not round) so the cap never exceeds true headroom —
                 // round() would, e.g., turn 0.8 dB of headroom into 1 step
-                // (1.5 dB) and re-introduce clipping.
+                // (1.5 dB) and re-introduce clipping. Negative results are
+                // allowed: when the source file already clips (peak > 1.0),
+                // headroom is negative and the cap legitimately needs to
+                // attenuate the file below its current loudness to remove
+                // clipping — matching the original MP3GainGUI behavior
+                // (issue #173).
                 let max_safe_steps = (max_safe_db / GAIN_STEP_DB).floor() as i32;
-                let max_safe_steps = max_safe_steps.max(0);
                 return Ok((
                     max_safe_steps,
                     true,
@@ -516,5 +520,44 @@ mod tests {
             check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert!(!prevented);
         assert_eq!(steps, 3);
+    }
+
+    /// Issue #173: when the source file already clips (peak > 1.0), the cap
+    /// must be allowed to go negative so the file is attenuated below its
+    /// current loudness, matching the original MP3GainGUI behavior. The old
+    /// `max(0)` clamp left such files clipping because it pinned the cap at
+    /// 0 steps.
+    #[test]
+    fn prevent_clipping_returns_negative_for_already_clipping_source() {
+        // peak 1.2 = ~ -1.58 dB of (negative) headroom -> floor(-1.58/1.5)
+        // = -2 steps (= -3 dB). Resulting peak = 1.2 * 10^(-3/20) = 0.85.
+        let opts = opts_with_track(1, 1.2, true);
+        let (steps, prevented, _) =
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+        assert!(prevented);
+        assert!(steps < 0, "expected negative steps, got {steps}");
+        let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
+        assert!(
+            new_peak <= 1.0,
+            "capped output still clips ({new_peak}) at steps={steps}"
+        );
+    }
+
+    /// Sweep clipping peaks (> 1.0). Cap must always produce a non-clipping
+    /// post-apply peak — independent of how many positive steps were
+    /// requested.
+    #[test]
+    fn prevent_clipping_never_overshoots_for_clipping_source() {
+        for &peak in &[1.001_f64, 1.05, 1.1, 1.2, 1.5, 2.0] {
+            let opts = opts_with_track(5, peak, true);
+            let (steps, prevented, _) =
+                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            assert!(prevented, "peak {peak} should trigger prevention");
+            let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
+            assert!(
+                new_peak <= 1.0,
+                "peak {peak} -> capped steps {steps} still clips ({new_peak})"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #173.

## Background

Boyd reported two issues against 2.7.1:

1. With Target=96 dB and **Prevent clipping** enabled, applying Track Gain
   to a track that already clips (peak > 1.0) did *not* attenuate the file
   to the non-clip maximum. The track stayed at its clipping loudness.

2. **Find Max Amplitude** reported `Error` on some AAC files in his
   library.

## Diagnosis

### 1. The prevent-clipping cap clamped at 0 steps

`apply::check_clipping` (the ReplayGain-peak branch) caps the requested
steps to `floor(headroom_db / 1.5)`. The result was then clamped via
`.max(0)`. For a source whose peak is already > 1.0, the headroom is
*negative*, so the cap should also be negative — i.e. apply attenuation.
The clamp pinned the cap at 0, so the file stayed clipping.

Original MP3GainGUI under `Don't clip when doing Track Gain` matched the
behavior Boyd expected (attenuate to non-clip max).

### 2. `find_max_amplitude` was MP3-only

`find_max_amplitude` always ran `scan_gain_range` over the raw bytes,
which only knows MP3 frame syncs. On AAC inputs it either errored with
`NoMp3Frames` (Boyd's report) or — for files where stray bytes happened
to match `0xFFE...` — returned bogus min/max gains (e.g. min=max=235
because only one false hit was found). The peak value from
`replaygain::find_peak_amplitude` was correct in both cases because
Symphonia decodes AAC natively.

## Changes

* `src/apply.rs`: drop the `.max(0)` clamp on the prevent-clipping cap so
  the floor()-rounded result can legitimately go negative for clipping
  sources. Added two tests (`prevent_clipping_returns_negative_for_already_clipping_source`,
  `prevent_clipping_never_overshoots_for_clipping_source`) covering the
  new direction.
* `src/analysis.rs`: split gain-range read by file format. MP3 keeps the
  byte-level frame scanner, AAC delegates to `aac::analyze_aac_gains`.
  Without the `aac` feature, AAC inputs now return
  `FeatureNotAvailable` (an honest error) instead of falsely matching
  the MP3 path.
* `mp3rgui/src/worker.rs`: doc-comment refresh — Max Amplitude is no
  longer "MP3-only frame scan".

## Verification

```sh
cargo test --release --lib   # all 39 pass
cargo test --release apply   # 7 pass, including the new ones
cargo test --release         # integration suite still green
```

Repro for #173-1:
```sh
# test171.mp3 has peak 1.389 (already clipping)
./target/release/mp3rgain -r --no-progress -d 7 -k -n test171.mp3
# Target: 96.5 dB ... would apply -4.5 dB, -3 steps
```
Before this PR the same invocation produced 0 steps.

Repro for #173-2:
```sh
./target/release/mp3rgain -x "Fix You (feat. Bia).m4a"
# Previously: "No valid MP3 frames found"
# Now: "Max PCM sample: 33907.24, Headroom: -0.30 dB"
```

## Test plan

- [ ] Open the GUI, load a track known to clip (peak > 1.0)
- [ ] Set Target to 96 dB, Prevent clipping = on
- [ ] Run Track Analysis, then Apply Track Gain
- [ ] Track Gain column should show a *negative* dB; status should read "Applying...", then "Done"
- [ ] Re-run Track Analysis: peak should now be ≤ 1.0 (no clip warning)
- [ ] Load a mixed selection of MP3 + AAC files
- [ ] Run Find Max Amplitude — no AAC file should report "Error"