### PR TITLE
GUI: parallelize undo/delete/max-amplitude workers and virtualize the file table

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -199,6 +199,13 @@ pub struct Mp3rgainApp {
     pub sort_column: Option<SortColumn>,
     /// Direction of the active sort. Ignored when `sort_column` is `None`.
     pub sort_descending: bool,
+
+    /// Cached display order, recomputed lazily when `display_order_dirty`
+    /// is set. The old per-frame re-sort allocated per comparison and
+    /// dominated frame time on large tables (issue #190).
+    display_order_cache: Vec<usize>,
+    /// Set whenever the sort key or any row data changes.
+    display_order_dirty: bool,
 }
 
 impl Mp3rgainApp {
@@ -222,6 +229,8 @@ impl Mp3rgainApp {
             last_target_volume: 89.0,
             sort_column: None,
             sort_descending: false,
+            display_order_cache: Vec::new(),
+            display_order_dirty: true,
         }
     }
 
@@ -242,28 +251,58 @@ impl Mp3rgainApp {
                 self.sort_descending = false;
             }
         }
+        self.display_order_dirty = true;
     }
 
-    /// Indices into `self.files` in current display (sort) order. Returned
-    /// fresh every call — cheap relative to the per-frame render cost.
-    pub fn compute_display_order(&self) -> Vec<usize> {
+    /// Indices into `self.files` in current display (sort) order, served
+    /// from the cache. The returned Vec is a clone so the table can iterate
+    /// it while mutably borrowing `self` for click handling.
+    pub fn display_order(&mut self) -> Vec<usize> {
+        if self.display_order_dirty {
+            self.display_order_cache = self.compute_display_order();
+            self.display_order_dirty = false;
+        }
+        self.display_order_cache.clone()
+    }
+
+    /// Sort `0..files.len()` by the active column. String columns
+    /// precompute one key per row instead of allocating lowercased copies
+    /// in every comparison (issue #190).
+    fn compute_display_order(&self) -> Vec<usize> {
         let mut order: Vec<usize> = (0..self.files.len()).collect();
         let Some(col) = self.sort_column else {
             return order;
         };
         let desc = self.sort_descending;
-        order.sort_by(|&a, &b| {
-            let fa = &self.files[a];
-            let fb = &self.files[b];
-            match col {
-                SortColumn::Filename => cmp_str(&fa.filename, &fb.filename, desc),
-                SortColumn::Volume => cmp_opt_f64(fa.volume, fb.volume, desc),
-                SortColumn::TrackGain => cmp_opt_f64(fa.track_gain, fb.track_gain, desc),
-                SortColumn::AlbumVolume => cmp_opt_f64(fa.album_volume, fb.album_volume, desc),
-                SortColumn::AlbumGain => cmp_opt_f64(fa.album_gain, fb.album_gain, desc),
-                SortColumn::Status => cmp_str(&fa.status.label(), &fb.status.label(), desc),
+        match col {
+            SortColumn::Filename => {
+                let keys: Vec<String> = self
+                    .files
+                    .iter()
+                    .map(|f| f.filename.to_lowercase())
+                    .collect();
+                order.sort_by(|&a, &b| cmp_str(&keys[a], &keys[b], desc));
             }
-        });
+            SortColumn::Status => {
+                let keys: Vec<String> = self
+                    .files
+                    .iter()
+                    .map(|f| f.status.label().to_lowercase())
+                    .collect();
+                order.sort_by(|&a, &b| cmp_str(&keys[a], &keys[b], desc));
+            }
+            SortColumn::Volume => order
+                .sort_by(|&a, &b| cmp_opt_f64(self.files[a].volume, self.files[b].volume, desc)),
+            SortColumn::TrackGain => order.sort_by(|&a, &b| {
+                cmp_opt_f64(self.files[a].track_gain, self.files[b].track_gain, desc)
+            }),
+            SortColumn::AlbumVolume => order.sort_by(|&a, &b| {
+                cmp_opt_f64(self.files[a].album_volume, self.files[b].album_volume, desc)
+            }),
+            SortColumn::AlbumGain => order.sort_by(|&a, &b| {
+                cmp_opt_f64(self.files[a].album_gain, self.files[b].album_gain, desc)
+            }),
+        }
         order
     }
 
@@ -275,6 +314,7 @@ impl Mp3rgainApp {
         if (self.target_volume - self.last_target_volume).abs() < f64::EPSILON {
             return;
         }
+        self.display_order_dirty = true;
         let delta = self.target_volume - self.last_target_volume;
         for file in &mut self.files {
             if let Some(g) = file.track_gain {
@@ -324,6 +364,9 @@ impl Mp3rgainApp {
             }
         }
 
+        if added > 0 {
+            self.display_order_dirty = true;
+        }
         if skipped > 0 {
             self.status_message =
                 format!("Added {} file(s), {} duplicate(s) skipped", added, skipped);
@@ -356,6 +399,7 @@ impl Mp3rgainApp {
             }
         }
         self.selected_indices.clear();
+        self.display_order_dirty = true;
     }
 
     pub fn clear_files(&mut self) {
@@ -365,6 +409,7 @@ impl Mp3rgainApp {
         self.files.clear();
         self.selected_indices.clear();
         self.selection_anchor = None;
+        self.display_order_dirty = true;
     }
 
     /// Replace the current selection with every file in the table. Used by
@@ -624,8 +669,9 @@ impl Mp3rgainApp {
         );
     }
 
-    /// `-x`: scan each file for its max amplitude / headroom without any
-    /// ReplayGain decoding. Faster than Track Analysis.
+    /// `-x`: scan each file for its max amplitude / headroom. Decodes the
+    /// audio for the true peak but skips the loudness analysis, so it is
+    /// lighter than Track Analysis (not decode-free).
     pub fn start_find_max_amplitude(&mut self, ctx: &egui::Context) {
         if self.files.is_empty() || self.is_processing {
             return;
@@ -827,6 +873,9 @@ impl Mp3rgainApp {
     }
 
     fn begin_worker(&mut self, kind: WorkerKind, total: usize, handle: WorkerHandle) {
+        // The start_* callers just reset row statuses to Pending, which a
+        // Status sort must observe.
+        self.display_order_dirty = true;
         self.worker = Some(handle);
         self.worker_kind = Some(kind);
         self.is_processing = true;
@@ -862,6 +911,11 @@ impl Mp3rgainApp {
                     }
                 }
             }
+        }
+        // Worker events mutate sortable row fields (volume, gains, status),
+        // so any applied event invalidates the cached display order.
+        if !events.is_empty() {
+            self.display_order_dirty = true;
         }
         for event in events {
             self.apply_event(event);
@@ -1111,12 +1165,12 @@ fn cmp_opt_f64(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering
     }
 }
 
-/// Case-insensitive string compare with empty-strings-last semantics.
+/// Compare two pre-lowercased sort keys with empty-strings-last semantics.
 fn cmp_str(a: &str, b: &str, desc: bool) -> std::cmp::Ordering {
     use std::cmp::Ordering;
     match (a.is_empty(), b.is_empty()) {
         (false, false) => {
-            let o = a.to_lowercase().cmp(&b.to_lowercase());
+            let o = a.cmp(b);
             if desc {
                 o.reverse()
             } else {

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -68,8 +68,12 @@ fn sort_header(
 }
 
 pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
-    let display_order = app.compute_display_order();
-    egui::ScrollArea::both().show(ui, |ui| {
+    let display_order = app.display_order();
+    // Horizontal scrolling only — vertical scrolling is the table's own,
+    // so `body.rows` can virtualize off-screen rows (issue #190). An outer
+    // vertical scroll area would hand the table unbounded height and force
+    // every row to be laid out each frame.
+    egui::ScrollArea::horizontal().show(ui, |ui| {
         egui_extras::TableBuilder::new(ui)
             .striped(true)
             .resizable(true)
@@ -128,20 +132,28 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                     sort_header(ui, app, "Status", SortColumn::Status, "");
                 });
             })
-            .body(|mut body| {
+            .body(|body| {
                 // Defer click handling: the row closure borrows `app.files`,
                 // so it can't also mutate `app.selected_indices` during the
                 // iteration. Capture the requested action and apply it after
                 // the loop.
                 let mut pending_click: Option<(usize, ClickMode)> = None;
                 let mut pending_reveal: Option<std::path::PathBuf> = None;
-                for &idx in &display_order {
-                    let Some(file) = app.files.get(idx) else {
-                        continue;
+                // Set lookup instead of `Vec::contains` per row, which made
+                // selection O(rows × selected) per frame (issue #190).
+                let selected: std::collections::HashSet<usize> =
+                    app.selected_indices.iter().copied().collect();
+                // `rows` (vs per-row `body.row`) lays out only the rows
+                // inside the viewport; fixed 18.0 height makes it a drop-in.
+                body.rows(18.0, display_order.len(), |mut row| {
+                    let Some(&idx) = display_order.get(row.index()) else {
+                        return;
                     };
-                    let is_selected = app.selected_indices.contains(&idx);
-                    body.row(18.0, |mut row| {
-                        row.set_selected(is_selected);
+                    let Some(file) = app.files.get(idx) else {
+                        return;
+                    };
+                    let is_selected = selected.contains(&idx);
+                    row.set_selected(is_selected);
 
                         row.col(|ui| {
                             let resp = ui.selectable_label(is_selected, &file.filename);
@@ -218,8 +230,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                         row.col(|ui| {
                             ui.label(file.status.label());
                         });
-                    });
-                }
+                });
                 if let Some((idx, mode)) = pending_click {
                     app.click_row(idx, mode);
                 }

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -102,8 +102,9 @@ pub enum WorkerEvent {
         view: StoredTagsView,
     },
 
-    /// `-x` Find Max Amplitude result for `idx`. Light alternative to
-    /// `TrackAnalyzed`: only walks MP3 frame headers, no decoding.
+    /// `-x` Find Max Amplitude result for `idx`. Lighter than
+    /// `TrackAnalyzed`: decodes for the true peak but skips the loudness
+    /// analysis.
     MaxAmplitudeFound {
         idx: usize,
         peak: f64,
@@ -213,79 +214,44 @@ impl Default for ApplyOptionsUi {
 
 /// Spawn a parallel track-analysis worker.
 ///
-/// Files are pulled from a shared queue by a pool of `available_parallelism`
-/// worker threads, so total wall time is comparable to Album Analysis
-/// (issue #158, which was previously serial). Each completed file emits a
-/// `TrackAnalyzed` event immediately so the table updates as work happens
-/// instead of in a single batch at the end. Cancellation is checked
-/// between files.
+/// Files run through [`run_job_pool`], so total wall time is comparable to
+/// Album Analysis (issue #158, which was previously serial). Each completed
+/// file emits a `TrackAnalyzed` event immediately so the table updates as
+/// work happens instead of in a single batch at the end. Cancellation is
+/// checked between files.
 pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let total = files.len();
-        if total == 0 {
-            send(
-                &tx,
-                &ctx,
-                WorkerEvent::Done {
-                    message: "Analyzed 0 file(s)".to_string(),
-                },
-            );
-            return;
-        }
+        let analyzed = AtomicUsize::new(0);
+        let errors = AtomicUsize::new(0);
 
-        let parallelism = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .max(1);
-        let pool_size = parallelism.min(total);
-
-        let queue: Arc<Mutex<Vec<(usize, PathBuf)>>> = Arc::new(Mutex::new(files));
-        let analyzed = Arc::new(AtomicUsize::new(0));
-        let errors = Arc::new(AtomicUsize::new(0));
-
-        let handles: Vec<_> = (0..pool_size)
-            .map(|_| {
-                let queue = Arc::clone(&queue);
-                let cancel = Arc::clone(&cancel_w);
-                let tx = tx.clone();
-                let ctx = ctx.clone();
-                let analyzed = Arc::clone(&analyzed);
-                let errors = Arc::clone(&errors);
-                thread::spawn(move || loop {
-                    if cancel.load(Ordering::Relaxed) {
-                        break;
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            let (analyzed, errors) = (&analyzed, &errors);
+            run_job_pool(files, &cancel_w, move |(idx, path)| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx });
+                match replaygain::analyze_track(&path) {
+                    Ok(result) => {
+                        analyzed.fetch_add(1, Ordering::Relaxed);
+                        send(&tx, &ctx, WorkerEvent::TrackAnalyzed { idx, result });
                     }
-                    let next = {
-                        let mut q = queue.lock().expect("track analysis queue poisoned");
-                        q.pop()
-                    };
-                    let Some((idx, path)) = next else { break };
-                    let _ = tx.send(WorkerEvent::FileStart { idx });
-                    ctx.request_repaint();
-                    match replaygain::analyze_track(&path) {
-                        Ok(result) => {
-                            analyzed.fetch_add(1, Ordering::Relaxed);
-                            let _ = tx.send(WorkerEvent::TrackAnalyzed { idx, result });
-                        }
-                        Err(e) => {
-                            errors.fetch_add(1, Ordering::Relaxed);
-                            let _ = tx.send(WorkerEvent::TrackAnalysisFailed {
+                    Err(e) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::TrackAnalysisFailed {
                                 idx,
                                 message: e.to_string(),
-                            });
-                        }
+                            },
+                        );
                     }
-                    ctx.request_repaint();
-                })
-            })
-            .collect();
-
-        for h in handles {
-            let _ = h.join();
+                }
+            });
         }
 
         if cancel_w.load(Ordering::Relaxed) {
@@ -443,12 +409,11 @@ pub fn spawn_album_analysis(
 
 /// Spawn the apply worker (used by both Track Gain and Album Gain).
 ///
-/// Jobs are pulled from a shared queue by a pool of `available_parallelism`
-/// worker threads, matching the parallel Track Analysis path so wall time
-/// scales with cores (issue #158 follow-up comment). Each file's apply is
-/// independent — the temp-file rename in `apply_with_options` uses an
-/// AtomicU64 counter so concurrent writes in the same directory don't
-/// collide. Cancellation is checked between files.
+/// Jobs run through [`run_job_pool`], matching the parallel Track Analysis
+/// path so wall time scales with cores (issue #158 follow-up comment). Each
+/// file's apply is independent — the temp-file rename in
+/// `apply_with_options` uses an AtomicU64 counter so concurrent writes in
+/// the same directory don't collide. Cancellation is checked between files.
 pub fn spawn_apply(
     ctx: egui::Context,
     jobs: Vec<ApplyJob>,
@@ -460,96 +425,65 @@ pub fn spawn_apply(
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let total = jobs.len();
-        if total == 0 {
-            let verb = if ui_opts.dry_run {
-                "Dry-ran"
-            } else {
-                "Applied"
-            };
-            send(
-                &tx,
-                &ctx,
-                WorkerEvent::Done {
-                    message: format!("{} {} on 0 file(s)", verb, action_label),
-                },
-            );
-            return;
-        }
+        let applied = AtomicUsize::new(0);
+        let errors = AtomicUsize::new(0);
 
-        let parallelism = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .max(1);
-        let pool_size = parallelism.min(total);
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            let (applied, errors) = (&applied, &errors);
+            run_job_pool(jobs, &cancel_w, move |job: ApplyJob| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-        let queue: Arc<Mutex<Vec<ApplyJob>>> = Arc::new(Mutex::new(jobs));
-        let applied = Arc::new(AtomicUsize::new(0));
-        let errors = Arc::new(AtomicUsize::new(0));
-
-        let handles: Vec<_> = (0..pool_size)
-            .map(|_| {
-                let queue = Arc::clone(&queue);
-                let cancel = Arc::clone(&cancel_w);
-                let tx = tx.clone();
-                let ctx = ctx.clone();
-                let applied = Arc::clone(&applied);
-                let errors = Arc::clone(&errors);
-                thread::spawn(move || loop {
-                    if cancel.load(Ordering::Relaxed) {
-                        break;
-                    }
-                    let next = {
-                        let mut q = queue.lock().expect("apply queue poisoned");
-                        q.pop()
-                    };
-                    let Some(job) = next else { break };
-                    let _ = tx.send(WorkerEvent::FileStart { idx: job.idx });
-                    ctx.request_repaint();
-
-                    let opts = build_apply_options(
-                        job.steps,
-                        job.track_result,
-                        job.album_info,
-                        job.channel,
-                        ui_opts,
-                    );
-                    let result = if ui_opts.dry_run {
-                        predict_apply(&job.path, &opts)
-                    } else {
-                        apply_with_options(&job.path, &opts)
-                    };
-                    match result {
-                        Ok(report) => {
-                            applied.fetch_add(1, Ordering::Relaxed);
-                            if ui_opts.dry_run {
-                                let _ = tx.send(WorkerEvent::FileApplyDryRun {
+                let opts = build_apply_options(
+                    job.steps,
+                    job.track_result,
+                    job.album_info,
+                    job.channel,
+                    ui_opts,
+                );
+                let result = if ui_opts.dry_run {
+                    predict_apply(&job.path, &opts)
+                } else {
+                    apply_with_options(&job.path, &opts)
+                };
+                match result {
+                    Ok(report) => {
+                        applied.fetch_add(1, Ordering::Relaxed);
+                        if ui_opts.dry_run {
+                            send(
+                                &tx,
+                                &ctx,
+                                WorkerEvent::FileApplyDryRun {
                                     idx: job.idx,
                                     actual_steps: report.actual_steps,
                                     clipping_prevented: report.clipping_prevented,
-                                });
-                            } else {
-                                let _ = tx.send(WorkerEvent::FileApplied {
+                                },
+                            );
+                        } else {
+                            send(
+                                &tx,
+                                &ctx,
+                                WorkerEvent::FileApplied {
                                     idx: job.idx,
                                     actual_steps: report.actual_steps,
-                                });
-                            }
-                        }
-                        Err(e) => {
-                            errors.fetch_add(1, Ordering::Relaxed);
-                            let _ = tx.send(WorkerEvent::FileApplyFailed {
-                                idx: job.idx,
-                                message: e.to_string(),
-                            });
+                                },
+                            );
                         }
                     }
-                    ctx.request_repaint();
-                })
-            })
-            .collect();
-
-        for h in handles {
-            let _ = h.join();
+                    Err(e) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplyFailed {
+                                idx: job.idx,
+                                message: e.to_string(),
+                            },
+                        );
+                    }
+                }
+            });
         }
 
         if cancel_w.load(Ordering::Relaxed) {
@@ -581,8 +515,10 @@ pub fn spawn_apply(
     WorkerHandle { rx, cancel }
 }
 
-/// Spawn the undo worker. Iterates jobs serially, checks cancel between
-/// files. Dispatches per file to the correct undo path:
+/// Spawn the undo worker. Runs jobs through [`run_job_pool`] (undo is
+/// dominated by per-file I/O and, for AAC, a bitstream re-analysis, so it
+/// parallelizes the same way apply does). Dispatches per file to the
+/// correct undo path:
 ///   - AAC: `mp3rgain::aac::undo_aac_gain`
 ///   - MP3 + `use_id3v2`: `mp3rgain::undo_gain_id3v2`
 ///   - MP3 (default APE): `mp3rgain::undo_gain`
@@ -594,64 +530,73 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let mut undone = 0usize;
-        let mut skipped = 0usize;
-        let mut errors = 0usize;
+        let undone = AtomicUsize::new(0);
+        let skipped = AtomicUsize::new(0);
+        let errors = AtomicUsize::new(0);
 
-        for job in jobs {
-            if cancel_w.load(Ordering::Relaxed) {
-                send(&tx, &ctx, WorkerEvent::Cancelled);
-                return;
-            }
-            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            let (undone, skipped, errors) = (&undone, &skipped, &errors);
+            run_job_pool(jobs, &cancel_w, move |job: UndoJob| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-            let original_mtime = if ui_opts.preserve_timestamp {
-                read_mtime(&job.path)
-            } else {
-                None
-            };
+                let original_mtime = if ui_opts.preserve_timestamp {
+                    read_mtime(&job.path)
+                } else {
+                    None
+                };
 
-            // Peek at the undo tag before running undo, so we can tell the
-            // UI how many steps to reverse on the display. We can't read
-            // it after undo because undo_gain_auto deletes the tag (issue #171).
-            let steps_undone = mp3rgain::read_undo_steps(&job.path, ui_opts.use_id3v2).unwrap_or(0);
+                // Peek at the undo tag before running undo, so we can tell the
+                // UI how many steps to reverse on the display. We can't read
+                // it after undo because undo_gain_auto deletes the tag (issue #171).
+                let steps_undone =
+                    mp3rgain::read_undo_steps(&job.path, ui_opts.use_id3v2).unwrap_or(0);
 
-            let result = mp3rgain::undo_gain_auto(&job.path, ui_opts.use_id3v2);
-            match result {
-                Ok(0) => {
-                    skipped += 1;
-                    send(&tx, &ctx, WorkerEvent::FileUndoSkipped { idx: job.idx });
-                }
-                Ok(_) => {
-                    if let Some(mtime) = original_mtime {
-                        restore_timestamp(&job.path, mtime);
+                let result = mp3rgain::undo_gain_auto(&job.path, ui_opts.use_id3v2);
+                match result {
+                    Ok(0) => {
+                        skipped.fetch_add(1, Ordering::Relaxed);
+                        send(&tx, &ctx, WorkerEvent::FileUndoSkipped { idx: job.idx });
                     }
-                    undone += 1;
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::FileUndone {
-                            idx: job.idx,
-                            steps_undone,
-                        },
-                    );
+                    Ok(_) => {
+                        if let Some(mtime) = original_mtime {
+                            restore_timestamp(&job.path, mtime);
+                        }
+                        undone.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileUndone {
+                                idx: job.idx,
+                                steps_undone,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplyFailed {
+                                idx: job.idx,
+                                message: e.to_string(),
+                            },
+                        );
+                    }
                 }
-                Err(e) => {
-                    errors += 1;
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::FileApplyFailed {
-                            idx: job.idx,
-                            message: e.to_string(),
-                        },
-                    );
-                }
-            }
+            });
+        }
+
+        if cancel_w.load(Ordering::Relaxed) {
+            send(&tx, &ctx, WorkerEvent::Cancelled);
+            return;
         }
 
         let mut parts: Vec<String> = Vec::new();
-        parts.push(format!("Undone {} file(s)", undone));
+        parts.push(format!("Undone {} file(s)", undone.load(Ordering::Relaxed)));
+        let skipped = skipped.load(Ordering::Relaxed);
+        let errors = errors.load(Ordering::Relaxed);
         if skipped > 0 {
             parts.push(format!("{} had no changes to undo", skipped));
         }
@@ -671,7 +616,8 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
 }
 
 /// Spawn the stored-tag deletion worker. Destructive: removes APE /
-/// ID3v2 RG / MP4 freeform RG+undo tags from each file in order.
+/// ID3v2 RG / MP4 freeform RG+undo tags from each file, fanned out via
+/// [`run_job_pool`].
 ///
 /// Dispatch mirrors the CLI's `process_delete_tags`:
 ///   - AAC: `mp4meta::delete_replaygain_tags` + `delete_undo_tags`
@@ -688,56 +634,63 @@ pub fn spawn_delete_tags(
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let mut deleted = 0usize;
-        let mut errors = 0usize;
+        let deleted = AtomicUsize::new(0);
+        let errors = AtomicUsize::new(0);
 
-        for job in jobs {
-            if cancel_w.load(Ordering::Relaxed) {
-                send(&tx, &ctx, WorkerEvent::Cancelled);
-                return;
-            }
-            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            let (deleted, errors) = (&deleted, &errors);
+            run_job_pool(jobs, &cancel_w, move |job: DeleteTagsJob| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-            let original_mtime = if preserve_timestamp {
-                read_mtime(&job.path)
-            } else {
-                None
-            };
+                let original_mtime = if preserve_timestamp {
+                    read_mtime(&job.path)
+                } else {
+                    None
+                };
 
-            let result = mp3rgain::delete_gain_tags_auto(&job.path, use_id3v2);
+                let result = mp3rgain::delete_gain_tags_auto(&job.path, use_id3v2);
 
-            match result {
-                Ok(()) => {
-                    if let Some(m) = original_mtime {
-                        restore_timestamp(&job.path, m);
+                match result {
+                    Ok(()) => {
+                        if let Some(m) = original_mtime {
+                            restore_timestamp(&job.path, m);
+                        }
+                        deleted.fetch_add(1, Ordering::Relaxed);
+                        // Tag deletion doesn't change audio levels, so the row's
+                        // volume/gain columns stay valid — pass 0 steps so the UI
+                        // doesn't shift them.
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplied {
+                                idx: job.idx,
+                                actual_steps: 0,
+                            },
+                        );
                     }
-                    deleted += 1;
-                    // Tag deletion doesn't change audio levels, so the row's
-                    // volume/gain columns stay valid — pass 0 steps so the UI
-                    // doesn't shift them.
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::FileApplied {
-                            idx: job.idx,
-                            actual_steps: 0,
-                        },
-                    );
+                    Err(e) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::FileApplyFailed {
+                                idx: job.idx,
+                                message: e.to_string(),
+                            },
+                        );
+                    }
                 }
-                Err(e) => {
-                    errors += 1;
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::FileApplyFailed {
-                            idx: job.idx,
-                            message: e.to_string(),
-                        },
-                    );
-                }
-            }
+            });
         }
 
+        if cancel_w.load(Ordering::Relaxed) {
+            send(&tx, &ctx, WorkerEvent::Cancelled);
+            return;
+        }
+
+        let errors = errors.load(Ordering::Relaxed);
         let suffix = if errors > 0 {
             format!(", {} error(s)", errors)
         } else {
@@ -747,7 +700,11 @@ pub fn spawn_delete_tags(
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!("Deleted stored tags from {} file(s){}", deleted, suffix),
+                message: format!(
+                    "Deleted stored tags from {} file(s){}",
+                    deleted.load(Ordering::Relaxed),
+                    suffix
+                ),
             },
         );
     });
@@ -758,50 +715,60 @@ pub fn spawn_delete_tags(
 /// Spawn the max-amplitude scanner. Mirrors the CLI's `-x` /
 /// `cmd_max_amplitude`: walks MP3 frame headers (or AAC `global_gain`
 /// fields) for the gain range and decodes the audio peak via
-/// `find_peak_amplitude` (no ReplayGain machinery).
+/// `find_peak_amplitude` (no loudness analysis, but still a full decode —
+/// hence the [`run_job_pool`] fan-out).
 pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_w = Arc::clone(&cancel);
 
     thread::spawn(move || {
-        let mut found = 0usize;
-        let mut errors = 0usize;
-        for (idx, path) in files {
-            if cancel_w.load(Ordering::Relaxed) {
-                send(&tx, &ctx, WorkerEvent::Cancelled);
-                return;
-            }
-            send(&tx, &ctx, WorkerEvent::FileStart { idx });
+        let found = AtomicUsize::new(0);
+        let errors = AtomicUsize::new(0);
 
-            match mp3rgain::find_max_amplitude(&path) {
-                Ok(amp) => {
-                    found += 1;
-                    let peak = amp.max_amplitude();
-                    let headroom_db = mp3rgain::peak_to_headroom_db(peak);
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::MaxAmplitudeFound {
-                            idx,
-                            peak,
-                            headroom_db,
-                        },
-                    );
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            let (found, errors) = (&found, &errors);
+            run_job_pool(files, &cancel_w, move |(idx, path)| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx });
+
+                match mp3rgain::find_max_amplitude(&path) {
+                    Ok(amp) => {
+                        found.fetch_add(1, Ordering::Relaxed);
+                        let peak = amp.max_amplitude();
+                        let headroom_db = mp3rgain::peak_to_headroom_db(peak);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::MaxAmplitudeFound {
+                                idx,
+                                peak,
+                                headroom_db,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                        send(
+                            &tx,
+                            &ctx,
+                            WorkerEvent::MaxAmplitudeFailed {
+                                idx,
+                                message: e.to_string(),
+                            },
+                        );
+                    }
                 }
-                Err(e) => {
-                    errors += 1;
-                    send(
-                        &tx,
-                        &ctx,
-                        WorkerEvent::MaxAmplitudeFailed {
-                            idx,
-                            message: e.to_string(),
-                        },
-                    );
-                }
-            }
+            });
         }
+
+        if cancel_w.load(Ordering::Relaxed) {
+            send(&tx, &ctx, WorkerEvent::Cancelled);
+            return;
+        }
+
+        let errors = errors.load(Ordering::Relaxed);
         let suffix = if errors > 0 {
             format!(", {} error(s)", errors)
         } else {
@@ -811,7 +778,11 @@ pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!("Max amplitude scanned on {} file(s){}", found, suffix),
+                message: format!(
+                    "Max amplitude scanned on {} file(s){}",
+                    found.load(Ordering::Relaxed),
+                    suffix
+                ),
             },
         );
     });
@@ -931,6 +902,47 @@ fn build_apply_options(
     opts.preserve_timestamp = ui_opts.preserve_timestamp;
     opts.use_id3v2 = ui_opts.use_id3v2;
     opts
+}
+
+/// Drain `jobs` through a pool of `available_parallelism` scoped worker
+/// threads, calling `per_job` for each job. Blocks until the queue is empty
+/// or `cancel` is observed (checked between jobs). Each pool thread gets its
+/// own clone of `per_job` — captures like `mpsc::Sender` and `egui::Context`
+/// are cheap reference-counted clones. Jobs start in their original order.
+fn run_job_pool<J, F>(jobs: Vec<J>, cancel: &AtomicBool, per_job: F)
+where
+    J: Send,
+    F: Fn(J) + Clone + Send,
+{
+    let pool_size = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .max(1)
+        .min(jobs.len());
+
+    // Popping takes from the Vec's tail; reverse once so files are picked
+    // up in the order the caller listed them.
+    let mut jobs = jobs;
+    jobs.reverse();
+    let queue = Mutex::new(jobs);
+
+    thread::scope(|scope| {
+        for _ in 0..pool_size {
+            let per_job = per_job.clone();
+            let queue = &queue;
+            scope.spawn(move || loop {
+                if cancel.load(Ordering::Relaxed) {
+                    break;
+                }
+                let next = {
+                    let mut q = queue.lock().expect("worker job queue poisoned");
+                    q.pop()
+                };
+                let Some(job) = next else { break };
+                per_job(job);
+            });
+        }
+    });
 }
 
 fn send(tx: &Sender<WorkerEvent>, ctx: &egui::Context, event: WorkerEvent) {


### PR DESCRIPTION
## Summary

Fixes #190.

## Changes

**1. One `run_job_pool` helper, five workers**
- The queue + `AtomicBool` cancel + worker-pool pattern existed as two near-identical hand-rolled copies in `spawn_track_analysis` and `spawn_apply`. It's now a single `run_job_pool(jobs, cancel, per_job)` helper using `std::thread::scope` (no `Arc` plumbing; each pool thread clones the job closure, which only holds an `mpsc::Sender` and `egui::Context` — both cheap reference-counted clones).
- **Find Max Amplitude**, **Undo**, and **Delete Tags** now run through the same pool instead of serial loops. With the `replaygain` feature, `find_max_amplitude` fully decodes each file, so the serial loop left ~8× on the table on an 8-core M3 for large batches. Undo/delete are per-file independent I/O (the MP4 `atomic_write` temp counter already makes concurrent same-directory writes safe — same argument as the existing parallel apply).
- Jobs are picked up in list order now (the old `Vec::pop` queue processed files bottom-up).
- Cancellation, per-event repaints, and all final status messages are unchanged.

**2. Table virtualization** (`ui/table.rs`)
- `body.row()` in a `for` loop laid out every row each frame; now `body.rows(18.0, n, ..)` (fixed row height made it a drop-in) lays out only the visible range.
- The outer `ScrollArea::both()` is reduced to horizontal-only — an outer vertical scroll area hands the table unbounded height, which would defeat the virtualization.
- Selection lookup is a `HashSet` per frame instead of `Vec::contains` per row (was O(rows × selected)).

**3. Display-order caching** (`app.rs`)
- `compute_display_order` re-sorted every frame and allocated per comparison (`to_lowercase()`, `status.label()`). The order is now cached and invalidated on: sort toggles, file add/remove/clear, worker events, target-volume edits, and worker start (status resets). String sorts precompute one lowercased key per row.
- Sort semantics are unchanged (stable sort, case-insensitive, empty-last).

**4. Comment fixes**
- `worker.rs` / `app.rs` comments claiming Find Max Amplitude does "no decoding" / is "faster than Track Analysis" predate the decode-based peak — now describe the actual behavior.

## Verification

`cargo build`, `cargo clippy` on mp3rgui pass (warning set identical to master).