### PR TITLE
Deduplicate CLI fan-out boilerplate, dry-run clipping summaries, and MP4 box navigation

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -18,6 +18,7 @@ use std::sync::OnceLock;
 
 use crate::aac_codebooks;
 use crate::mp4meta;
+use crate::mp4meta::{read_u32_be, read_u64_be};
 
 // =============================================================================
 // Public types
@@ -387,29 +388,6 @@ struct SampleEntry {
     size: u32,
 }
 
-/// Read a u32 big-endian from data at offset
-fn read_u32_be(data: &[u8], offset: usize) -> u32 {
-    u32::from_be_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-    ])
-}
-
-fn read_u64_be(data: &[u8], offset: usize) -> u64 {
-    u64::from_be_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-        data[offset + 4],
-        data[offset + 5],
-        data[offset + 6],
-        data[offset + 7],
-    ])
-}
-
 /// Verify that `count` entries of `entry_size` bytes starting at `start` fit
 /// inside `data`. Counts come straight from the file, so a malformed MP4 can
 /// otherwise drive out-of-bounds reads or multi-GB allocations.
@@ -539,82 +517,23 @@ fn build_sample_table(data: &[u8]) -> Result<(Vec<SampleEntry>, usize)> {
     Ok((entries, stsd_pos))
 }
 
+/// Find the first AAC (mp4a) trak's stbl. Returns
+/// `(stbl_start, stbl_size, stsd_pos)`.
 fn find_audio_stbl(
     data: &[u8],
     moov_start: usize,
     moov_size: usize,
 ) -> Result<(usize, usize, usize)> {
-    let mut search_pos = moov_start;
-    let moov_end = moov_start + moov_size;
-
-    while search_pos < moov_end {
-        let (trak_pos, trak_header) = match mp4meta::find_box_in_container(
-            data,
-            search_pos,
-            moov_end - search_pos,
-            mp4meta::TRAK,
-        ) {
-            Some(x) => x,
-            None => break,
-        };
-
-        if let Some(result) = find_aac_stbl_in_trak(data, &trak_header, trak_pos) {
-            return Ok(result);
-        }
-
-        // size == 0 means "extends to EOF" — nothing can follow, and
-        // advancing by 0 would loop forever on a malformed file.
-        if trak_header.size == 0 {
-            break;
-        }
-        search_pos = trak_pos + trak_header.size as usize;
-    }
-
-    Err(Error::NoAacTrack)
-}
-
-/// Navigate trak -> mdia -> minf -> stbl -> stsd and check for mp4a codec.
-/// Returns (stbl_start, stbl_size, stsd_pos) if this trak contains AAC audio.
-fn find_aac_stbl_in_trak(
-    data: &[u8],
-    trak_header: &mp4meta::BoxHeader,
-    trak_pos: usize,
-) -> Option<(usize, usize, usize)> {
-    let trak_start = trak_pos + trak_header.header_size as usize;
-    let trak_size = trak_header.content_size() as usize;
-
-    let (mdia_pos, mdia_h) =
-        mp4meta::find_box_in_container(data, trak_start, trak_size, mp4meta::MDIA)?;
-    let (minf_pos, minf_h) = mp4meta::find_box_in_container(
-        data,
-        mdia_pos + mdia_h.header_size as usize,
-        mdia_h.content_size() as usize,
-        mp4meta::MINF,
-    )?;
-    let (stbl_pos, stbl_h) = mp4meta::find_box_in_container(
-        data,
-        minf_pos + minf_h.header_size as usize,
-        minf_h.content_size() as usize,
-        mp4meta::STBL,
-    )?;
-
-    let stbl_start = stbl_pos + stbl_h.header_size as usize;
-    let stbl_size = stbl_h.content_size() as usize;
-
-    let (stsd_pos, stsd_h) =
-        mp4meta::find_box_in_container(data, stbl_start, stbl_size, mp4meta::STSD)?;
-
-    let entries_start = stsd_pos + stsd_h.header_size as usize + 8;
-    if entries_start + 8 > data.len() {
-        return None;
-    }
-
-    let entry_type = read_u32_be(data, entries_start + 4);
-    if entry_type == mp4meta::MP4A {
-        Some((stbl_start, stbl_size, stsd_pos))
-    } else {
-        None
-    }
+    mp4meta::traks(data, moov_start, moov_size)
+        .find_map(|(trak_start, trak_size)| {
+            let info = mp4meta::find_trak_sample_info(data, trak_start, trak_size)?;
+            (info.entry_type == mp4meta::MP4A).then_some((
+                info.stbl_start,
+                info.stbl_size,
+                info.stsd_pos,
+            ))
+        })
+        .ok_or(Error::NoAacTrack)
 }
 
 fn parse_chunk_offsets(data: &[u8], stbl_start: usize, stbl_size: usize) -> Result<Vec<u64>> {

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -427,6 +427,20 @@ fn apply_mp3_id3v2_bytes(
     Ok(modified)
 }
 
+/// Build a unique `.mp3rgain_temp_*` sibling path for `file`. Shared by the
+/// MP3 temp-file write and the MP4 `atomic_write` so parallel tasks writing
+/// in the same directory never collide (one process-wide counter).
+pub(crate) fn temp_sibling_path(file: &Path, ext: &str) -> std::path::PathBuf {
+    let parent = file.parent().unwrap_or(Path::new("."));
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".mp3rgain_temp_{}_{}.{}",
+        std::process::id(),
+        counter,
+        ext
+    ))
+}
+
 fn with_temp_file<F>(file: &Path, use_temp: bool, operation: F) -> Result<usize>
 where
     F: FnOnce(&Path, &Path) -> Result<usize>,
@@ -435,13 +449,7 @@ where
         return operation(file, file);
     }
 
