### PR TITLE
ci: build and lint mp3rgui across all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,44 @@ jobs:
       - name: Build with replaygain feature
         run: cargo build --features replaygain --verbose
 
+  gui:
+    name: GUI on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            mp3rgui/target
+          key: ${{ runner.os }}-cargo-gui-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libxkbcommon-dev libwayland-dev libgtk-3-dev
+
+      - name: Check formatting
+        if: runner.os == 'Linux'
+        run: cargo fmt --manifest-path mp3rgui/Cargo.toml -- --check
+
+      - name: Build
+        run: cargo build --manifest-path mp3rgui/Cargo.toml --verbose
+
+      - name: Clippy
+        run: cargo clippy --manifest-path mp3rgui/Cargo.toml -- -D warnings
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -81,18 +81,10 @@ pub struct FileEntry {
 
 /// State for the "Apply Manual Gain" modal. `open` toggles visibility;
 /// `steps` is preserved across closes so the next open shows the same value.
+#[derive(Default)]
 pub struct ManualGainModal {
     pub open: bool,
     pub steps: i32,
-}
-
-impl Default for ManualGainModal {
-    fn default() -> Self {
-        Self {
-            open: false,
-            steps: 0,
-        }
-    }
 }
 
 /// State for the "Apply Channel Gain" modal (`-l`).


### PR DESCRIPTION
## Problem

The GUI subproject `mp3rgui` is a standalone crate (not a workspace member), so the root `cargo build` in `ci.yml` never compiled it. Only `release.yml` builds the GUI, and that workflow runs **on tags only**.

As a result, platform-specific GUI code went completely unvalidated on PRs and first compiled at release time. PR #198 (the Windows `explorer /select` reveal fix) was a concrete example: its Windows-only `raw_arg` block was never compiled by CI before merge.

## Change

Add a `gui` job that, across **ubuntu / macos / windows**:

- builds `mp3rgui` (`cargo build --manifest-path mp3rgui/Cargo.toml`)
- runs `cargo clippy ... -- -D warnings`

plus an `fmt --check` on Linux (formatting is OS-independent). Linux system deps mirror `release.yml` (`libxkbcommon-dev libwayland-dev libgtk-3-dev`).

This makes every platform's `#[cfg]` branch (Windows `explorer /select`, macOS `open -R`, Linux `xdg-open`) compile-checked on PRs instead of only at release.

Also replaces a manual `Default` impl in `app.rs` with `#[derive(Default)]` to satisfy the new `-D warnings` clippy gate (`false`/`0` are identical to the derived defaults — no behavior change).

## Verification (local)

- `cargo fmt --manifest-path mp3rgui/Cargo.toml -- --check` → OK
- `cargo clippy --manifest-path mp3rgui/Cargo.toml -- -D warnings` → exit 0
- `cargo check` (host + `x86_64-pc-windows-msvc` type-check) → OK