### PR TITLE
Fix #172: refresh cached peak after Apply Gain

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1054,9 +1054,12 @@ impl Mp3rgainApp {
 
     /// Shift the row's cached display values by the dB that was actually
     /// applied. Lets the user see the post-apply state without rerunning
-    /// analysis (issue #160). Subsequent prevent-clipping checks still
-    /// consult the pre-apply `track_result.peak`; that is left as a noted
-    /// approximation — re-analysis after apply gives the exact peak.
+    /// analysis (issue #160). Also rewrites `track_result.peak()` to the
+    /// post-apply peak so the next Apply correctly drives prevent_clipping
+    /// off the file's current loudness (issue #172) — previously the
+    /// cached peak was the pre-apply value, which made a sequence like
+    /// "reduce gain to remove clip → raise gain" re-clip the file because
+    /// the second pass thought the file still had its original headroom.
     fn shift_displayed_values(file: &mut FileEntry, actual_steps: i32) {
         let db_applied = mp3rgain::steps_to_db(actual_steps);
         let gain_linear = 10.0_f64.powf(db_applied / 20.0);
@@ -1073,7 +1076,7 @@ impl Mp3rgainApp {
         if let Some(g) = file.album_gain {
             file.album_gain = Some(g - db_applied);
         }
-        if let Some(track) = file.track_result.as_ref() {
+        if let Some(track) = file.track_result.take() {
             let new_peak = track.peak() * gain_linear;
             file.clipping = new_peak >= 1.0;
             file.track_clip = file
@@ -1084,6 +1087,7 @@ impl Mp3rgainApp {
                 .album_gain
                 .map(|g| Self::would_clip(new_peak, g))
                 .unwrap_or(false);
+            file.track_result = Some(track.with_peak(new_peak));
         }
     }
 }

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -115,6 +115,16 @@ impl ReplayGainResult {
     pub fn gain_steps(&self) -> i32 {
         (self.gain_db / crate::GAIN_STEP_DB).round() as i32
     }
+
+    /// Return a copy of this result with `peak` overwritten. Used by
+    /// frontends that have applied gain to the file and need the cached
+    /// analysis to reflect the new peak for subsequent clipping checks
+    /// (issue #172). `gain_db` is not touched — the caller can decide
+    /// whether to re-analyze or keep the original target value.
+    pub fn with_peak(mut self, peak: f64) -> Self {
+        self.peak = peak;
+        self
+    }
 }
 
 impl std::fmt::Display for ReplayGainResult {
@@ -1824,6 +1834,17 @@ mod tests {
         assert!(available);
         #[cfg(not(feature = "replaygain"))]
         assert!(!available);
+    }
+
+    #[test]
+    fn with_peak_replaces_peak_and_preserves_other_fields() {
+        let original = ReplayGainResult::new(-15.0, 6.0, 0.5, 44_100, AudioFileType::Mp3);
+        let updated = original.clone().with_peak(0.8);
+        assert_eq!(updated.peak(), 0.8);
+        assert_eq!(updated.gain_db(), original.gain_db());
+        assert_eq!(updated.loudness_db(), original.loudness_db());
+        assert_eq!(updated.sample_rate(), original.sample_rate());
+        assert_eq!(updated.file_type(), original.file_type());
     }
 
     #[cfg(feature = "replaygain")]


### PR DESCRIPTION
Fixes #172.

## Symptom

Boyd reported that, with **Prevent clipping** enabled, applying gain
reduction (to remove an existing clip) followed by a gain increase
re-introduced clipping. His diagnosis was on point: \"the results of
the clipping analysis are not persisting.\"

## Root cause

The GUI caches each row's ReplayGain analysis in
\`FileEntry::track_result\` and hands it back to the worker on every
Apply via \`ApplyJob::track_result\`. Inside \`apply_with_options\`,
the ReplayGain-peak branch of \`check_clipping\` uses
\`track.peak()\` as the basis for the cap.

After the first Apply, \`shift_displayed_values\` updated the row's
displayed Volume / Gain columns and the boolean clipping flags, but it
*read* the cached peak and only wrote back the booleans. The cached
\`ReplayGainResult\` itself kept the pre-apply peak. So when the user
ran a second Apply, the worker's clipping check was computed against
the original (now wrong) peak — typically green-lighting a gain delta
that re-clips the file.

## Fix

\`shift_displayed_values\` now also rewrites the cached peak:
\`track_result.peak() *= 10^(actual_db / 20)\`, persisted back into
\`file.track_result\`.

\`ReplayGainResult\`'s fields are private and its constructor is
\`pub(crate)\`, so the library now exposes a small \`with_peak(self,
peak: f64) -> Self\` helper for this exact case. \`gain_db\` is left
untouched — the caller can decide whether to re-analyze for an exact
new gain target or keep the original.

## Files

- \`src/replaygain.rs\` — new \`ReplayGainResult::with_peak\` + unit
  test that asserts only \`peak\` changes.
- \`mp3rgui/src/app.rs\` — \`shift_displayed_values\` updates
  \`file.track_result\` via \`with_peak\`.

## Verification

\`\`\`sh
cargo test --release --lib       # 39 pass, incl. new with_peak test
cargo build --release            # both binaries compile
\`\`\`

## Test plan

- [ ] Load a clipping track, run Track Analysis
- [ ] Apply Track Gain with \`Prevent clipping\` on — file's clip warning clears
- [ ] Without re-analyzing, raise Target and Apply Track Gain again
- [ ] Check Status / Track Clip column — file should still be free of clip warnings
- [ ] Repeat with Album Gain