-    let parent = file.parent().unwrap_or(Path::new("."));
-    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let temp_path = parent.join(format!(
-        ".mp3rgain_temp_{}_{}.mp3",
-        std::process::id(),
-        counter
-    ));
+    let temp_path = temp_sibling_path(file, "mp3");
 
     match operation(file, &temp_path) {
         Ok(frames) => {

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::{analyze, steps_to_db, Channel};
-use rayon::prelude::*;
-use std::io::{self, Write};
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::threading::effective_threads;
-use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::json_output::{JsonFileResult, JsonOutput};
+use crate::commands::utils::{create_json_summary, finish_with_summary, for_each_file};
+use crate::json_output::JsonOutput;
 use crate::processors::apply::{process_apply, process_apply_channel};
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
 pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
@@ -51,112 +48,26 @@ pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-    let mut successful = 0;
-    let mut failed = 0;
-
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(JsonFileResult, String, Option<String>)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String, Option<String>)> {
-                let (result, text) = process_apply(file, steps, opts)?;
-                let tsv_line = if opts.output_format == OutputFormat::Tsv {
-                    analyze(file).ok().map(|info| {
-                        format!(
-                            "{}\t{}\t{:.1}\t{:.6}\t{}\t{}",
-                            get_filename(file),
-                            steps,
-                            db_value,
-                            1.0,
-                            info.max_gain(),
-                            info.min_gain()
-                        )
-                    })
-                } else {
-                    None
-                };
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok((result, text, tsv_line))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text, tsv) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-            if let Some(line) = tsv {
-                writeln!(handle, "{}", line)?;
+    let (json_results, successful, failed) = for_each_file(files, opts, |file| {
+        let (result, mut text) = process_apply(file, steps, opts)?;
+        if opts.output_format == OutputFormat::Tsv {
+            if let Ok(info) = analyze(file) {
+                writeln!(
+                    text,
+                    "{}\t{}\t{:.1}\t{:.6}\t{}\t{}",
+                    get_filename(file),
+                    steps,
+                    db_value,
+                    1.0,
+                    info.max_gain(),
+                    info.min_gain()
+                )?;
             }
         }
-        drop(handle);
+        Ok((Some(result), text))
+    })?;
 
-        for (result, _, _) in collected {
-            update_counters(&result, &mut successful, &mut failed);
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_apply(file, steps, opts)?;
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            update_counters(&result, &mut successful, &mut failed);
-
-            if opts.output_format == OutputFormat::Tsv {
-                if let Ok(info) = analyze(file) {
-                    println!(
-                        "{}\t{}\t{:.1}\t{:.6}\t{}\t{}",
-                        filename,
-                        steps,
-                        db_value,
-                        1.0,
-                        info.max_gain(),
-                        info.min_gain()
-                    );
-                }
-            }
-
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: Some(create_json_summary(
-                files.len(),
-                successful,
-                failed,
-                opts.dry_run,
-            )),
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_dry_run_notice(opts);
-    }
-
-    Ok(())
+    finish_with_summary(files.len(), json_results, successful, failed, opts)
 }
 
 pub fn cmd_apply_channel(
@@ -201,78 +112,10 @@ pub fn cmd_apply_channel(
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-    let mut successful = 0;
-    let mut failed = 0;
+    let (json_results, successful, failed) = for_each_file(files, opts, |file| {
+        let (result, text) = process_apply_channel(file, channel, steps, opts)?;
+        Ok((Some(result), text))
+    })?;
 
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(JsonFileResult, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String)> {
-                let r = process_apply_channel(file, channel, steps, opts)?;
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            update_counters(&result, &mut successful, &mut failed);
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_apply_channel(file, channel, steps, opts)?;
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            update_counters(&result, &mut successful, &mut failed);
-
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: Some(create_json_summary(
-                files.len(),
-                successful,
-                failed,
-                opts.dry_run,
-            )),
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_dry_run_notice(opts);
-    }
-
-    Ok(())
+    finish_with_summary(files.len(), json_results, successful, failed, opts)
 }

--- a/src/commands/max_amplitude.rs
+++ b/src/commands/max_amplitude.rs
@@ -1,15 +1,12 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::{find_max_amplitude, peak_to_headroom_db, peak_to_pcm_sample};
-use rayon::prelude::*;
 use std::fmt::Write as _;
-use std::io::{self, Write as IoWrite};
 use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::threading::effective_threads;
-use crate::json_output::{FileStatus, JsonFileResult, JsonOutput};
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::commands::utils::{finish_without_summary, for_each_file};
+use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
 pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
@@ -22,68 +19,10 @@ pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::new();
+    let (json_results, _, _) =
+        for_each_file(files, opts, |file| Ok(process_max_amplitude(file, opts)))?;
 
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(Option<JsonFileResult>, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(Option<JsonFileResult>, String)> {
-                let r = process_max_amplitude(file, opts);
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            if let Some(r) = result {
-                json_results.push(r);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_max_amplitude(file, opts);
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            if let Some(r) = result {
-                json_results.push(r);
-            }
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: None,
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    }
-
-    Ok(())
+    finish_without_summary(json_results, opts)
 }
 
 fn process_max_amplitude(file: &Path, opts: &Options) -> (Option<JsonFileResult>, String) {

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -5,17 +5,13 @@ use mp3rgain::{
     TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
     TAG_REPLAYGAIN_TRACK_PEAK,
 };
-use rayon::prelude::*;
 use std::fmt::Write as _;
-use std::io::{self, Write as IoWrite};
 use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::threading::effective_threads;
-use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::json_output::{FileStatus, JsonFileResult, JsonOutput};
+use crate::commands::utils::{finish_with_summary, finish_without_summary, for_each_file};
+use crate::json_output::{FileStatus, JsonFileResult};
 use crate::processors::utils::{restore_timestamp, save_original_mtime};
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
 /// Tag values and labels for display in cmd_check_tags
@@ -121,75 +117,12 @@ pub fn cmd_delete_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-    let mut successful = 0;
-    let mut failed = 0;
+    let (json_results, successful, failed) = for_each_file(files, opts, |file| {
+        let (result, text) = process_delete_tags(file, opts)?;
+        Ok((Some(result), text))
+    })?;
 
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(JsonFileResult, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String)> {
-                let r = process_delete_tags(file, opts)?;
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            update_counters(&result, &mut successful, &mut failed);
-            json_results.push(result);
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_delete_tags(file, opts)?;
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            update_counters(&result, &mut successful, &mut failed);
-            json_results.push(result);
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: Some(create_json_summary(
-                files.len(),
-                successful,
-                failed,
-                opts.dry_run,
-            )),
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_dry_run_notice(opts);
-    }
-
-    Ok(())
+    finish_with_summary(files.len(), json_results, successful, failed, opts)
 }
 
 fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, String)> {
@@ -265,68 +198,10 @@ pub fn cmd_check_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::new();
+    let (json_results, _, _) =
+        for_each_file(files, opts, |file| Ok(process_check_tags(file, opts)))?;
 
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(Option<JsonFileResult>, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(Option<JsonFileResult>, String)> {
-                let r = process_check_tags(file, opts);
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            if let Some(r) = result {
-                json_results.push(r);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_check_tags(file, opts);
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            if let Some(r) = result {
-                json_results.push(r);
-            }
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: None,
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    }
-
-    Ok(())
+    finish_without_summary(json_results, opts)
 }
 
 fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, String) {

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -1,16 +1,10 @@
 use anyhow::Result;
 use colored::*;
-use rayon::prelude::*;
-use std::io::{self, Write};
 use std::path::PathBuf;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::threading::effective_threads;
-use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
-use crate::json_output::{JsonFileResult, JsonOutput};
+use crate::commands::utils::{finish_with_summary, for_each_file};
 use crate::processors::undo::process_undo;
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
-use crate::util::get_filename;
 
 pub fn cmd_undo(files: &[PathBuf], opts: &Options) -> Result<()> {
     let dry_run_prefix = opts.dry_run_prefix();
@@ -30,78 +24,10 @@ pub fn cmd_undo(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let pb = create_progress_bar(files.len(), opts);
-    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-    let mut successful = 0;
-    let mut failed = 0;
+    let (json_results, successful, failed) = for_each_file(files, opts, |file| {
+        let (result, text) = process_undo(file, opts)?;
+        Ok((Some(result), text))
+    })?;
 
-    let parallel = effective_threads(opts) > 1 && files.len() > 1;
-
-    if parallel {
-        let pb_ref = pb.as_ref();
-        let collected: Vec<(JsonFileResult, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String)> {
-                let r = process_undo(file, opts)?;
-                if let Some(pb) = pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            update_counters(&result, &mut successful, &mut failed);
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            progress_set_message(&pb, filename);
-
-            let (result, text) = process_undo(file, opts)?;
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-            update_counters(&result, &mut successful, &mut failed);
-
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-
-            progress_inc(&pb);
-        }
-    }
-
-    progress_finish(pb);
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: Some(create_json_summary(
-                files.len(),
-                successful,
-                failed,
-                opts.dry_run,
-            )),
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_dry_run_notice(opts);
-    }
-
-    Ok(())
+    finish_with_summary(files.len(), json_results, successful, failed, opts)
 }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,7 +1,128 @@
+use anyhow::Result;
 use colored::*;
+use rayon::prelude::*;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::json_output::{FileStatus, JsonFileResult, JsonSummary};
+use crate::commands::threading::effective_threads;
+use crate::json_output::{FileStatus, JsonFileResult, JsonOutput, JsonSummary};
+use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::util::get_filename;
+
+/// Run `per_file` over every file — in parallel when `-j` allows it — with
+/// progress reporting and ordered stdout flushing. `per_file` returns the
+/// optional JSON record plus the text to print for that file; records are
+/// collected in input order and counted into (successful, failed).
+///
+/// This is the shared fan-out driver for the per-file commands (apply,
+/// channel apply, undo, delete tags, check tags, max amplitude), which all
+/// repeated the progress-bar / par_iter / ordered-flush / counter loop.
+pub fn for_each_file<F>(
+    files: &[PathBuf],
+    opts: &Options,
+    per_file: F,
+) -> Result<(Vec<JsonFileResult>, usize, usize)>
+where
+    F: Fn(&Path) -> Result<(Option<JsonFileResult>, String)> + Sync,
+{
+    let pb = create_progress_bar(files.len(), opts);
+    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
+    let mut successful = 0;
+    let mut failed = 0;
+
+    let parallel = effective_threads(opts) > 1 && files.len() > 1;
+
+    if parallel {
+        let pb_ref = pb.as_ref();
+        let collected: Vec<(Option<JsonFileResult>, String)> = files
+            .par_iter()
+            .map(|file| -> Result<(Option<JsonFileResult>, String)> {
+                let r = per_file(file)?;
+                if let Some(pb) = pb_ref {
+                    pb.set_message(get_filename(file).to_string());
+                    pb.inc(1);
+                }
+                Ok(r)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+        for (_, text) in &collected {
+            if !text.is_empty() {
+                handle.write_all(text.as_bytes())?;
+            }
+        }
+        drop(handle);
+
+        for (result, _) in collected {
+            if let Some(result) = result {
+                update_counters(&result, &mut successful, &mut failed);
+                json_results.push(result);
+            }
+        }
+    } else {
+        for file in files {
+            progress_set_message(&pb, get_filename(file));
+
+            let (result, text) = per_file(file)?;
+            if !text.is_empty() {
+                print!("{}", text);
+            }
+            if let Some(result) = result {
+                update_counters(&result, &mut successful, &mut failed);
+                json_results.push(result);
+            }
+
+            progress_inc(&pb);
+        }
+    }
+
+    progress_finish(pb);
+    Ok((json_results, successful, failed))
+}
+
+/// Shared command epilogue: JSON output (with per-run summary) in JSON mode,
+/// otherwise the dry-run notice.
+pub fn finish_with_summary(
+    total_files: usize,
+    json_results: Vec<JsonFileResult>,
+    successful: usize,
+    failed: usize,
+    opts: &Options,
+) -> Result<()> {
+    if opts.output_format == OutputFormat::Json {
+        let output = JsonOutput {
+            files: Some(json_results),
+            album: None,
+            summary: Some(create_json_summary(
+                total_files,
+                successful,
+                failed,
+                opts.dry_run,
+            )),
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_dry_run_notice(opts);
+    }
+    Ok(())
+}
+
+/// Epilogue for read-only commands (check tags, max amplitude): JSON output
+/// without a summary block, nothing otherwise.
+pub fn finish_without_summary(json_results: Vec<JsonFileResult>, opts: &Options) -> Result<()> {
+    if opts.output_format == OutputFormat::Json {
+        let output = JsonOutput {
+            files: Some(json_results),
+            album: None,
+            summary: None,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    }
+    Ok(())
+}
 
 pub fn update_counters(result: &JsonFileResult, successful: &mut usize, failed: &mut usize) {
     match result.status {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -304,8 +304,52 @@ pub(crate) fn is_xing_frame(data: &[u8], frame_offset: usize, header: &FrameHead
     marker == b"Xing" || marker == b"Info"
 }
 
+/// Scan forward from `pos` to the next valid, non-Xing MP3 frame.
+/// Returns `(frame_pos, header, next_pos)`, or `None` when no further
+/// frame exists before `audio_end`. Shared by the frame iterator and the
+/// gain-apply walks so the scan/validate/skip-Xing logic exists once.
+fn next_frame(
+    data: &[u8],
+    mut pos: usize,
+    audio_end: usize,
+) -> Option<(usize, FrameHeader, usize)> {
+    while pos + 4 <= audio_end {
+        let header = match parse_header(&data[pos..]) {
+            Some(h) => h,
+            None => {
+                pos += 1;
+                continue;
+            }
+        };
+
+        let next_pos = pos + header.frame_size;
+
+        // A frame is valid when another sync word follows it, or when it
+        // ends exactly at the audio end.
+        let valid_frame = if next_pos + 2 <= audio_end {
+            data[next_pos] == 0xFF && (data[next_pos + 1] & 0xE0) == 0xE0
+        } else {
+            next_pos <= audio_end
+        };
+
+        if !valid_frame {
+            pos += 1;
+            continue;
+        }
+
+        // Skip Xing/Info VBR header frames to match mp3gain behavior.
+        if is_xing_frame(data, pos, &header) {
+            pos = next_pos;
+            continue;
+        }
+
+        return Some((pos, header, next_pos));
+    }
+
+    None
+}
+
 /// Internal function to iterate over frames
-/// Skips Xing/Info VBR header frames to match mp3gain behavior
 pub(crate) fn iterate_frames<F>(data: &[u8], mut callback: F) -> Result<usize>
 where
     F: FnMut(usize, &FrameHeader, &[GainLocation]),
@@ -318,35 +362,9 @@ where
         bit_offset: 0,
     }; MAX_GAIN_LOCATIONS];
 
-    while pos + 4 <= audio_end {
-        let header = match parse_header(&data[pos..]) {
-            Some(h) => h,
-            None => {
-                pos += 1;
-                continue;
-            }
-        };
-
-        let next_pos = pos + header.frame_size;
-
-        let valid_frame = if next_pos + 2 <= audio_end {
-            data[next_pos] == 0xFF && (data[next_pos + 1] & 0xE0) == 0xE0
-        } else {
-            next_pos <= audio_end
-        };
-
-        if !valid_frame {
-            pos += 1;
-            continue;
-        }
-
-        if is_xing_frame(data, pos, &header) {
-            pos = next_pos;
-            continue;
-        }
-
-        let len = calculate_gain_locations(pos, &header, &mut locations);
-        callback(pos, &header, &locations[..len]);
+    while let Some((frame_pos, header, next_pos)) = next_frame(data, pos, audio_end) {
+        let len = calculate_gain_locations(frame_pos, &header, &mut locations);
+        callback(frame_pos, &header, &locations[..len]);
 
         frame_count += 1;
         pos = next_pos;
@@ -380,63 +398,15 @@ pub(crate) fn adjust_gain_value(current: u8, steps: i32, mode: GainMode) -> u8 {
     }
 }
 
-/// Internal function to apply gain to all frames in data
-pub(crate) fn apply_gain_to_data(data: &mut [u8], gain_steps: i32, mode: GainMode) -> usize {
-    let audio_end = find_audio_end(data);
-    let mut pos = skip_id3v2(data);
-    let mut modified_frames = 0;
-    let mut locations = [GainLocation {
-        byte_offset: 0,
-        bit_offset: 0,
-    }; MAX_GAIN_LOCATIONS];
-
-    while pos + 4 <= audio_end {
-        let header = match parse_header(&data[pos..]) {
-            Some(h) => h,
-            None => {
-                pos += 1;
-                continue;
-            }
-        };
-
-        let next_pos = pos + header.frame_size;
-
-        let valid_frame = if next_pos + 2 <= audio_end {
-            data[next_pos] == 0xFF && (data[next_pos + 1] & 0xE0) == 0xE0
-        } else {
-            next_pos <= audio_end
-        };
-
-        if !valid_frame {
-            pos += 1;
-            continue;
-        }
-
-        if is_xing_frame(data, pos, &header) {
-            pos = next_pos;
-            continue;
-        }
-
-        let len = calculate_gain_locations(pos, &header, &mut locations);
-
-        for loc in &locations[..len] {
-            let current_gain = read_gain_at(data, loc);
-            let new_gain = adjust_gain_value(current_gain, gain_steps, mode);
-            write_gain_at(data, loc, new_gain);
-        }
-
-        modified_frames += 1;
-        pos = next_pos;
-    }
-
-    modified_frames
-}
-
-/// Internal function to apply gain to a specific channel in data
-pub(crate) fn apply_gain_to_channel_data(
+/// Internal function to apply gain to frames in data. With
+/// `channel_index = None` every gain location in each frame is adjusted;
+/// with `Some(ch)` only that channel's location per granule is touched
+/// (always saturating — wrap mode has no channel-specific path).
+pub(crate) fn apply_gain_to_data(
     data: &mut [u8],
-    channel_index: usize,
     gain_steps: i32,
+    mode: GainMode,
+    channel_index: Option<usize>,
 ) -> usize {
     let audio_end = find_audio_end(data);
     let mut pos = skip_id3v2(data);
@@ -446,44 +416,29 @@ pub(crate) fn apply_gain_to_channel_data(
         bit_offset: 0,
     }; MAX_GAIN_LOCATIONS];
 
-    while pos + 4 <= audio_end {
-        let header = match parse_header(&data[pos..]) {
-            Some(h) => h,
+    while let Some((frame_pos, header, next_pos)) = next_frame(data, pos, audio_end) {
+        let len = calculate_gain_locations(frame_pos, &header, &mut locations);
+
+        match channel_index {
             None => {
-                pos += 1;
-                continue;
+                for loc in &locations[..len] {
+                    let current_gain = read_gain_at(data, loc);
+                    let new_gain = adjust_gain_value(current_gain, gain_steps, mode);
+                    write_gain_at(data, loc, new_gain);
+                }
             }
-        };
-
-        let next_pos = pos + header.frame_size;
-
-        let valid_frame = if next_pos + 2 <= audio_end {
-            data[next_pos] == 0xFF && (data[next_pos + 1] & 0xE0) == 0xE0
-        } else {
-            next_pos <= audio_end
-        };
-
-        if !valid_frame {
-            pos += 1;
-            continue;
-        }
-
-        if is_xing_frame(data, pos, &header) {
-            pos = next_pos;
-            continue;
-        }
-
-        let len = calculate_gain_locations(pos, &header, &mut locations);
-        let num_channels = header.channel_mode.channel_count();
-        let num_granules = header.granule_count();
-
-        for gr in 0..num_granules {
-            let loc_index = gr * num_channels + channel_index;
-            if loc_index < len {
-                let loc = &locations[loc_index];
-                let current_gain = read_gain_at(data, loc);
-                let new_gain = adjust_gain_value(current_gain, gain_steps, GainMode::Saturating);
-                write_gain_at(data, loc, new_gain);
+            Some(ch) => {
+                let num_channels = header.channel_mode.channel_count();
+                for gr in 0..header.granule_count() {
+                    let loc_index = gr * num_channels + ch;
+                    if loc_index < len {
+                        let loc = &locations[loc_index];
+                        let current_gain = read_gain_at(data, loc);
+                        let new_gain =
+                            adjust_gain_value(current_gain, gain_steps, GainMode::Saturating);
+                        write_gain_at(data, loc, new_gain);
+                    }
+                }
             }
         }
 

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -4,7 +4,7 @@ use crate::ape::{
     TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
-use crate::frame::{apply_gain_to_channel_data, apply_gain_to_data, GainMode};
+use crate::frame::{apply_gain_to_data, GainMode};
 
 use std::fs;
 use std::path::Path;
@@ -223,10 +223,10 @@ pub(crate) fn apply_undo_to_data(data: &mut [u8], left: i32, right: i32, wrap: b
         } else {
             GainMode::Saturating
         };
-        apply_gain_to_data(data, -left, mode)
+        apply_gain_to_data(data, -left, mode, None)
     } else {
-        let left_frames = apply_gain_to_channel_data(data, 0, -left);
-        let right_frames = apply_gain_to_channel_data(data, 1, -right);
+        let left_frames = apply_gain_to_data(data, -left, GainMode::Saturating, Some(0));
+        let right_frames = apply_gain_to_data(data, -right, GainMode::Saturating, Some(1));
         left_frames.max(right_frames)
     }
 }
@@ -310,7 +310,7 @@ fn apply_gain_simple_to_path(
 ) -> Result<usize> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
-    let modified_frames = apply_gain_to_data(&mut data, gain_steps, mode);
+    let modified_frames = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
 
@@ -348,7 +348,7 @@ fn apply_gain_with_undo_impl_to_path(
         tag.set_minmax(analysis.min_gain(), analysis.max_gain());
     }
 
-    let frames = apply_gain_to_data(&mut data, gain_steps, mode);
+    let frames = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
@@ -369,7 +369,12 @@ fn apply_gain_channel_impl(
         return Err(Error::ChannelGainOnMono);
     }
 
-    let modified_frames = apply_gain_to_channel_data(&mut data, channel.index(), gain_steps);
+    let modified_frames = apply_gain_to_data(
+        &mut data,
+        gain_steps,
+        GainMode::Saturating,
+        Some(channel.index()),
+    );
 
     fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
 
@@ -404,7 +409,12 @@ fn apply_gain_channel_with_undo(
         tag.set_minmax(analysis.min_gain(), analysis.max_gain());
     }
 
-    let frames = apply_gain_to_channel_data(&mut data, channel.index(), gain_steps);
+    let frames = apply_gain_to_data(
+        &mut data,
+        gain_steps,
+        GainMode::Saturating,
+        Some(channel.index()),
+    );
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -24,12 +24,6 @@ use crate::error::{Error, Result};
 use std::fs;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-// Per-process counter for atomic_write temp filenames. Without this, parallel
-// callers writing to MP4 files in the same parent directory would collide on
-// `.mp3rgain_temp_{pid}.m4a`.
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// ReplayGain tag keys (iTunes freeform format)
 pub const RG_TRACK_GAIN: &str = "replaygain_track_gain";
@@ -621,13 +615,7 @@ pub fn write_replaygain_tags(file_path: &Path, tags: &ReplayGainTags) -> Result<
 /// Atomic write: write to a temp file then rename over the original.
 /// Falls back to direct write if rename fails (e.g., cross-filesystem).
 pub(crate) fn atomic_write(file_path: &Path, data: &[u8]) -> Result<()> {
-    let parent = file_path.parent().unwrap_or(Path::new("."));
-    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let temp_path = parent.join(format!(
-        ".mp3rgain_temp_{}_{}.m4a",
-        std::process::id(),
-        counter
-    ));
+    let temp_path = crate::apply::temp_sibling_path(file_path, "m4a");
 
     if let Err(e) = fs::write(&temp_path, data) {
         let _ = fs::remove_file(&temp_path);
@@ -1305,6 +1293,10 @@ impl Iterator for TrakIter<'_> {
 
 /// stbl location and codec identifier for one trak, from
 /// [`find_trak_sample_info`].
+//
+// The stbl/stsd fields are only consumed by the `aac` module's
+// sample-table builder; without that feature only `entry_type` is read.
+#[cfg_attr(not(feature = "aac"), allow(dead_code))]
 pub(crate) struct TrakSampleInfo {
     pub(crate) stbl_start: usize,
     pub(crate) stbl_size: usize,

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -348,6 +348,32 @@ pub(crate) fn find_box_in_container(
     None
 }
 
+/// Read u32 big-endian from data at offset. Shared with the `aac` module —
+/// callers are responsible for bounds (panics on out-of-range, like direct
+/// indexing).
+pub(crate) fn read_u32_be(data: &[u8], offset: usize) -> u32 {
+    u32::from_be_bytes([
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+    ])
+}
+
+/// Read u64 big-endian from data at offset. See [`read_u32_be`].
+pub(crate) fn read_u64_be(data: &[u8], offset: usize) -> u64 {
+    u64::from_be_bytes([
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+        data[offset + 4],
+        data[offset + 5],
+        data[offset + 6],
+        data[offset + 7],
+    ])
+}
+
 /// Parse freeform tag from data
 fn parse_freeform_tag(data: &[u8]) -> Option<FreeformTag> {
     let mut cursor = Cursor::new(data);
@@ -1006,12 +1032,7 @@ fn create_udta_box(content: &[u8]) -> Vec<u8> {
 }
 
 fn read_box_size(data: &[u8], box_pos: usize) -> usize {
-    u32::from_be_bytes([
-        data[box_pos],
-        data[box_pos + 1],
-        data[box_pos + 2],
-        data[box_pos + 3],
-    ]) as usize
+    read_u32_be(data, box_pos) as usize
 }
 
 fn update_box_size(data: &mut [u8], box_pos: usize, size_diff: i64) {
@@ -1019,12 +1040,7 @@ fn update_box_size(data: &mut [u8], box_pos: usize, size_diff: i64) {
         return;
     }
 
-    let current_size = u32::from_be_bytes([
-        data[box_pos],
-        data[box_pos + 1],
-        data[box_pos + 2],
-        data[box_pos + 3],
-    ]);
+    let current_size = read_u32_be(data, box_pos);
 
     // Don't update if it's an extended size box (size == 1) or extends to EOF (size == 0)
     if current_size <= 1 {
@@ -1076,9 +1092,8 @@ fn update_offsets_recursive(
     let mut pos = start;
 
     while pos + 8 <= end {
-        let size = u32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
-        let box_type =
-            u32::from_be_bytes([data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7]]);
+        let size = read_u32_be(data, pos);
+        let box_type = read_u32_be(data, pos + 4);
 
         if size == 0 || pos + size as usize > end {
             break;
@@ -1090,24 +1105,14 @@ fn update_offsets_recursive(
                 let version_flags_pos = pos + 8;
                 let entry_count_pos = version_flags_pos + 4;
                 if entry_count_pos + 4 <= data.len() {
-                    let entry_count = u32::from_be_bytes([
-                        data[entry_count_pos],
-                        data[entry_count_pos + 1],
-                        data[entry_count_pos + 2],
-                        data[entry_count_pos + 3],
-                    ]);
+                    let entry_count = read_u32_be(data, entry_count_pos);
 
                     let mut offset_pos = entry_count_pos + 4;
                     for _ in 0..entry_count {
                         if offset_pos + 4 > data.len() {
                             break;
                         }
-                        let offset = u32::from_be_bytes([
-                            data[offset_pos],
-                            data[offset_pos + 1],
-                            data[offset_pos + 2],
-                            data[offset_pos + 3],
-                        ]);
+                        let offset = read_u32_be(data, offset_pos);
                         if (offset as usize) >= threshold {
                             let new_offset = (offset as i64 + size_diff) as u32;
                             data[offset_pos..offset_pos + 4]
@@ -1122,28 +1127,14 @@ fn update_offsets_recursive(
                 let version_flags_pos = pos + 8;
                 let entry_count_pos = version_flags_pos + 4;
                 if entry_count_pos + 4 <= data.len() {
-                    let entry_count = u32::from_be_bytes([
-                        data[entry_count_pos],
-                        data[entry_count_pos + 1],
-                        data[entry_count_pos + 2],
-                        data[entry_count_pos + 3],
-                    ]);
+                    let entry_count = read_u32_be(data, entry_count_pos);
 
                     let mut offset_pos = entry_count_pos + 4;
                     for _ in 0..entry_count {
                         if offset_pos + 8 > data.len() {
                             break;
                         }
-                        let offset = u64::from_be_bytes([
-                            data[offset_pos],
-                            data[offset_pos + 1],
-                            data[offset_pos + 2],
-                            data[offset_pos + 3],
-                            data[offset_pos + 4],
-                            data[offset_pos + 5],
-                            data[offset_pos + 6],
-                            data[offset_pos + 7],
-                        ]);
+                        let offset = read_u64_be(data, offset_pos);
                         if (offset as usize) >= threshold {
                             let new_offset = (offset as i64 + size_diff) as u64;
                             data[offset_pos..offset_pos + 8]
@@ -1196,7 +1187,7 @@ pub fn is_mp4_file(file_path: &Path) -> bool {
     if bytes_read < 12 {
         return false;
     }
-    let size = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    let size = read_u32_be(&buf, 0) as usize;
     if &buf[4..8] != b"ftyp" || size < 12 {
         return false;
     }
@@ -1270,35 +1261,66 @@ fn read_moov_content(file_path: &Path) -> Option<Vec<u8>> {
     None
 }
 
-/// Detect the audio codec in an MP4 file by inspecting the stsd box.
-/// Navigates moov → trak → mdia → minf → stbl → stsd to find the codec.
-pub fn detect_mp4_audio_codec(file_path: &Path) -> Option<Mp4AudioCodec> {
-    let moov = read_moov_content(file_path)?;
-
-    // Search through all trak boxes for an audio track
-    let mut trak_search_pos = 0;
-
-    while trak_search_pos < moov.len() {
-        let (trak_pos, trak_header) =
-            find_box_in_container(&moov, trak_search_pos, moov.len() - trak_search_pos, TRAK)?;
-        let trak_start = trak_pos + trak_header.header_size as usize;
-        let trak_size = trak_header.content_size() as usize;
-
-        if let Some(codec) = detect_codec_in_trak(&moov, trak_start, trak_size) {
-            return Some(codec);
-        }
-
-        // size == 0 means "extends to EOF"; advancing by 0 would loop forever.
-        if trak_header.size == 0 {
-            break;
-        }
-        trak_search_pos = trak_pos + trak_header.size as usize;
+/// Iterate the trak boxes inside a container region of `data`, yielding
+/// `(trak_start, trak_size)` content ranges. Shared by codec detection,
+/// track counting, and the AAC sample-table builder, which all walked
+/// traks with the same loop.
+pub(crate) fn traks(data: &[u8], start: usize, size: usize) -> TrakIter<'_> {
+    TrakIter {
+        data,
+        pos: start,
+        end: start.saturating_add(size).min(data.len()),
     }
-
-    None
 }
 
-fn detect_codec_in_trak(data: &[u8], trak_start: usize, trak_size: usize) -> Option<Mp4AudioCodec> {
+pub(crate) struct TrakIter<'a> {
+    data: &'a [u8],
+    pos: usize,
+    end: usize,
+}
+
+impl Iterator for TrakIter<'_> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.end {
+            return None;
+        }
+        let (trak_pos, trak_header) =
+            find_box_in_container(self.data, self.pos, self.end - self.pos, TRAK)?;
+        let item = (
+            trak_pos + trak_header.header_size as usize,
+            trak_header.content_size() as usize,
+        );
+        // size == 0 means "extends to EOF" — nothing can follow, and
+        // advancing by 0 would loop forever on a malformed file.
+        self.pos = if trak_header.size == 0 {
+            self.end
+        } else {
+            trak_pos + trak_header.size as usize
+        };
+        Some(item)
+    }
+}
+
+/// stbl location and codec identifier for one trak, from
+/// [`find_trak_sample_info`].
+pub(crate) struct TrakSampleInfo {
+    pub(crate) stbl_start: usize,
+    pub(crate) stbl_size: usize,
+    pub(crate) stsd_pos: usize,
+    /// First stsd sample entry's box type (e.g. `mp4a`, `alac`, `avc1`).
+    pub(crate) entry_type: u32,
+}
+
+/// Navigate trak → mdia → minf → stbl → stsd and read the first sample
+/// entry's box type (the codec identifier). Shared by MP4 codec detection
+/// and the AAC sample-table builder.
+pub(crate) fn find_trak_sample_info(
+    data: &[u8],
+    trak_start: usize,
+    trak_size: usize,
+) -> Option<TrakSampleInfo> {
     let (mdia_pos, mdia_header) = find_box_in_container(data, trak_start, trak_size, MDIA)?;
     let mdia_start = mdia_pos + mdia_header.header_size as usize;
     let mdia_size = mdia_header.content_size() as usize;
@@ -1321,15 +1343,25 @@ fn detect_codec_in_trak(data: &[u8], trak_start: usize, trak_size: usize) -> Opt
         return None;
     }
 
-    // Read the first sample entry's box type (the codec identifier)
-    let entry_type = u32::from_be_bytes([
-        data[entries_start + 4],
-        data[entries_start + 5],
-        data[entries_start + 6],
-        data[entries_start + 7],
-    ]);
+    Some(TrakSampleInfo {
+        stbl_start,
+        stbl_size,
+        stsd_pos,
+        entry_type: read_u32_be(data, entries_start + 4),
+    })
+}
 
-    match entry_type {
+/// Detect the audio codec in an MP4 file by inspecting the stsd box.
+/// Navigates moov → trak → mdia → minf → stbl → stsd to find the codec.
+pub fn detect_mp4_audio_codec(file_path: &Path) -> Option<Mp4AudioCodec> {
+    let moov = read_moov_content(file_path)?;
+    traks(&moov, 0, moov.len())
+        .find_map(|(trak_start, trak_size)| detect_codec_in_trak(&moov, trak_start, trak_size))
+}
+
+fn detect_codec_in_trak(data: &[u8], trak_start: usize, trak_size: usize) -> Option<Mp4AudioCodec> {
+    let info = find_trak_sample_info(data, trak_start, trak_size)?;
+    match info.entry_type {
         MP4A => Some(Mp4AudioCodec::Aac),
         ALAC => Some(Mp4AudioCodec::Alac),
         _ => Some(Mp4AudioCodec::Unknown),
@@ -1355,32 +1387,11 @@ pub fn count_audio_tracks(file_path: &Path) -> usize {
         Some(m) => m,
         None => return 0,
     };
-
-    let mut count = 0;
-    let mut search_pos = 0;
-
-    while search_pos < moov.len() {
-        let (trak_pos, trak_header) =
-            match find_box_in_container(&moov, search_pos, moov.len() - search_pos, TRAK) {
-                Some(x) => x,
-                None => break,
-            };
-
-        // Check if this trak has an audio codec (mp4a or alac)
-        let trak_start = trak_pos + trak_header.header_size as usize;
-        let trak_size = trak_header.content_size() as usize;
-        if detect_codec_in_trak(&moov, trak_start, trak_size).is_some() {
-            count += 1;
-        }
-
-        // size == 0 means "extends to EOF"; advancing by 0 would loop forever.
-        if trak_header.size == 0 {
-            break;
-        }
-        search_pos = trak_pos + trak_header.size as usize;
-    }
-
-    count
+    traks(&moov, 0, moov.len())
+        .filter(|&(trak_start, trak_size)| {
+            detect_codec_in_trak(&moov, trak_start, trak_size).is_some()
+        })
+        .count()
 }
 
 #[cfg(test)]

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::apply::{apply_with_options, ApplyOptions, ClippingDetection};
-use mp3rgain::{analyze, mp4meta, steps_to_db, Channel, MAX_GAIN};
+use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions, ClippingDetection};
+use mp3rgain::{analyze, mp4meta, steps_to_db, Channel};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -32,10 +32,26 @@ fn process_apply_into(
     }
 
     // Dry run: don't touch the file. Headroom-based clipping prevention
-    // still needs to be reflected in the "would apply N steps" line.
+    // still needs to be reflected in the "would apply N steps" line, so
+    // drive the same clipping check through predict_apply.
+    //
+    // Without -k the steps are never capped, and the clipping warning is
+    // only emitted/recorded when neither -c (ignore) nor -q (quiet) is set.
+    // In that case the prediction feeds nothing the caller can observe, so
+    // skip it — a `--dry-run -c`/`-q` sweep then avoids a full read per file.
     if opts.dry_run {
         let (actual_steps, warning_msg) =
-            dry_run_clipping_summary(file, steps, opts, is_aac, dry_run_prefix, filename);
+            if !opts.prevent_clipping && (opts.ignore_clipping || opts.quiet) {
+                (steps, None)
+            } else {
+                let mut apply_opts = ApplyOptions::new(steps);
+                apply_opts.prevent_clipping = opts.prevent_clipping;
+                apply_opts.wrap = opts.wrap_gain;
+                let report = predict_apply(file, &apply_opts)?;
+                let warning =
+                    emit_clipping_warning_headroom(steps, &report, opts, dry_run_prefix, filename);
+                (report.actual_steps, warning)
+            };
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
                 out,
@@ -114,95 +130,8 @@ fn process_apply_into(
     }
 }
 
-/// Recompute the headroom-based clipping cap purely for the dry-run
-/// branch. Mirrors [`mp3rgain::apply::apply_with_options`]'s check.
-fn dry_run_clipping_summary(
-    file: &Path,
-    steps: i32,
-    opts: &Options,
-    is_aac: bool,
-    dry_run_prefix: &str,
-    filename: &str,
-) -> (i32, Option<String>) {
-    if steps <= 0 || opts.wrap_gain {
-        return (steps, None);
-    }
-
-    // Without -k the steps are never capped, and the clipping warning is only
-    // emitted/recorded when neither -c (ignore) nor -q (quiet) is set. In that
-    // case the analysis below feeds nothing the caller can observe, so skip it
-    // — a `--dry-run -c`/`-q` sweep then avoids a full read per file.
-    if !opts.prevent_clipping && (opts.ignore_clipping || opts.quiet) {
-        return (steps, None);
-    }
-
-    let headroom = if is_aac {
-        #[cfg(feature = "aac")]
-        {
-            mp3rgain::aac::analyze_aac_gains(file)
-                .ok()
-                .map(|a| MAX_GAIN.saturating_sub(a.max_gain()) as i32)
-        }
-        #[cfg(not(feature = "aac"))]
-        {
-            let _ = file;
-            None
-        }
-    } else {
-        analyze(file).ok().map(|i| i.headroom_steps())
-    };
-
-    let Some(headroom_steps) = headroom else {
-        return (steps, None);
-    };
-    if steps <= headroom_steps {
-        return (steps, None);
-    }
-    if opts.prevent_clipping {
-        let actual = headroom_steps;
-        if opts.output_format == OutputFormat::Text && !opts.quiet {
-            eprintln!(
-                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                steps,
-                actual
-            );
-        }
-        return (
-            actual,
-            Some(format!(
-                "gain reduced from {} to {} steps to prevent clipping",
-                steps, actual
-            )),
-        );
-    }
-    if !opts.ignore_clipping && !opts.quiet {
-        if opts.output_format == OutputFormat::Text {
-            eprintln!(
-                "  {} {}{} - clipping warning: requested {} steps but only {} headroom",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                steps,
-                headroom_steps
-            );
-            eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
-        }
-        return (
-            steps,
-            Some(format!(
-                "clipping warning: requested {} steps but only {} headroom",
-                steps, headroom_steps
-            )),
-        );
-    }
-    (steps, None)
-}
-
-/// Render the user-visible clipping warning after a real apply, using the
-/// headroom diagnostic from [`ApplyReport`].
+/// Render the user-visible clipping warning after a real or predicted
+/// apply, using the headroom diagnostic from [`ApplyReport`].
 fn emit_clipping_warning_headroom(
     requested_steps: i32,
     report: &mp3rgain::ApplyReport,

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use colored::*;
 use indicatif::ProgressBar;
-use mp3rgain::apply::{apply_with_options, ApplyOptions, ClippingDetection};
+use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions, ClippingDetection};
 use mp3rgain::replaygain::{self, AudioFileType, ReplayGainResult};
-use mp3rgain::{apply_gain_to_peak, mp4meta, steps_to_db, AacAlbumInfo};
+use mp3rgain::{mp4meta, steps_to_db, AacAlbumInfo};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -131,11 +131,17 @@ fn apply_replaygain_with_album_into(
     let is_aac = result.file_type() == AudioFileType::Aac;
 
     // Dry run: don't actually modify. Clipping prevention still needs to
-    // be reflected in the "would apply N steps" message, so mirror the
-    // ReplayGain-peak cap here without touching the file.
+    // be reflected in the "would apply N steps" message, so drive the same
+    // ReplayGain-peak cap through predict_apply without touching the file.
     if opts.dry_run {
-        let (actual_steps, warning_msg) =
-            dry_run_clipping_summary(steps, result, opts, dry_run_prefix, filename);
+        let mut apply_opts = ApplyOptions::new(steps);
+        apply_opts.track_result = Some(result.clone());
+        apply_opts.prevent_clipping = opts.prevent_clipping;
+        apply_opts.wrap = opts.wrap_gain;
+        let report = predict_apply(file, &apply_opts)?;
+        let warning_msg =
+            emit_clipping_warning_peak(steps, result, &report, opts, dry_run_prefix, filename);
+        let actual_steps = report.actual_steps;
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(
                 out,
@@ -231,78 +237,8 @@ fn apply_replaygain_with_album_into(
     }
 }
 
-/// Recompute the ReplayGain-peak clipping cap purely for the dry-run
-/// branch (no file writes). Mirrors [`mp3rgain::apply::apply_with_options`]
-/// for the same inputs so the displayed "would apply N steps" matches what
-/// a real apply would do.
-fn dry_run_clipping_summary(
-    steps: i32,
-    result: &ReplayGainResult,
-    opts: &Options,
-    dry_run_prefix: &str,
-    filename: &str,
-) -> (i32, Option<String>) {
-    if steps <= 0 || opts.wrap_gain {
-        return (steps, None);
-    }
-    let new_peak = apply_gain_to_peak(result.peak(), steps_to_db(steps));
-    if new_peak <= 1.0 {
-        return (steps, None);
-    }
-    if opts.prevent_clipping {
-        let max_safe_db = mp3rgain::peak_to_headroom_db(result.peak()).unwrap_or(0.0);
-        // Floor (not round) and allow negative results, matching the real
-        // apply path in `mp3rgain::apply::check_clipping`: round() could push
-        // the cap above true headroom, and clamping to 0 would leave an
-        // already-clipping source (peak > 1.0) still clipping in the preview
-        // while the real apply attenuates it (#173).
-        let actual = (max_safe_db / mp3rgain::GAIN_STEP_DB).floor() as i32;
-        if opts.output_format == OutputFormat::Text && !opts.quiet {
-            eprintln!(
-                "  {} {}{} - gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                steps,
-                actual,
-                result.peak()
-            );
-        }
-        return (
-            actual,
-            Some(format!(
-                "gain reduced from {} to {} steps to prevent clipping (peak: {:.4})",
-                steps,
-                actual,
-                result.peak()
-            )),
-        );
-    }
-    if !opts.ignore_clipping && !opts.quiet {
-        if opts.output_format == OutputFormat::Text {
-            eprintln!(
-                "  {} {}{} - clipping warning: peak would be {:.2} (>{:.2})",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                new_peak,
-                1.0
-            );
-            eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
-        }
-        return (
-            steps,
-            Some(format!(
-                "clipping warning: peak would be {:.2} (>1.00)",
-                new_peak
-            )),
-        );
-    }
-    (steps, None)
-}
-
-/// Render the user-visible clipping warning after a real apply, using the
-/// ReplayGain-peak diagnostic from [`ApplyReport`].
+/// Render the user-visible clipping warning after a real or predicted
+/// apply, using the ReplayGain-peak diagnostic from [`ApplyReport`].
 fn emit_clipping_warning_peak(
     requested_steps: i32,
     result: &ReplayGainResult,


### PR DESCRIPTION
## Summary

Fixes #191. Behavior-preserving refactor, net **−536 lines** (427 added / 963 removed).

> Originally stacked on #193; now rebased onto `master` after #193's squash merge.

## Changes (one commit per item)

**1. CLI dry-run clipping summaries → `predict_apply`**
`processors/apply.rs` (headroom variant) and `processors/replaygain.rs` (peak variant) re-implemented the library's `check_clipping` — including the `floor()` cap from #173 — plus near-identical warning strings. Both now call `predict_apply` and format the returned `ApplyReport` with the same `emit_clipping_warning_*` helpers the real apply path uses, so the dry-run preview can never drift from the real apply again. The `--dry-run -c`/`-q` fast path that skips per-file analysis is preserved.

**2. Per-file fan-out boilerplate (6 commands → 1 driver)**
`cmd_apply`, `cmd_apply_channel`, `cmd_undo`, `cmd_delete_tags`, `cmd_check_tags`, `cmd_max_amplitude` each repeated the ~60-line progress-bar / `par_iter` / ordered-stdout-flush / counter loop and epilogue. Now: `for_each_file(files, opts, per_file)` + `finish_with_summary` / `finish_without_summary` in `commands/utils.rs`. `cmd_apply`'s TSV line is appended to the per-file text inside the closure (same output order).

**3. `frame.rs` frame-walk dedup**
The ~40-line scan/validate/skip-Xing walk existed in `iterate_frames`, `apply_gain_to_data`, and `apply_gain_to_channel_data`. Extracted into `next_frame` (returns owned values, so the mutating apply paths can share it), and the channel variant folded into `apply_gain_to_data` behind an `Option<usize>` channel parameter (channel applies stay always-saturating).

**4. MP4 box navigation shared between `mp4meta` and `aac`**
The trak → mdia → minf → stbl → stsd descent existed in `detect_codec_in_trak` and `find_aac_stbl_in_trak`, and three functions repeated the trak-walk loop. Now: a `traks()` iterator + `find_trak_sample_info()` (returns stbl range, stsd pos, and the stsd entry type) serve all call sites. `read_u32_be`/`read_u64_be` moved from the feature-gated `aac` module into `mp4meta` and replace its hand-expanded `from_be_bytes` calls.
*One deliberate hardening:* the unified stsd bounds check is the stricter `mp4meta` variant (clamped to the declared stsd box end); the old `aac` check only clamped to the buffer, so a malformed stsd that undersizes its own box now reads as no-AAC-track instead of reading a codec id from past the box (in line with the #149/9471354 hardening).

**5. Misc**
Temp-file naming (`TEMP_COUNTER` + format string) was duplicated between `apply.rs::with_temp_file` and `mp4meta::atomic_write` — now one `temp_sibling_path(file, ext)` with a single process-wide counter.

## Intentionally deferred from the issue

- **`read_gain_tags_auto` shared library fn** (GUI `read_stored_tags` vs CLI `process_check_tags`): the two frontends differ in error handling, labels, and no-tag messages; a shared struct would add more API than it removes. Can revisit if the dispatch grows a third copy.
- **TSV min/max from pre-apply analysis**: deriving post-apply min/max without re-analyzing requires `ApplyReport` to carry gain-range data — an API change out of scope for a no-behavior-change PR.

## Verification

`cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` clean after the rebase; `cargo check --no-default-features` warning set identical to master.