### PR TITLE
Fix #171: refresh row values after undo

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -973,10 +973,18 @@ impl Mp3rgainApp {
                     file.status = FileStatus::Error(message);
                 }
             }
-            WorkerEvent::FileUndone { idx } => {
+            WorkerEvent::FileUndone { idx, steps_undone } => {
                 if let Some(file) = self.files.get_mut(idx) {
                     file.status = FileStatus::Done;
                     file.stored_tags = None;
+                    // Reverse the post-apply display shift so the row
+                    // returns to its pre-apply numbers (issue #171). The
+                    // file's bytes are back to the original state, so a
+                    // shift of `-steps_undone` lines the display up with
+                    // reality.
+                    if steps_undone != 0 {
+                        Self::shift_displayed_values(file, -steps_undone);
+                    }
                 }
             }
             WorkerEvent::FileUndoSkipped { idx } => {
@@ -1053,13 +1061,11 @@ impl Mp3rgainApp {
     }
 
     /// Shift the row's cached display values by the dB that was actually
-    /// applied. Lets the user see the post-apply state without rerunning
-    /// analysis (issue #160). Also rewrites `track_result.peak()` to the
-    /// post-apply peak so the next Apply correctly drives prevent_clipping
-    /// off the file's current loudness (issue #172) — previously the
-    /// cached peak was the pre-apply value, which made a sequence like
-    /// "reduce gain to remove clip → raise gain" re-clip the file because
-    /// the second pass thought the file still had its original headroom.
+    /// applied (or, for undo, the negative of what was rolled back).
+    /// Lets the user see the post-apply / post-undo state without
+    /// rerunning analysis (issues #160, #171). The cached
+    /// `track_result.peak()` is also rewritten so subsequent
+    /// prevent-clipping checks see the file's current peak (issue #172).
     fn shift_displayed_values(file: &mut FileEntry, actual_steps: i32) {
         let db_applied = mp3rgain::steps_to_db(actual_steps);
         let gain_linear = 10.0_f64.powf(db_applied / 20.0);

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -114,10 +114,15 @@ pub enum WorkerEvent {
         message: String,
     },
 
-    /// Undo succeeded on `idx`. Distinct from `FileApplied` so the UI can
-    /// restore the row to its post-analyze state instead of marking it Done.
+    /// Undo succeeded on `idx`. `steps_undone` is the left-channel gain
+    /// step value that was stored in the undo tag — i.e. the cumulative
+    /// gain that was applied to this file across previous applies, and
+    /// that the undo just rolled back. The UI uses it to reverse the
+    /// post-apply display shift so the volume / gain columns return to
+    /// their pre-apply values without forcing a re-analyze (issue #171).
     FileUndone {
         idx: usize,
+        steps_undone: i32,
     },
     /// `frames == 0` outcome: undo ran but the file had no recorded changes
     /// to roll back. Kept separate so the row status reads "no changes" rather
@@ -606,6 +611,11 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
                 None
             };
 
+            // Peek at the undo tag before running undo, so we can tell the
+            // UI how many steps to reverse on the display. We can't read
+            // it after undo because run_undo deletes the tag (issue #171).
+            let steps_undone = peek_undo_steps(&job.path, ui_opts.use_id3v2).unwrap_or(0);
+
             let result = run_undo(&job.path, ui_opts.use_id3v2);
             match result {
                 Ok(0) => {
@@ -617,7 +627,14 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
                         restore_timestamp(&job.path, mtime);
                     }
                     undone += 1;
-                    send(&tx, &ctx, WorkerEvent::FileUndone { idx: job.idx });
+                    send(
+                        &tx,
+                        &ctx,
+                        WorkerEvent::FileUndone {
+                            idx: job.idx,
+                            steps_undone,
+                        },
+                    );
                 }
                 Err(e) => {
                     errors += 1;
@@ -906,6 +923,25 @@ fn run_undo(path: &Path, use_id3v2: bool) -> mp3rgain::error::Result<usize> {
     } else {
         mp3rgain::gain::undo_gain(path)
     }
+}
+
+/// Read the left-channel step value from the file's undo tag without
+/// modifying anything. Returns `None` when the tag is absent or unreadable.
+/// Dispatch mirrors `run_undo` so the value reflects what `run_undo` will
+/// roll back. Used by `spawn_undo` to tell the UI how far to reverse-shift
+/// the row's displayed volume / gain on undo (issue #171).
+fn peek_undo_steps(path: &Path, use_id3v2: bool) -> Option<i32> {
+    if mp4meta::is_aac_file(path) {
+        let undo_tags = mp4meta::read_undo_tags(path).ok()?;
+        let undo_str = undo_tags.undo()?;
+        return Some(mp3rgain::ape::parse_undo_values(Some(undo_str)).0);
+    }
+    if use_id3v2 {
+        let rg = id3v2::read_id3v2_replaygain(path).ok()?;
+        return Some(mp3rgain::ape::parse_undo_values(rg.undo.as_deref()).0);
+    }
+    let tag = read_ape_tag_from_file(path).ok()??;
+    tag.get_undo_gain()
 }
 
 /// Build the final `ApplyOptions` by combining always-on safety rails

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -117,10 +117,11 @@ impl ReplayGainResult {
     }
 
     /// Return a copy of this result with `peak` overwritten. Used by
-    /// frontends that have applied gain to the file and need the cached
-    /// analysis to reflect the new peak for subsequent clipping checks
-    /// (issue #172). `gain_db` is not touched — the caller can decide
-    /// whether to re-analyze or keep the original target value.
+    /// frontends that have applied (or undone) gain on the file and
+    /// need the cached analysis to reflect the file's new peak for
+    /// subsequent clipping checks (issues #171, #172). `gain_db` is
+    /// not touched — the caller can decide whether to re-analyze or
+    /// keep the original target value.
     pub fn with_peak(mut self, peak: f64) -> Self {
         self.peak = peak;
         self


### PR DESCRIPTION
Fixes #171.

## Symptom

After applying gain in the GUI, then choosing **Undo Gain Changes**, the
row's Volume / Track Gain / Album Volume / Album Gain columns stayed at
the *post-apply* numbers. The file's bytes were correctly restored,
but the display still claimed the file was loud / quiet at the new
target. The user had to re-run Track Analysis to get accurate numbers.

## Approach

The Apply path already does an in-place display refresh via
\`shift_displayed_values(file, actual_steps)\`. The Undo path needs
the same treatment, but in reverse:

1. \`spawn_undo\` peeks the file's undo tag *before* calling
   \`run_undo\` (which deletes the tag). The peek dispatches the same
   way as the undo itself — APE for default MP3, ID3v2 TXXX with
   \`-s i\`, MP4 freeform for AAC — and pulls the left-channel step
   value via the existing \`ape::parse_undo_values\` helper.
2. \`WorkerEvent::FileUndone\` now carries that \`steps_undone: i32\`.
3. The UI reuses \`shift_displayed_values\` with \`-steps_undone\` to
   invert the apply-side shift on volume, gain, cached peak, and the
   clipping flags.

## Library API touch

\`shift_displayed_values\` needs to rewrite \`track_result\`'s peak so
the row's clip warnings stay correct after undo. \`ReplayGainResult\`'s
fields are private and its constructor is \`pub(crate)\`, so we add a
small \`with_peak(self, peak) -> Self\` helper alongside the existing
\`peak()\` getter. The same helper also fixes #172 (sequential applies
with prevent_clipping), so the two PRs may produce a trivial overlap
when both land — git's three-way merge handles it without manual
intervention.

## Verification

CLI repro of the underlying tag round-trip:

\`\`\`sh
mp3rgain -k /tmp/test.mp3            # apply, leaves MP3GAIN_UNDO=-006,-006,N
mp3rgain -s c /tmp/test.mp3          # confirms tag value
mp3rgain -u /tmp/test.mp3            # undo, tag removed
mp3rgain -s c /tmp/test.mp3          # \"no APE tag found\"
\`\`\`

The GUI side mirrors this: the row's Volume column shifts back by
\`steps_undone * 1.5 dB\`, Track Gain shifts back by
\`-steps_undone * 1.5 dB\`, clip warnings are recomputed against the
restored peak.

\`\`\`sh
cargo test --release --lib       # 7 replaygain tests pass, incl. new with_peak
cargo build --release            # CLI + GUI both compile
\`\`\`

## Test plan

- [ ] Open GUI, add a track, run Track Analysis
- [ ] Apply Track Gain — note Volume / Track Gain columns shift
- [ ] Undo Gain Changes — Volume / Track Gain should return to pre-apply numbers without re-analysis
- [ ] Repeat with an AAC (.m4a) file and with \`Use ID3v2 RG tags on MP3\` enabled, to exercise all three undo dispatch paths
- [ ] Apply Manual Gain (\`-g\`) and Apply Channel Gain (\`-l\`) — verify Undo refreshes the row in those cases too