### PR TITLE
Analyze AAC bitstream once per apply and read only moov for codec detection

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1379,6 +1379,20 @@ pub fn apply_aac_gain(file_path: &Path, gain_steps: i32) -> Result<usize> {
 /// directly to `write_to` — the caller (e.g. `apply_with_temp_file`) is
 /// responsible for the rename to atomically swap the file (issue #135).
 pub fn apply_aac_gain_to_path(read_from: &Path, write_to: &Path, gain_steps: i32) -> Result<usize> {
+    apply_aac_gain_to_path_with_analysis(read_from, write_to, gain_steps, None)
+}
+
+/// [`apply_aac_gain_to_path`] with an optional pre-computed analysis of
+/// `read_from`, so callers that already analyzed the file (e.g. the clipping
+/// check in `apply_with_options`) don't pay for a second bitstream walk
+/// (issue #188). The caller guarantees the file is unchanged since the
+/// analysis — same contract as the MP3 `mp3_analysis` cache from #135.
+pub(crate) fn apply_aac_gain_to_path_with_analysis(
+    read_from: &Path,
+    write_to: &Path,
+    gain_steps: i32,
+    analysis: Option<AacAnalysis>,
+) -> Result<usize> {
     if gain_steps == 0 {
         if read_from != write_to {
             std::fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
@@ -1388,7 +1402,10 @@ pub fn apply_aac_gain_to_path(read_from: &Path, write_to: &Path, gain_steps: i32
 
     let mut data = std::fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
-    let analysis = analyze_aac_gains_from_data(&data)?;
+    let analysis = match analysis {
+        Some(a) => a,
+        None => analyze_aac_gains_from_data(&data)?,
+    };
 
     let modified = apply_aac_gain_to_data(&mut data, &analysis, gain_steps);
 
@@ -1422,6 +1439,17 @@ pub fn apply_aac_gain_with_undo_to_path(
     write_to: &Path,
     gain_steps: i32,
 ) -> Result<usize> {
+    apply_aac_gain_with_undo_to_path_with_analysis(read_from, write_to, gain_steps, None)
+}
+
+/// [`apply_aac_gain_with_undo_to_path`] with an optional pre-computed analysis
+/// of `read_from` — see [`apply_aac_gain_to_path_with_analysis`] (issue #188).
+pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
+    read_from: &Path,
+    write_to: &Path,
+    gain_steps: i32,
+    analysis: Option<AacAnalysis>,
+) -> Result<usize> {
     if gain_steps == 0 {
         if read_from != write_to {
             std::fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
@@ -1431,7 +1459,10 @@ pub fn apply_aac_gain_with_undo_to_path(
 
     let mut data = std::fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
-    let analysis = analyze_aac_gains_from_data(&data)?;
+    let analysis = match analysis {
+        Some(a) => a,
+        None => analyze_aac_gains_from_data(&data)?,
+    };
 
     let existing_undo = mp4meta::read_undo_tags_from_data(&data);
     let existing_gain = crate::ape::parse_undo_values(existing_undo.undo()).0;

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -33,6 +33,14 @@ use crate::{ape, id3v2, mp4meta};
 /// Lifted from `src/processors/utils.rs`.
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// AAC analysis cached between the clipping check and the apply step so a
+/// single apply never walks the bitstream twice (issue #188). Mirrors the
+/// MP3 `mp3_analysis` cache from #135.
+#[cfg(feature = "aac")]
+type AacAnalysisCache = Option<aac::AacAnalysis>;
+#[cfg(not(feature = "aac"))]
+type AacAnalysisCache = Option<std::convert::Infallible>;
+
 /// Album-level ReplayGain info passed alongside per-track results.
 ///
 /// Used to populate the album fields of the ReplayGain tags
@@ -172,16 +180,23 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 
     // 1) Clipping check + cap.
     //
-    // The MP3 branch caches its `analyze(file)` result so the ID3v2
-    // undo write below can reuse it instead of a second file scan
-    // (issue #135).
+    // Both branches cache their analysis so the apply step below can
+    // reuse it instead of a second file scan: the MP3 `analyze(file)`
+    // result feeds the ID3v2 undo write (issue #135), the AAC bitstream
+    // analysis feeds the gain application itself (issue #188).
     let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
-    let (actual_steps, clipping_prevented, clipping_detected) =
-        check_clipping(file_path, opts, is_aac, &mut mp3_analysis)?;
+    let mut aac_analysis: AacAnalysisCache = None;
+    let (actual_steps, clipping_prevented, clipping_detected) = check_clipping(
+        file_path,
+        opts,
+        is_aac,
+        &mut mp3_analysis,
+        &mut aac_analysis,
+    )?;
 
     // 2) Apply gain to bytes.
     let modified = if is_aac {
-        apply_aac_bytes(file_path, actual_steps, opts)?
+        apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
     } else if opts.use_id3v2 {
         apply_mp3_id3v2_bytes(file_path, actual_steps, opts, &mut mp3_analysis)?
     } else {
@@ -240,8 +255,14 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
     let is_aac = mp4meta::is_aac_file(file_path);
     let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
-    let (actual_steps, clipping_prevented, clipping_detected) =
-        check_clipping(file_path, opts, is_aac, &mut mp3_analysis)?;
+    let mut aac_analysis: AacAnalysisCache = None;
+    let (actual_steps, clipping_prevented, clipping_detected) = check_clipping(
+        file_path,
+        opts,
+        is_aac,
+        &mut mp3_analysis,
+        &mut aac_analysis,
+    )?;
     Ok(ApplyReport {
         modified: 0,
         actual_steps,
@@ -255,6 +276,7 @@ fn check_clipping(
     opts: &ApplyOptions,
     is_aac: bool,
     mp3_analysis: &mut Option<crate::Mp3Analysis>,
+    aac_analysis: &mut AacAnalysisCache,
 ) -> Result<(i32, bool, Option<ClippingDetection>)> {
     let steps = opts.steps;
     if steps <= 0 || opts.wrap {
@@ -293,13 +315,17 @@ fn check_clipping(
     let headroom = if is_aac {
         #[cfg(feature = "aac")]
         {
-            aac::analyze_aac_gains(file_path)
-                .ok()
-                .map(|a| (MAX_GAIN as i32).saturating_sub(a.max_gain() as i32))
+            let analysis = aac::analyze_aac_gains(file_path).ok();
+            let headroom = analysis
+                .as_ref()
+                .map(|a| (MAX_GAIN as i32).saturating_sub(a.max_gain() as i32));
+            *aac_analysis = analysis;
+            headroom
         }
         #[cfg(not(feature = "aac"))]
         {
             let _ = file_path;
+            let _ = &aac_analysis;
             None
         }
     } else {
@@ -322,18 +348,28 @@ fn check_clipping(
 }
 
 #[cfg(feature = "aac")]
-fn apply_aac_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Result<usize> {
+fn apply_aac_bytes(
+    file_path: &Path,
+    steps: i32,
+    opts: &ApplyOptions,
+    analysis: AacAnalysisCache,
+) -> Result<usize> {
     with_temp_file(file_path, opts.use_temp_file, |r, w| {
         if opts.write_undo {
-            aac::apply_aac_gain_with_undo_to_path(r, w, steps)
+            aac::apply_aac_gain_with_undo_to_path_with_analysis(r, w, steps, analysis)
         } else {
-            aac::apply_aac_gain_to_path(r, w, steps)
+            aac::apply_aac_gain_to_path_with_analysis(r, w, steps, analysis)
         }
     })
 }
 
 #[cfg(not(feature = "aac"))]
-fn apply_aac_bytes(_file_path: &Path, _steps: i32, _opts: &ApplyOptions) -> Result<usize> {
+fn apply_aac_bytes(
+    _file_path: &Path,
+    _steps: i32,
+    _opts: &ApplyOptions,
+    _analysis: AacAnalysisCache,
+) -> Result<usize> {
     Err(Error::FeatureNotAvailable {
         feature: "AAC support",
         feature_flag: "aac",
@@ -487,7 +523,7 @@ mod tests {
     fn prevent_clipping_caps_at_floor_not_round() {
         let opts = opts_with_track(5, 0.9, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(prevented);
         assert_eq!(steps, 0);
         let new_peak = 0.9 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -501,7 +537,7 @@ mod tests {
         for &peak in &[0.55_f64, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 0.99] {
             let opts = opts_with_track(20, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(
@@ -517,7 +553,7 @@ mod tests {
     fn prevent_clipping_passthrough_when_safe() {
         let opts = opts_with_track(3, 0.5, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(!prevented);
         assert_eq!(steps, 3);
     }
@@ -533,7 +569,7 @@ mod tests {
         // = -2 steps (= -3 dB). Resulting peak = 1.2 * 10^(-3/20) = 0.85.
         let opts = opts_with_track(1, 1.2, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(prevented);
         assert!(steps < 0, "expected negative steps, got {steps}");
         let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -551,7 +587,7 @@ mod tests {
         for &peak in &[1.001_f64, 1.05, 1.1, 1.2, 1.5, 2.0] {
             let opts = opts_with_track(5, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -22,7 +22,7 @@
 
 use crate::error::{Error, Result};
 use std::fs;
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -1237,26 +1237,54 @@ impl std::fmt::Display for Mp4AudioCodec {
     }
 }
 
+/// Read the content of the top-level `moov` box without loading the rest of
+/// the file — the audio payload (`mdat`) is usually orders of magnitude
+/// larger than the metadata, so codec/track inspection shouldn't pay for a
+/// full-file read (issue #188).
+fn read_moov_content(file_path: &Path) -> Option<Vec<u8>> {
+    let mut file = fs::File::open(file_path).ok()?;
+    let file_len = file.metadata().ok()?.len();
+    let mut pos = 0u64;
+
+    while pos + 8 <= file_len {
+        file.seek(SeekFrom::Start(pos)).ok()?;
+        let header = BoxHeader::read(&mut file).ok()??;
+        if header.box_type == MOOV {
+            // Clamp to the bytes actually present: a malformed size must not
+            // drive the allocation or read past EOF.
+            let content_start = pos + header.header_size as u64;
+            let len = header
+                .content_size()
+                .min(file_len.saturating_sub(content_start));
+            let mut buf = vec![0u8; len as usize];
+            file.read_exact(&mut buf).ok()?;
+            return Some(buf);
+        }
+        // size == 0 means "extends to EOF"; advancing by 0 would loop forever.
+        if header.size == 0 {
+            break;
+        }
+        pos = pos.saturating_add(header.size);
+    }
+
+    None
+}
+
 /// Detect the audio codec in an MP4 file by inspecting the stsd box.
 /// Navigates moov → trak → mdia → minf → stbl → stsd to find the codec.
 pub fn detect_mp4_audio_codec(file_path: &Path) -> Option<Mp4AudioCodec> {
-    let data = fs::read(file_path).ok()?;
-
-    let (moov_pos, moov_header) = find_box(&data, MOOV)?;
-    let moov_start = moov_pos + moov_header.header_size as usize;
-    let moov_size = moov_header.content_size() as usize;
+    let moov = read_moov_content(file_path)?;
 
     // Search through all trak boxes for an audio track
-    let mut trak_search_pos = moov_start;
-    let moov_end = moov_start + moov_size;
+    let mut trak_search_pos = 0;
 
-    while trak_search_pos < moov_end {
+    while trak_search_pos < moov.len() {
         let (trak_pos, trak_header) =
-            find_box_in_container(&data, trak_search_pos, moov_end - trak_search_pos, TRAK)?;
+            find_box_in_container(&moov, trak_search_pos, moov.len() - trak_search_pos, TRAK)?;
         let trak_start = trak_pos + trak_header.header_size as usize;
         let trak_size = trak_header.content_size() as usize;
 
-        if let Some(codec) = detect_codec_in_trak(&data, trak_start, trak_size) {
+        if let Some(codec) = detect_codec_in_trak(&moov, trak_start, trak_size) {
             return Some(codec);
         }
 
@@ -1323,25 +1351,17 @@ pub fn is_aac_file(file_path: &Path) -> bool {
 /// Count the number of audio tracks in an MP4 file.
 /// Returns 0 if the file cannot be read or has no moov box.
 pub fn count_audio_tracks(file_path: &Path) -> usize {
-    let data = match fs::read(file_path) {
-        Ok(d) => d,
-        Err(_) => return 0,
-    };
-
-    let (moov_pos, moov_header) = match find_box(&data, MOOV) {
-        Some(x) => x,
+    let moov = match read_moov_content(file_path) {
+        Some(m) => m,
         None => return 0,
     };
 
-    let moov_start = moov_pos + moov_header.header_size as usize;
-    let moov_end = moov_start + moov_header.content_size() as usize;
-
     let mut count = 0;
-    let mut search_pos = moov_start;
+    let mut search_pos = 0;
 
-    while search_pos < moov_end {
+    while search_pos < moov.len() {
         let (trak_pos, trak_header) =
-            match find_box_in_container(&data, search_pos, moov_end - search_pos, TRAK) {
+            match find_box_in_container(&moov, search_pos, moov.len() - search_pos, TRAK) {
                 Some(x) => x,
                 None => break,
             };
@@ -1349,7 +1369,7 @@ pub fn count_audio_tracks(file_path: &Path) -> usize {
         // Check if this trak has an audio codec (mp4a or alac)
         let trak_start = trak_pos + trak_header.header_size as usize;
         let trak_size = trak_header.content_size() as usize;
-        if detect_codec_in_trak(&data, trak_start, trak_size).is_some() {
+        if detect_codec_in_trak(&moov, trak_start, trak_size).is_some() {
             count += 1;
         }
 
@@ -1462,6 +1482,64 @@ mod tests {
         let new_undo = UndoTags::new(Some("+005,+005,N".to_string()), None);
         let result = create_ilst_box_undo(&new_undo, &existing);
         assert!(result.len() > 8);
+    }
+
+    /// Codec detection and track counting must work without a full-file
+    /// read, including the non-faststart layout where moov follows mdat
+    /// (issue #188).
+    #[test]
+    fn test_detect_codec_and_count_tracks_reads_moov_only() {
+        use std::io::Write;
+
+        fn mp4_box(typ: &[u8; 4], content: &[u8]) -> Vec<u8> {
+            let mut v = Vec::with_capacity(8 + content.len());
+            v.extend_from_slice(&((content.len() + 8) as u32).to_be_bytes());
+            v.extend_from_slice(typ);
+            v.extend_from_slice(content);
+            v
+        }
+
+        fn audio_trak(codec: &[u8; 4]) -> Vec<u8> {
+            let entry = mp4_box(codec, &[]);
+            let mut stsd_content = vec![0u8; 4]; // version + flags
+            stsd_content.extend_from_slice(&1u32.to_be_bytes()); // entry count
+            stsd_content.extend_from_slice(&entry);
+            let stsd = mp4_box(b"stsd", &stsd_content);
+            let stbl = mp4_box(b"stbl", &stsd);
+            let minf = mp4_box(b"minf", &stbl);
+            let mdia = mp4_box(b"mdia", &minf);
+            mp4_box(b"trak", &mdia)
+        }
+
+        let ftyp = mp4_box(b"ftyp", b"M4A \x00\x00\x00\x00M4A ");
+        let mdat = mp4_box(b"mdat", &[0u8; 4096]);
+        let mut moov_content = audio_trak(b"mp4a");
+        moov_content.extend_from_slice(&audio_trak(b"alac"));
+        let moov = mp4_box(b"moov", &moov_content);
+
+        let dir = std::env::temp_dir().join("mp3rgain_test_moov_only_read");
+        let _ = std::fs::create_dir_all(&dir);
+
+        for (name, layout) in [
+            ("faststart.m4a", [&ftyp, &moov, &mdat]),
+            ("trailing_moov.m4a", [&ftyp, &mdat, &moov]),
+        ] {
+            let path = dir.join(name);
+            let mut f = std::fs::File::create(&path).unwrap();
+            for part in layout {
+                f.write_all(part).unwrap();
+            }
+
+            assert_eq!(
+                detect_mp4_audio_codec(&path),
+                Some(Mp4AudioCodec::Aac),
+                "{name}"
+            );
+            assert_eq!(count_audio_tracks(&path), 2, "{name}");
+            assert!(is_aac_file(&path), "{name}");
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #188.

A single `mp3rgain -g N file.m4a` did roughly five full file reads and two full AAC bitstream analyses. This PR removes the duplicate bitstream walk and the full-file reads in codec/track detection.

## Changes

**1. Single bitstream analysis per apply**
- `check_clipping` now caches the `AacAnalysis` from its headroom probe (new `AacAnalysisCache` alias, cfg-safe for non-aac builds) and `apply_with_options` threads it into the apply step — mirroring the MP3 `mp3_analysis` cache from #135.
- `aac::apply_aac_gain_to_path` / `apply_aac_gain_with_undo_to_path` delegate to new `pub(crate)` `*_with_analysis` variants that accept an optional pre-computed analysis and fall back to analyzing when none is supplied (e.g. the ReplayGain-peak path, which never runs the headroom probe). Public API unchanged.
- A stale cache cannot corrupt or panic: `read_bits_u8`/`write_bits_u8` bounds-check and no-op out of range; the caller guarantees the file is unchanged between check and apply, same contract as #135.

**2. moov-only reads for MP4 inspection**
- New `read_moov_content` walks top-level boxes with seeks and loads only the moov payload (clamped to actual file bytes against malformed sizes; handles 64-bit/extended box sizes and stops on size-0 boxes as before).
- `detect_mp4_audio_codec` and `count_audio_tracks` operate on that buffer instead of `fs::read`-ing the whole file. These run up to 3× per operation (`is_aac_file` in the CLI processor, again in `apply_with_options`, and `warn_aac_multi_track`), so the per-apply read amplification drops from ~3 full reads to ~3 small moov reads.
- `is_aac_file` dispatch semantics are intentionally untouched (`None` codec still maps to AAC) — undetectable MP4s must keep away from the MP3 byte scanner per #149.

## Tests

- New `test_detect_codec_and_count_tracks_reads_moov_only` builds synthetic MP4s in both faststart (moov-first) and trailing-moov layouts and verifies `detect_mp4_audio_codec`, `count_audio_tracks`, and `is_aac_file`.
- `cargo test`, `cargo clippy --all-targets` pass; `cargo check --no-default-features` warning set is identical to master.