### PR TITLE
Fix 0-step RG skip (#206) and warn on global_gain saturation (#207)

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -21,6 +21,7 @@ use std::time::SystemTime;
 #[cfg(feature = "aac")]
 use crate::aac;
 use crate::error::{Error, Result};
+use crate::frame::SaturationStats;
 use crate::gain::{
     apply_gain_to_peak, peak_to_headroom_db, steps_to_db, Channel, GainOptions, GAIN_STEP_DB,
     MAX_GAIN,
@@ -144,6 +145,15 @@ pub struct ApplyReport {
     /// `prevent_clipping` is off. `None` if no check ran (steps<=0 or
     /// wrap mode).
     pub clipping_detected: Option<ClippingDetection>,
+
+    /// MP3 global_gain values that clamped at 0 (silence) during a
+    /// saturating apply, where the requested gain couldn't be fully
+    /// applied (issue #207). Always 0 for wrap mode and for [`predict_apply`].
+    pub saturated_low: usize,
+
+    /// MP3 global_gain values that clamped at 255 (distortion) during a
+    /// saturating apply (issue #207).
+    pub saturated_high: usize,
 }
 
 /// Per-strategy clipping signal.
@@ -194,13 +204,17 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
         &mut aac_analysis,
     )?;
 
-    // 2) Apply gain to bytes.
+    // 2) Apply gain to bytes. MP3 reports global_gain saturation (issue
+    // #207); AAC clamps in its own path and isn't tallied here.
+    let mut saturation = SaturationStats::default();
     let modified = if is_aac {
         apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
     } else if opts.use_id3v2 {
-        apply_mp3_id3v2_bytes(file_path, actual_steps, opts, &mut mp3_analysis)?
+        saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts, &mut mp3_analysis)?;
+        saturation.frames
     } else {
-        apply_mp3_ape_bytes(file_path, actual_steps, opts)?
+        saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts)?;
+        saturation.frames
     };
 
     // 3) ReplayGain tag write.
@@ -242,6 +256,8 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
         actual_steps,
         clipping_prevented,
         clipping_detected,
+        saturated_low: saturation.saturated_low,
+        saturated_high: saturation.saturated_high,
     })
 }
 
@@ -268,6 +284,8 @@ pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyRepor
         actual_steps,
         clipping_prevented,
         clipping_detected,
+        saturated_low: 0,
+        saturated_high: 0,
     })
 }
 
