### PR TITLE
Write REPLAYGAIN_* tags in default APEv2 mode (#204)

### DIFF
--- a/src/ape.rs
+++ b/src/ape.rs
@@ -357,6 +357,46 @@ pub fn write_ape_tag(file_path: &Path, tag: &ApeTag) -> Result<()> {
     Ok(())
 }
 
+/// ReplayGain analysis values written into an APEv2 tag (issue #204).
+///
+/// The mp3gain-compatible default mode records these alongside the
+/// `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` items the apply step already writes,
+/// so APEv2 files carry the same `REPLAYGAIN_*` metadata as `mp3gain` and
+/// as mp3rgain's ID3v2 (`-s i`) and AAC paths.
+#[derive(Debug, Clone, Default)]
+pub struct ApeReplayGain {
+    pub track_gain: Option<String>,
+    pub track_peak: Option<String>,
+    pub album_gain: Option<String>,
+    pub album_peak: Option<String>,
+}
+
+/// Add (or replace) the `REPLAYGAIN_*` items in `file_path`'s APEv2 tag.
+///
+/// Existing items written by the gain-apply step (`MP3GAIN_UNDO`,
+/// `MP3GAIN_MINMAX`) are preserved — only the four ReplayGain keys present
+/// in `rg` are set.
+pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> {
+    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+    let mut tag = read_ape_tag(&data).unwrap_or_default();
+
+    let fields: [(&str, &Option<String>); 4] = [
+        (TAG_REPLAYGAIN_TRACK_GAIN, &rg.track_gain),
+        (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
+        (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
+        (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
+    ];
+    for (key, value) in fields {
+        if let Some(v) = value {
+            tag.set(key, v);
+        }
+    }
+
+    let new_data = replace_ape_tag(&data, &tag);
+    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
+    Ok(())
+}
+
 /// Delete APEv2 tag from file
 pub fn delete_ape_tag(file_path: &Path) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
@@ -463,5 +503,32 @@ mod tests {
 
         let tiny = write_temp("tiny.mp3", &[0u8; 10]);
         assert_eq!(read_ape_tag_from_file(&tiny).unwrap(), None);
+    }
+
+    /// Issue #204: write_ape_replaygain must add the REPLAYGAIN_* items while
+    /// preserving the MP3GAIN_UNDO/MINMAX items the apply step already wrote.
+    #[test]
+    fn write_ape_replaygain_preserves_existing_items() {
+        let mut tag = ApeTag::new();
+        tag.set_undo_gain(2, 2, false);
+        tag.set_minmax(100, 200);
+        let data = replace_ape_tag(&vec![0u8; 20_000], &tag);
+        let path = write_temp("rg_preserve.mp3", &data);
+
+        let rg = ApeReplayGain {
+            track_gain: Some("+1.50 dB".to_string()),
+            track_peak: Some("0.250000".to_string()),
+            album_gain: None,
+            album_peak: None,
+        };
+        write_ape_replaygain(&path, &rg).unwrap();
+
+        let out = read_ape_tag_from_file(&path).unwrap().unwrap();
+        assert_eq!(out.get(TAG_MP3GAIN_UNDO), Some("+002,+002,N"));
+        assert_eq!(out.get(TAG_MP3GAIN_MINMAX), Some("100,200"));
+        assert_eq!(out.get(TAG_REPLAYGAIN_TRACK_GAIN), Some("+1.50 dB"));
+        assert_eq!(out.get(TAG_REPLAYGAIN_TRACK_PEAK), Some("0.250000"));
+        // Album fields were None, so they must not be written.
+        assert_eq!(out.get(TAG_REPLAYGAIN_ALBUM_GAIN), None);
     }
 }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -91,9 +91,9 @@ pub struct ApplyOptions {
     pub write_undo: bool,
 
     /// Write ReplayGain metadata tags. Requires [`Self::track_result`] to
-    /// be set. AAC writes to mp4 freeform metadata; MP3 only writes when
-    /// [`Self::use_id3v2`] is also on (there is no APE-based ReplayGain
-    /// tag in this codebase).
+    /// be set. AAC writes to mp4 freeform metadata; MP3 writes ID3v2 TXXX
+    /// frames when [`Self::use_id3v2`] is on, otherwise APEv2 `REPLAYGAIN_*`
+    /// items (issue #204).
     pub write_replaygain_tags: bool,
 
     /// `-s i`: MP3 only — use ID3v2 TXXX frames for undo and ReplayGain
@@ -173,7 +173,8 @@ pub enum ClippingDetection {
 /// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, with optional temp
 ///    file + atomic rename.
 /// 3. ID3v2 undo tag write (MP3 + [`ApplyOptions::use_id3v2`]).
-/// 4. ReplayGain tag write (AAC, or MP3 + [`ApplyOptions::use_id3v2`]).
+/// 4. ReplayGain tag write (AAC mp4 metadata, MP3 ID3v2 TXXX with
+///    [`ApplyOptions::use_id3v2`], or MP3 APEv2 by default — issue #204).
 /// 5. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
 pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
     let is_aac = mp4meta::is_aac_file(file_path);
@@ -219,9 +220,10 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 
     // 3) ReplayGain tag write.
     //
-    // AAC writes always (caller gates with `write_replaygain_tags`).
-    // MP3 only writes when also using ID3v2 — there is no APE-based RG
-    // path in this codebase.
+    // AAC writes to mp4 freeform metadata; MP3 writes ID3v2 TXXX frames in
+    // `-s i` mode, otherwise APEv2 `REPLAYGAIN_*` items (the default,
+    // mp3gain-compatible mode — issue #204). All three carry the same
+    // analysis values; only the container differs.
     if opts.write_replaygain_tags {
         if let Some(track) = opts.track_result.as_ref() {
             if is_aac {
@@ -242,6 +244,16 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
                     ..Default::default()
                 };
                 id3v2::write_id3v2_replaygain(file_path, &rg)?;
+            } else {
+                let rg = ape::ApeReplayGain {
+                    track_gain: Some(format!("{:+.2} dB", track.gain_db())),
+                    track_peak: Some(format!("{:.6}", track.peak())),
+                    album_gain: opts
+                        .album_info
+                        .map(|a| format!("{:+.2} dB", a.album_gain_db)),
+                    album_peak: opts.album_info.map(|a| format!("{:.6}", a.album_peak)),
+                };
+                ape::write_ape_replaygain(file_path, &rg)?;
             }
         }
     }

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -82,7 +82,11 @@ fn process_track_gain_into(
             //     reference loudness yet already clips (peak > 1.0).
             // Only the common already-normalized, non-clipping, no-tags case
             // keeps the cheap "no adjustment needed" skip.
-            let writes_rg_tags = result.file_type() == AudioFileType::Aac || opts.use_id3v2;
+            // RG analysis tags are written for AAC always, and for MP3 in any
+            // mode that keeps tags (APE default or `-s i` ID3v2) — only `-s s`
+            // skips them (issue #204).
+            let writes_rg_tags = result.file_type() == AudioFileType::Aac
+                || opts.stored_tag_mode != StoredTagMode::Skip;
             let clip_prevention_applies = opts.prevent_clipping && result.peak() > 1.0;
             if modified_steps == 0 && !writes_rg_tags && !clip_prevention_applies {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {
@@ -199,9 +203,10 @@ fn apply_replaygain_with_album_into(
     apply_opts.wrap = opts.wrap_gain;
     apply_opts.preserve_timestamp = opts.preserve_timestamp;
     apply_opts.use_temp_file = opts.use_temp_file;
-    // RG path writes undo unless -s s.
+    // RG path writes undo and ReplayGain tags unless -s s. Default APE,
+    // `-s i` ID3v2, and AAC all write the REPLAYGAIN_* tags (issue #204).
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
-    apply_opts.write_replaygain_tags = opts.use_id3v2;
+    apply_opts.write_replaygain_tags = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.use_id3v2 = opts.use_id3v2;
 
     match apply_with_options(file, &apply_opts) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -571,3 +571,78 @@ fn test_file_not_modified_on_zero_gain() {
 
     cleanup(&path);
 }
+
+// =============================================================================
+// APEv2 ReplayGain tag writing (issue #204)
+// =============================================================================
+
+/// Issue #204: applying track gain in the default APEv2 mode must write the
+/// REPLAYGAIN_TRACK_* analysis tags alongside MP3GAIN_UNDO/MINMAX, matching
+/// the original mp3gain. Previously only the MP3GAIN_* tags were written.
+#[test]
+fn test_apply_track_gain_writes_ape_replaygain_tags() {
+    use mp3rgain::apply::{apply_with_options, ApplyOptions};
+    use mp3rgain::{
+        replaygain, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_TRACK_GAIN,
+        TAG_REPLAYGAIN_TRACK_PEAK,
+    };
+
+    let path = copy_test_file("test_mono.mp3");
+    let result = replaygain::analyze_track_with_index(&path, None).unwrap();
+
+    let mut opts = ApplyOptions::new(result.gain_steps());
+    opts.track_result = Some(result);
+    opts.write_replaygain_tags = true; // default APEv2 path (use_id3v2 = false)
+    apply_with_options(&path, &opts).unwrap();
+
+    let tag = read_ape_tag_from_file(&path).unwrap().expect("APE tag");
+    assert!(
+        tag.get(TAG_REPLAYGAIN_TRACK_GAIN).is_some(),
+        "REPLAYGAIN_TRACK_GAIN missing from APEv2 tag"
+    );
+    assert!(
+        tag.get(TAG_REPLAYGAIN_TRACK_PEAK).is_some(),
+        "REPLAYGAIN_TRACK_PEAK missing from APEv2 tag"
+    );
+    // The mp3gain-compatible apply tags must still be present.
+    assert!(tag.get(TAG_MP3GAIN_UNDO).is_some(), "MP3GAIN_UNDO missing");
+    assert!(
+        tag.get(TAG_MP3GAIN_MINMAX).is_some(),
+        "MP3GAIN_MINMAX missing"
+    );
+
+    cleanup(&path);
+}
+
+/// Album info must additionally populate the REPLAYGAIN_ALBUM_* APEv2 items.
+#[test]
+fn test_apply_album_gain_writes_ape_album_replaygain_tags() {
+    use mp3rgain::apply::{apply_with_options, AacAlbumInfo, ApplyOptions};
+    use mp3rgain::{replaygain, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK};
+
+    let path = copy_test_file("test_mono.mp3");
+    let result = replaygain::analyze_track_with_index(&path, None).unwrap();
+
+    let mut opts = ApplyOptions::new(result.gain_steps());
+    opts.track_result = Some(result);
+    opts.album_info = Some(AacAlbumInfo {
+        album_gain_db: 1.5,
+        album_peak: 0.5,
+    });
+    opts.write_replaygain_tags = true;
+    apply_with_options(&path, &opts).unwrap();
+
+    let tag = read_ape_tag_from_file(&path).unwrap().expect("APE tag");
+    assert_eq!(
+        tag.get(TAG_REPLAYGAIN_ALBUM_GAIN),
+        Some("+1.50 dB"),
+        "REPLAYGAIN_ALBUM_GAIN missing or malformed"
+    );
+    assert_eq!(
+        tag.get(TAG_REPLAYGAIN_ALBUM_PEAK),
+        Some("0.500000"),
+        "REPLAYGAIN_ALBUM_PEAK missing or malformed"
+    );
+
+    cleanup(&path);
+}


### PR DESCRIPTION
Fixes #204.

## Problem

In the default **APEv2** mode (MP3, no `-s i`), `mp3rgain` applied gain but wrote
only `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` — never the `REPLAYGAIN_*` analysis tags
the original `mp3gain` writes. APEv2 files processed by `mp3rgain` therefore
carried less metadata than `mp3gain`'s, and ReplayGain-aware players/tools saw
nothing. The unified apply pipeline had RG write paths only for AAC (mp4
metadata) and MP3 + ID3v2 (TXXX); there was no APE-based path.

This affected **both** the CLI and `mp3rgui` — the GUI already set
`write_replaygain_tags`, but the pipeline silently dropped it for MP3 + APE.

## Fix

- Add `ape::ApeReplayGain` + `ape::write_ape_replaygain`, which adds the four
  `REPLAYGAIN_*` items to a file's APEv2 tag while preserving the
  `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` items the apply step already wrote.
- Add an APEv2 branch to `apply_with_options`'s ReplayGain write step (the
  `else` after AAC / ID3v2), reusing the same analysis values and string format
  as the existing ID3v2 and AAC paths — only the container differs.
- Gate `write_replaygain_tags` on `stored_tag_mode != Skip` (CLI) so default
  APE and `-s i` both write the tags, while `-s s` still writes nothing. Also
  include APE mode in the 0-step `writes_rg_tags` check so an already-normalized
  track still records its analysis tags (matching the existing AAC/ID3v2
  behavior and `mp3gain`).

### Verified against mp3gain 1.6.2

Before — default `mp3rgain -r file.mp3`:

```
MP3GAIN_UNDO, MP3GAIN_MINMAX          # no REPLAYGAIN_* at all
```

After:

```
MP3GAIN_UNDO, MP3GAIN_MINMAX,
REPLAYGAIN_TRACK_GAIN, REPLAYGAIN_TRACK_PEAK
```

Album mode (`-a`) additionally writes `REPLAYGAIN_ALBUM_GAIN` / `_PEAK`.
`-s s` writes nothing; an already-normalized (0-step) track still writes the
`REPLAYGAIN_TRACK_*` analysis tags. Existing `cargo test`, `clippy`, and
`scripts/compatibility-test.sh` (byte-identical audio vs `mp3gain`) all pass.

## Scope notes

- **Tag values / format** follow `mp3rgain`'s existing convention (shared with
  its ID3v2 and AAC paths: `{:+.2} dB` gain, `{:.6}` peak, *pre-apply* analysis
  values) for internal consistency across all three backends. `mp3gain` instead
  writes the *post-apply residual* with 6-decimal precision — see below.
- **`MP3GAIN_ALBUM_MINMAX`** (proposed-fix item 2) is **not** included here. It
  needs album-wide `global_gain` min/max aggregation that the album phase does
  not currently compute, and its pre-/post-apply timing is entangled with the
  secondary observation. Deferred to a focused follow-up.

## Secondary observation — verified (controlled repro, mp3gain 1.6.2)

Reproduced on clean fixtures. The reported differences are **systematic storage
conventions, not gain-direction bugs**:

| Aspect | mp3gain | mp3rgain |
|---|---|---|
| `MP3GAIN_UNDO` sign | undo delta (`-015` for +15 applied) | applied delta (`+015`) |
| `MP3GAIN_MINMAX` timing | post-apply | pre-apply |
| `REPLAYGAIN_*` values | post-apply residual (`+0.595000 dB`) | pre-apply analysis (`+23.17 dB`) |

- **Same gain is applied by both tools** — after `-g 5`, the tag-stripped audio
  is byte-identical. The opposite `MP3GAIN_UNDO` sign is purely how each tool
  records undo, not a different amount/direction.
- **Cross-tool undo is genuinely broken**, though: `mp3rgain -u` correctly
  reverses its own files but doubles the gain on a `mp3gain`-processed file
  (it reads `mp3gain`'s negated value and applies it the wrong way).

Fixing the sign convention would let `mp3rgain` undo `mp3gain` files but would
break undo of files `mp3rgain` itself already wrote — so it needs its own issue
and a migration story rather than riding along here. The `MINMAX`/`REPLAYGAIN`
pre-vs-post-apply semantics are the same family of difference. Recommend a
single follow-up issue covering the undo-sign convention, MINMAX/RG value
timing, decimal-precision parity, and `MP3GAIN_ALBUM_MINMAX`.