@@ -279,11 +297,17 @@ fn check_clipping(
     aac_analysis: &mut AacAnalysisCache,
 ) -> Result<(i32, bool, Option<ClippingDetection>)> {
     let steps = opts.steps;
-    if steps <= 0 || opts.wrap {
+    if opts.wrap {
         return Ok((steps, false, None));
     }
 
     // ReplayGain-peak branch.
+    //
+    // Runs for any step count, including `steps <= 0` (issue #206): a
+    // track already at the reference loudness nets 0 gain steps, but if it
+    // already clips (peak > 1.0) `-k` must still attenuate it below
+    // unity. The headroom branch below keeps its `steps <= 0` early-out —
+    // there, only positive gain can introduce clipping.
     if let Some(track) = opts.track_result.as_ref() {
         let new_peak = apply_gain_to_peak(track.peak(), steps_to_db(steps));
         if new_peak > 1.0 {
@@ -311,7 +335,13 @@ fn check_clipping(
         return Ok((steps, false, None));
     }
 
-    // Headroom-based branch (no ReplayGain analysis available).
+    // Headroom-based branch (no ReplayGain analysis available). Lowering
+    // or holding gain (steps <= 0) can never push the peak up, so there is
+    // nothing to check.
+    if steps <= 0 {
+        return Ok((steps, false, None));
+    }
+
     let headroom = if is_aac {
         #[cfg(feature = "aac")]
         {
@@ -376,7 +406,11 @@ fn apply_aac_bytes(
     })
 }
 
-fn apply_mp3_ape_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Result<usize> {
+fn apply_mp3_ape_bytes(
+    file_path: &Path,
+    steps: i32,
+    opts: &ApplyOptions,
+) -> Result<SaturationStats> {
     with_temp_file(file_path, opts.use_temp_file, |r, w| {
         let mut gain = GainOptions::new(steps)
             .wrap(opts.wrap)
@@ -384,7 +418,7 @@ fn apply_mp3_ape_bytes(file_path: &Path, steps: i32, opts: &ApplyOptions) -> Res
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
         }
-        gain.apply_to_path(r, w)
+        gain.apply_to_path_with_stats(r, w)
     })
 }
 
@@ -393,7 +427,7 @@ fn apply_mp3_id3v2_bytes(
     steps: i32,
     opts: &ApplyOptions,
     mp3_analysis: &mut Option<crate::Mp3Analysis>,
-) -> Result<usize> {
+) -> Result<SaturationStats> {
     // Need pre-apply analysis if undo will be written. Reuse the cached
     // one from the clipping-check pass when available (issue #135).
     if opts.write_undo && mp3_analysis.is_none() {
@@ -402,12 +436,12 @@ fn apply_mp3_id3v2_bytes(
 
     // APE undo is never written in `-s i` mode; the undo goes into a
     // TXXX:MP3GAIN_UNDO frame instead, written below.
-    let modified = with_temp_file(file_path, opts.use_temp_file, |r, w| {
+    let stats = with_temp_file(file_path, opts.use_temp_file, |r, w| {
         let mut gain = GainOptions::new(steps).wrap(opts.wrap).undo(false);
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
         }
-        gain.apply_to_path(r, w)
+        gain.apply_to_path_with_stats(r, w)
     })?;
 
     if opts.write_undo {
@@ -424,7 +458,7 @@ fn apply_mp3_id3v2_bytes(
             mp3_analysis.as_ref(),
         )?;
     }
-    Ok(modified)
+    Ok(stats)
 }
 
 /// Build a unique `.mp3rgain_temp_*` sibling path for `file`. Shared by the
@@ -441,9 +475,9 @@ pub(crate) fn temp_sibling_path(file: &Path, ext: &str) -> std::path::PathBuf {
     ))
 }
 
-fn with_temp_file<F>(file: &Path, use_temp: bool, operation: F) -> Result<usize>
+fn with_temp_file<T, F>(file: &Path, use_temp: bool, operation: F) -> Result<T>
 where
-    F: FnOnce(&Path, &Path) -> Result<usize>,
+    F: FnOnce(&Path, &Path) -> Result<T>,
 {
     if !use_temp {
         return operation(file, file);
@@ -452,9 +486,9 @@ where
     let temp_path = temp_sibling_path(file, "mp3");
 
     match operation(file, &temp_path) {
-        Ok(frames) => {
+        Ok(value) => {
             std::fs::rename(&temp_path, file).map_err(|e| Error::io_write(file, e))?;
-            Ok(frames)
+            Ok(value)
         }
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
@@ -585,6 +619,32 @@ mod tests {
             new_peak <= 1.0,
             "capped output still clips ({new_peak}) at steps={steps}"
         );
+    }
+
+    /// Issue #206: a track already at the reference loudness nets 0 gain
+    /// steps. If it already clips (peak > 1.0), `-k` must still attenuate it
+    /// — the old `steps <= 0` early-out skipped the peak check entirely.
+    #[test]
+    fn prevent_clipping_caps_zero_step_clipping_track() {
+        let opts = opts_with_track(0, 1.2, true);
+        let (steps, prevented, _) =
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+        assert!(prevented);
+        assert!(steps < 0, "expected attenuation, got {steps}");
+        let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
+        assert!(new_peak <= 1.0, "capped output still clips ({new_peak})");
+    }
+
+    /// Issue #206: a 0-step track that does not clip must pass through
+    /// unchanged with no clipping signal.
+    #[test]
+    fn zero_step_non_clipping_track_is_noop() {
+        let opts = opts_with_track(0, 0.8, true);
+        let (steps, prevented, detected) =
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+        assert_eq!(steps, 0);
+        assert!(!prevented);
+        assert!(detected.is_none());
     }
 
     /// Sweep clipping peaks (> 1.0). Cap must always produce a non-clipping

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -380,6 +380,35 @@ pub(crate) enum GainMode {
     Wrapping,
 }
 
+/// Outcome of an [`apply_gain_to_data`] pass.
+///
+/// `frames` is the number of frames touched (the value the function used
+/// to return bare). `saturated_low` / `saturated_high` count global_gain
+/// values that clamped at 0 (silence) / 255 (distortion) under saturating
+/// mode, where the requested adjustment couldn't be fully applied and the
+/// original value is lost — i.e. the apply is no longer losslessly
+/// reversible at those locations (issue #207). Wrapping mode never
+/// saturates, so both counts stay 0.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct SaturationStats {
+    pub frames: usize,
+    pub saturated_low: usize,
+    pub saturated_high: usize,
+}
+
+impl SaturationStats {
+    /// Record one saturating adjustment of `current` by `steps`, using the
+    /// same `[-255, 255]` step clamp as [`adjust_gain_value`].
+    fn tally(&mut self, current: u8, steps: i32) {
+        let target = current as i32 + steps.clamp(-255, 255);
+        if target > 255 {
+            self.saturated_high += 1;
+        } else if target < 0 {
+            self.saturated_low += 1;
+        }
+    }
+}
+
 /// Apply the gain adjustment to a single gain location.
 ///
 /// `steps` is normalized first (clamp for saturating, modulo for wrapping)
@@ -407,10 +436,10 @@ pub(crate) fn apply_gain_to_data(
     gain_steps: i32,
     mode: GainMode,
     channel_index: Option<usize>,
-) -> usize {
+) -> SaturationStats {
     let audio_end = find_audio_end(data);
     let mut pos = skip_id3v2(data);
-    let mut modified_frames = 0;
+    let mut stats = SaturationStats::default();
     let mut locations = [GainLocation {
         byte_offset: 0,
         bit_offset: 0,
@@ -424,6 +453,9 @@ pub(crate) fn apply_gain_to_data(
                 for loc in &locations[..len] {
                     let current_gain = read_gain_at(data, loc);
                     let new_gain = adjust_gain_value(current_gain, gain_steps, mode);
+                    if mode == GainMode::Saturating {
+                        stats.tally(current_gain, gain_steps);
+                    }
                     write_gain_at(data, loc, new_gain);
                 }
             }
@@ -436,17 +468,18 @@ pub(crate) fn apply_gain_to_data(
                         let current_gain = read_gain_at(data, loc);
                         let new_gain =
                             adjust_gain_value(current_gain, gain_steps, GainMode::Saturating);
+                        stats.tally(current_gain, gain_steps);
                         write_gain_at(data, loc, new_gain);
                     }
                 }
             }
         }
 
-        modified_frames += 1;
+        stats.frames += 1;
         pos = next_pos;
     }
 
-    modified_frames
+    stats
 }
 
 /// Scan gain range (min/max global_gain) across all frames in file data.
@@ -513,6 +546,19 @@ mod tests {
         write_gain_at(&mut data, &loc_unaligned, 0x99);
         assert_eq!(data[1], 0xC9);
         assert_eq!(data[2], 0x9F);
+    }
+
+    #[test]
+    fn test_saturation_tally() {
+        let mut s = SaturationStats::default();
+        s.tally(200, 100); // 300 -> clamps high
+        s.tally(250, 50); //  300 -> clamps high
+        s.tally(10, -50); //  -40 -> clamps low
+        s.tally(100, 10); //  110 -> in range
+        s.tally(255, 0); //   255 -> exactly at ceiling, not over
+        s.tally(0, 0); //     0   -> exactly at floor, not under
+        assert_eq!(s.saturated_high, 2);
+        assert_eq!(s.saturated_low, 1);
     }
 
     #[test]

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -4,7 +4,7 @@ use crate::ape::{
     TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
-use crate::frame::{apply_gain_to_data, GainMode};
+use crate::frame::{apply_gain_to_data, GainMode, SaturationStats};
 
 use std::fs;
 use std::path::Path;
@@ -158,13 +158,25 @@ impl GainOptions {
     /// directly to the temp file without an intermediate full-file copy of the
     /// original (issue #135).
     pub fn apply_to_path(&self, read_from: &Path, write_to: &Path) -> Result<usize> {
+        Ok(self.apply_to_path_with_stats(read_from, write_to)?.frames)
+    }
+
+    /// [`apply_to_path`] variant that also reports global_gain saturation
+    /// (issue #207). The unified apply pipeline uses this to surface a
+    /// "values clamped at 0/255" warning; the public API keeps the bare
+    /// frame count.
+    pub(crate) fn apply_to_path_with_stats(
+        &self,
+        read_from: &Path,
+        write_to: &Path,
+    ) -> Result<SaturationStats> {
         let same_path = read_from == write_to;
 
         if self.steps == 0 {
             if !same_path {
                 fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
             }
-            return Ok(0);
+            return Ok(SaturationStats::default());
         }
 
         if let Some(channel) = self.channel {
@@ -223,10 +235,10 @@ pub(crate) fn apply_undo_to_data(data: &mut [u8], left: i32, right: i32, wrap: b
         } else {
             GainMode::Saturating
         };
-        apply_gain_to_data(data, -left, mode, None)
+        apply_gain_to_data(data, -left, mode, None).frames
     } else {
-        let left_frames = apply_gain_to_data(data, -left, GainMode::Saturating, Some(0));
-        let right_frames = apply_gain_to_data(data, -right, GainMode::Saturating, Some(1));
+        let left_frames = apply_gain_to_data(data, -left, GainMode::Saturating, Some(0)).frames;
+        let right_frames = apply_gain_to_data(data, -right, GainMode::Saturating, Some(1)).frames;
         left_frames.max(right_frames)
     }
 }
@@ -307,14 +319,14 @@ fn apply_gain_simple_to_path(
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
-) -> Result<usize> {
+) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
-    let modified_frames = apply_gain_to_data(&mut data, gain_steps, mode, None);
+    let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
 
-    Ok(modified_frames)
+    Ok(stats)
 }
 
 /// Apply gain with APEv2 undo tag support (unified for both saturating and wrapping).
@@ -327,7 +339,7 @@ fn apply_gain_with_undo_impl_to_path(
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
-) -> Result<usize> {
+) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
     let analysis = analyze_data(&data)?;
 
@@ -348,12 +360,12 @@ fn apply_gain_with_undo_impl_to_path(
         tag.set_minmax(analysis.min_gain(), analysis.max_gain());
     }
 
-    let frames = apply_gain_to_data(&mut data, gain_steps, mode, None);
+    let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
 
-    Ok(frames)
+    Ok(stats)
 }
 
 /// Apply gain to a specific channel (no undo)
@@ -362,14 +374,14 @@ fn apply_gain_channel_impl(
     write_to: &Path,
     channel: Channel,
     gain_steps: i32,
-) -> Result<usize> {
+) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
     let analysis = analyze_data(&data)?;
     if analysis.channel_mode() == ChannelMode::Mono {
         return Err(Error::ChannelGainOnMono);
     }
 
-    let modified_frames = apply_gain_to_data(
+    let stats = apply_gain_to_data(
         &mut data,
         gain_steps,
         GainMode::Saturating,
@@ -378,7 +390,7 @@ fn apply_gain_channel_impl(
 
     fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
 
-    Ok(modified_frames)
+    Ok(stats)
 }
 
 /// Apply channel-specific gain and store undo information in APEv2 tag
@@ -387,7 +399,7 @@ fn apply_gain_channel_with_undo(
     write_to: &Path,
     channel: Channel,
     gain_steps: i32,
-) -> Result<usize> {
+) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
     let analysis = analyze_data(&data)?;
     if analysis.channel_mode() == ChannelMode::Mono {
@@ -409,7 +421,7 @@ fn apply_gain_channel_with_undo(
         tag.set_minmax(analysis.min_gain(), analysis.max_gain());
     }
 
-    let frames = apply_gain_to_data(
+    let stats = apply_gain_to_data(
         &mut data,
         gain_steps,
         GainMode::Saturating,
@@ -419,7 +431,7 @@ fn apply_gain_channel_with_undo(
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
 
-    Ok(frames)
+    Ok(stats)
 }
 
 #[cfg(test)]

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -82,8 +82,10 @@ fn process_apply_into(
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
-            let warning_msg =
+            let clip_warn =
                 emit_clipping_warning_headroom(steps, &report, opts, dry_run_prefix, filename);
+            let sat_warn = emit_saturation_warning(&report, opts, filename);
+            let warning_msg = combine_warnings(clip_warn, sat_warn);
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 if is_aac {
@@ -178,6 +180,41 @@ fn emit_clipping_warning_headroom(
     ))
 }
 
+/// Warn when a saturating manual-gain apply clamped global_gain values at
+/// the [0, 255] boundary (issue #207). Saturation is lossy — the clamped
+/// frames can no longer be byte-restored by undo, so the lossless guarantee
+/// silently doesn't hold there. ReplayGain adjustments never get near this
+/// range, so the warning only fires for extreme manual `-g` / `-l` values.
+fn emit_saturation_warning(
+    report: &mp3rgain::ApplyReport,
+    opts: &Options,
+    filename: &str,
+) -> Option<String> {
+    let (low, high) = (report.saturated_low, report.saturated_high);
+    if low == 0 && high == 0 {
+        return None;
+    }
+    let detail = match (low, high) {
+        (l, 0) => format!("{l} gain value(s) clamped at 0 (silence)"),
+        (0, h) => format!("{h} gain value(s) clamped at 255 (distortion)"),
+        (l, h) => format!("{l} gain value(s) clamped at 0 (silence), {h} at 255 (distortion)"),
+    };
+    let msg = format!("{detail} - saturated gain is not losslessly reversible");
+    if opts.output_format == OutputFormat::Text && !opts.quiet {
+        eprintln!("  {} {} - {}", "!".yellow(), filename, msg);
+    }
+    Some(msg)
+}
+
+/// Join optional clipping and saturation warnings into the single
+/// [`JsonFileResult::warning`] field.
+fn combine_warnings(clip: Option<String>, saturation: Option<String>) -> Option<String> {
+    match (clip, saturation) {
+        (Some(a), Some(b)) => Some(format!("{a}; {b}")),
+        (a, b) => a.or(b),
+    }
+}
+
 pub fn process_apply_channel(
     file: &Path,
     channel: Channel,
@@ -243,6 +280,8 @@ fn process_apply_channel_into(
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
+            let warning_msg = emit_saturation_warning(&report, opts, filename);
+
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(
                     out,
@@ -260,6 +299,7 @@ fn process_apply_channel_into(
                 frames: Some(report.modified),
                 gain_applied_steps: Some(steps),
                 gain_applied_db: Some(steps_to_db(steps)),
+                warning: warning_msg,
                 ..Default::default()
             })
         }

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -74,7 +74,17 @@ fn process_track_gain_into(
                 )?;
             }
 
-            if modified_steps == 0 {
+            // A net 0-step adjustment still has work to do when (issue #206):
+            //   - ReplayGain analysis tags would be written (AAC always; MP3
+            //     in `-s i` mode), so an already-on-target track gets its
+            //     REPLAYGAIN_* tags (re)written rather than skipped, and/or
+            //   - `-k` must attenuate a track that is already at the
+            //     reference loudness yet already clips (peak > 1.0).
+            // Only the common already-normalized, non-clipping, no-tags case
+            // keeps the cheap "no adjustment needed" skip.
+            let writes_rg_tags = result.file_type() == AudioFileType::Aac || opts.use_id3v2;
+            let clip_prevention_applies = opts.prevent_clipping && result.peak() > 1.0;
+            if modified_steps == 0 && !writes_rg_tags && !clip_prevention_applies {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {
                     writeln!(out, "  {} {} (no adjustment needed)", ".".cyan(), filename)?;
                 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -198,6 +198,53 @@ fn test_apply_gain_saturates_at_min() {
     cleanup(&path);
 }
 
+/// Issue #207: a saturating apply that clamps global_gain values at the
+/// 0/255 boundary must surface a saturation count so the CLI can warn that
+/// the change is no longer losslessly reversible.
+#[test]
+fn test_apply_reports_saturation() {
+    use mp3rgain::{apply_with_options, ApplyOptions};
+
+    // test_joint_stereo.mp3 spans global_gain 110..210, so a large positive
+    // gain pushes every frame past 255 and a large negative gain drops the
+    // quietest frames below 0.
+    let path = copy_test_file("test_joint_stereo.mp3");
+    let mut opts = ApplyOptions::new(200);
+    opts.write_undo = false;
+    let report = apply_with_options(&path, &opts).unwrap();
+    assert!(
+        report.saturated_high > 0,
+        "expected ceiling saturation, got {report:?}"
+    );
+    assert_eq!(report.saturated_low, 0);
+    cleanup(&path);
+
+    let path = copy_test_file("test_joint_stereo.mp3");
+    let mut opts = ApplyOptions::new(-200);
+    opts.write_undo = false;
+    let report = apply_with_options(&path, &opts).unwrap();
+    assert!(
+        report.saturated_low > 0,
+        "expected floor saturation, got {report:?}"
+    );
+    assert_eq!(report.saturated_high, 0);
+    cleanup(&path);
+}
+
+/// A modest in-range adjustment must report no saturation.
+#[test]
+fn test_apply_no_saturation_when_in_range() {
+    use mp3rgain::{apply_with_options, ApplyOptions};
+
+    let path = copy_test_file("test_joint_stereo.mp3");
+    let mut opts = ApplyOptions::new(1);
+    opts.write_undo = false;
+    let report = apply_with_options(&path, &opts).unwrap();
+    assert_eq!(report.saturated_low, 0);
+    assert_eq!(report.saturated_high, 0);
+    cleanup(&path);
+}
+
 // =============================================================================
 // Undo Tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes two latent defects ported from the original aacgain.

### #206 — 0-step track gain skipped tag writing and clip-prevention (bug)

The track-gain CLI path returned early whenever the net ReplayGain
adjustment was **0 steps**, so an already-on-target track:

1. never got its `REPLAYGAIN_*` tags written — even in modes that otherwise
   write them (AAC always; MP3 with `-s i`), and
2. was never attenuated by `-k`, even if it was already clipping.

**Fix**
- `src/processors/replaygain.rs`: only take the cheap *"no adjustment
  needed"* skip when there are no RG tags to write **and** clip-prevention
  doesn't apply. Otherwise route through the apply path. The common
  already-normalized APE-mode case still skips (no perf regression).
- `src/apply.rs` `check_clipping`: the ReplayGain-peak branch now runs for
  any step count (including `<= 0`), so a 0-step but already-clipping track
  can still be capped under `-k`. The headroom branch keeps its `steps <= 0`
  early-out (lowering gain can't introduce clipping).

### #207 — manual gain saturated global_gain silently (enhancement)

Saturating manual gain (`-g` / `-l`) clamped `global_gain` at 0 (silence) or
255 (distortion) with **no warning**, and such clamps break the lossless undo
guarantee at the boundary.

**Fix**
- `src/frame.rs`: `apply_gain_to_data` returns `SaturationStats` (frames +
  floor/ceiling clamp counts).
- `src/gain.rs` / `src/apply.rs`: counts are surfaced through `ApplyReport`.
  The public `apply_gain` / `GainOptions` API still returns the bare frame
  count (no breaking change).
- `src/processors/apply.rs`: the manual-gain paths emit a warning when any
  `global_gain` value clamps, noting it is not losslessly reversible.

## Verification

- `cargo test` — all pass (added unit tests for the 0-step clip check and
  saturation tally, plus end-to-end `ApplyReport` saturation tests).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Manual:
  - `mp3rgain -r -s i -m -4 file` (net 0 steps) now writes
    `REPLAYGAIN_TRACK_GAIN`/`_PEAK` (previously skipped).
  - Default APE-mode net-0 still prints *"no adjustment needed"*.
  - `mp3rgain -g 200 file` now warns `... gain value(s) clamped at 255
    (distortion) - saturated gain is not losslessly reversible`.

Closes #206
Closes #207