### PR TITLE
fix: post-apply residual ReplayGain and post-apply MINMAX (#210)

### DIFF
--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -22,8 +22,14 @@ mp3rgain -r -k -d 0 -s s -o file.mp3
 ```
 
 The CLI surface, the TSV output format, and the APEv2 undo tag are all
-mp3gain-compatible. You can even mix the two tools on the same file — gain
-written by mp3gain can be undone by mp3rgain and vice versa.
+mp3gain-compatible.
+
+> **Note on cross-tool undo:** each tool reliably undoes *its own* changes, but
+> undoing an mp3gain-written file with `mp3rgain -u` (or vice versa) is currently
+> broken because the two tools store the `mp3gain_undo` value with opposite signs
+> — see [Behaviour differences](#behaviour-differences) and
+> [#210](https://github.com/M-Igashi/mp3rgain/issues/210). Undo the file with the
+> same tool that applied the gain.
 
 ## Drop-in alias
 
@@ -52,7 +58,7 @@ flags are accepted with the same semantics; mp3rgain adds a few extensions.
 | `-g <i>` | Apply gain of `i` steps (1 step = 1.5 dB) | Bit-identical output (see compatibility report) |
 | `-d <n>` | Modify suggested gain by `n` dB (applied with `-r` / `-a`) | mp3gain-compatible since v1.2.1 |
 | `-m <i>` | Modify suggested gain by `i` steps | |
-| `-u` | Undo gain changes (reads APEv2 `mp3gain_undo`) | Reads tags written by either tool |
+| `-u` | Undo gain changes (reads APEv2 `mp3gain_undo`) | Reliably undoes mp3rgain's own files; cross-tool undo is currently broken ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)) |
 | `-x` | Print max amplitude only | |
 | `-k` | Prevent clipping (auto-limit gain) | |
 | `-c` | Ignore clipping warnings | |
@@ -109,7 +115,7 @@ For new integrations, prefer `-o json`, which is structured and stable.
 
 | Tag location | mp3gain | mp3rgain | Interop |
 |--------------|---------|----------|---------|
-| APEv2 `mp3gain_undo` (MP3) | Written | Written | Bidirectional — either tool can undo the other's changes |
+| APEv2 `mp3gain_undo` (MP3) | Written | Written | ⚠️ Opposite sign convention — each tool undoes its own files, but cross-tool undo is currently broken ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)) |
 | APEv2 `mp3gain_minmax` (MP3) | Written | Written | Same |
 | APEv2 ReplayGain (`mp3gain_album_*`, `replaygain_*`) | Written | Written | Same |
 | ID3v2 TXXX/RVA2 ReplayGain | Not written | Written with `-s i` | Standard ReplayGain readers (foobar2000, mpd, etc.) recognise it |
@@ -124,6 +130,7 @@ These are the only behaviour differences worth knowing about:
 
 | Area | Difference | Impact |
 |------|------------|--------|
+| Cross-tool undo | `mp3gain` stores the *undo* delta in `mp3gain_undo`; `mp3rgain` stores the *applied* delta (opposite sign) | Each tool undoes its own files correctly. Running `mp3rgain -u` on an `mp3gain`-written file (or vice versa) **doubles** the gain instead of undoing it. Tracked in [#210](https://github.com/M-Igashi/mp3rgain/issues/210); undo with the same tool that applied the gain |
 | Undo cleanup | mp3gain leaves empty APEv2 tags after `-u`; mp3rgain removes them | Audio data is identical; only the tag block differs |
 | ReplayGain analysis | mp3gain uses LAME; mp3rgain uses Symphonia + native Rust | Track/album gain values may differ by <0.1 dB. The *applied* gain is bit-identical for any given step value |
 | Format coverage | mp3gain handles MP3 only | mp3rgain also handles AAC/M4A/.mp4 (lossless `global_gain` rewrite, the same idea aacgain used) |

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -35,8 +35,7 @@ use crate::{ape, id3v2, mp4meta};
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// AAC analysis cached between the clipping check and the apply step so a
-/// single apply never walks the bitstream twice (issue #188). Mirrors the
-/// MP3 `mp3_analysis` cache from #135.
+/// single apply never walks the bitstream twice (issue #188).
 #[cfg(feature = "aac")]
 type AacAnalysisCache = Option<aac::AacAnalysis>;
 #[cfg(not(feature = "aac"))]
@@ -191,19 +190,13 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 
     // 1) Clipping check + cap.
     //
-    // Both branches cache their analysis so the apply step below can
-    // reuse it instead of a second file scan: the MP3 `analyze(file)`
-    // result feeds the ID3v2 undo write (issue #135), the AAC bitstream
-    // analysis feeds the gain application itself (issue #188).
-    let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
+    // The AAC bitstream analysis is cached so the apply step below can reuse
+    // it instead of a second scan (issue #188). MINMAX / ReplayGain are now
+    // recorded from a *post-apply* scan (issue #210), so no pre-apply MP3
+    // analysis needs to be threaded through here.
     let mut aac_analysis: AacAnalysisCache = None;
-    let (actual_steps, clipping_prevented, clipping_detected) = check_clipping(
-        file_path,
-        opts,
-        is_aac,
-        &mut mp3_analysis,
-        &mut aac_analysis,
-    )?;
+    let (actual_steps, clipping_prevented, clipping_detected) =
+        check_clipping(file_path, opts, is_aac, &mut aac_analysis)?;
 
     // 2) Apply gain to bytes. MP3 reports global_gain saturation (issue
     // #207); AAC clamps in its own path and isn't tallied here.
@@ -211,7 +204,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     let modified = if is_aac {
         apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
     } else if opts.use_id3v2 {
-        saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts, &mut mp3_analysis)?;
+        saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts)?;
         saturation.frames
     } else {
         saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts)?;
@@ -222,36 +215,73 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     //
     // AAC writes to mp4 freeform metadata; MP3 writes ID3v2 TXXX frames in
     // `-s i` mode, otherwise APEv2 `REPLAYGAIN_*` items (the default,
-    // mp3gain-compatible mode — issue #204). All three carry the same
-    // analysis values; only the container differs.
+    // mp3gain-compatible mode — issue #204). Only the container differs.
+    //
+    // mp3gain stores the *post-apply residual* — the gain a player should
+    // still apply on top of the gain already baked into global_gain — at
+    // 6-decimal precision, not the pre-apply analysis value (issue #210).
+    // Absent global_gain saturation, applying N steps shifts loudness by
+    // exactly N*1.5 dB, so the residual is arithmetic; under saturation (or
+    // `-w` wrap) the shift is not uniform, so re-analyze the modified file
+    // for the true post-apply values. AAC clamps internally and is always
+    // treated arithmetically (mp3gain has no AAC, so it is interop-neutral).
     if opts.write_replaygain_tags {
         if let Some(track) = opts.track_result.as_ref() {
+            let needs_reanalysis = !is_aac
+                && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
+
+            let arithmetic = || {
+                let db = steps_to_db(actual_steps);
+                (
+                    track.gain_db() - db,
+                    apply_gain_to_peak(track.peak(), db),
+                    db,
+                )
+            };
+            let (track_gain_db, track_peak, applied_db) = if needs_reanalysis {
+                match crate::replaygain::analyze_track(file_path) {
+                    Ok(post) => (
+                        post.gain_db(),
+                        post.peak(),
+                        track.gain_db() - post.gain_db(),
+                    ),
+                    Err(_) => arithmetic(),
+                }
+            } else {
+                arithmetic()
+            };
+
+            // Album residual: the same loudness shift applies to the album
+            // gain/peak (the album value is uniform across the set).
+            let album_residual = opts.album_info.map(|a| {
+                (
+                    a.album_gain_db - applied_db,
+                    apply_gain_to_peak(a.album_peak, applied_db),
+                )
+            });
+
             if is_aac {
                 let mut tags = mp4meta::ReplayGainTags::default();
-                tags.set_track(track.gain_db(), track.peak());
-                if let Some(album) = opts.album_info {
-                    tags.set_album(album.album_gain_db, album.album_peak);
+                tags.set_track(track_gain_db, track_peak);
+                if let Some((album_gain, album_peak)) = album_residual {
+                    tags.set_album(album_gain, album_peak);
                 }
                 mp4meta::write_replaygain_tags(file_path, &tags)?;
             } else if opts.use_id3v2 {
                 let rg = id3v2::Id3v2ReplayGain {
-                    track_gain: Some(format!("{:+.2} dB", track.gain_db())),
-                    track_peak: Some(format!("{:.6}", track.peak())),
-                    album_gain: opts
-                        .album_info
-                        .map(|a| format!("{:+.2} dB", a.album_gain_db)),
-                    album_peak: opts.album_info.map(|a| format!("{:.6}", a.album_peak)),
+                    track_gain: Some(format!("{:+.6} dB", track_gain_db)),
+                    track_peak: Some(format!("{:.6}", track_peak)),
+                    album_gain: album_residual.map(|(g, _)| format!("{:+.6} dB", g)),
+                    album_peak: album_residual.map(|(_, p)| format!("{:.6}", p)),
                     ..Default::default()
                 };
                 id3v2::write_id3v2_replaygain(file_path, &rg)?;
             } else {
                 let rg = ape::ApeReplayGain {
-                    track_gain: Some(format!("{:+.2} dB", track.gain_db())),
-                    track_peak: Some(format!("{:.6}", track.peak())),
-                    album_gain: opts
-                        .album_info
-                        .map(|a| format!("{:+.2} dB", a.album_gain_db)),
-                    album_peak: opts.album_info.map(|a| format!("{:.6}", a.album_peak)),
+                    track_gain: Some(format!("{:+.6} dB", track_gain_db)),
+                    track_peak: Some(format!("{:.6}", track_peak)),
+                    album_gain: album_residual.map(|(g, _)| format!("{:+.6} dB", g)),
+                    album_peak: album_residual.map(|(_, p)| format!("{:.6}", p)),
                 };
                 ape::write_ape_replaygain(file_path, &rg)?;
             }
@@ -282,15 +312,9 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 /// would do.
 pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
     let is_aac = mp4meta::is_aac_file(file_path);
-    let mut mp3_analysis: Option<crate::Mp3Analysis> = None;
     let mut aac_analysis: AacAnalysisCache = None;
-    let (actual_steps, clipping_prevented, clipping_detected) = check_clipping(
-        file_path,
-        opts,
-        is_aac,
-        &mut mp3_analysis,
-        &mut aac_analysis,
-    )?;
+    let (actual_steps, clipping_prevented, clipping_detected) =
+        check_clipping(file_path, opts, is_aac, &mut aac_analysis)?;
     Ok(ApplyReport {
         modified: 0,
         actual_steps,
@@ -305,7 +329,6 @@ fn check_clipping(
     file_path: &Path,
     opts: &ApplyOptions,
     is_aac: bool,
-    mp3_analysis: &mut Option<crate::Mp3Analysis>,
     aac_analysis: &mut AacAnalysisCache,
 ) -> Result<(i32, bool, Option<ClippingDetection>)> {
     let steps = opts.steps;
@@ -371,10 +394,7 @@ fn check_clipping(
             None
         }
     } else {
-        let info = crate::analyze(file_path).ok();
-        let headroom = info.as_ref().map(|i| i.headroom_steps());
-        *mp3_analysis = info;
-        headroom
+        crate::analyze(file_path).ok().map(|i| i.headroom_steps())
     };
 
     if let Some(h) = headroom {
@@ -438,14 +458,7 @@ fn apply_mp3_id3v2_bytes(
     file_path: &Path,
     steps: i32,
     opts: &ApplyOptions,
-    mp3_analysis: &mut Option<crate::Mp3Analysis>,
 ) -> Result<SaturationStats> {
-    // Need pre-apply analysis if undo will be written. Reuse the cached
-    // one from the clipping-check pass when available (issue #135).
-    if opts.write_undo && mp3_analysis.is_none() {
-        *mp3_analysis = crate::analyze(file_path).ok();
-    }
-
     // APE undo is never written in `-s i` mode; the undo goes into a
     // TXXX:MP3GAIN_UNDO frame instead, written below.
     let stats = with_temp_file(file_path, opts.use_temp_file, |r, w| {
@@ -462,13 +475,7 @@ fn apply_mp3_id3v2_bytes(
             Some(Channel::Right) => (0, steps),
             None => (steps, steps),
         };
-        write_id3v2_undo_after_apply(
-            file_path,
-            delta_left,
-            delta_right,
-            opts.wrap,
-            mp3_analysis.as_ref(),
-        )?;
+        write_id3v2_undo_after_apply(file_path, delta_left, delta_right, opts.wrap)?;
     }
     Ok(stats)
 }
@@ -529,27 +536,22 @@ fn write_id3v2_undo_after_apply(
     delta_left: i32,
     delta_right: i32,
     wrap: bool,
-    analysis: Option<&crate::Mp3Analysis>,
 ) -> Result<()> {
     let existing_rg = id3v2::read_id3v2_replaygain(file).unwrap_or_default();
     let (existing_left, existing_right) = ape::parse_undo_values(existing_rg.undo.as_deref());
 
-    let owned;
-    let (min, max) = match analysis {
-        Some(a) => (a.min_gain(), a.max_gain()),
-        None => {
-            owned = crate::analyze(file)?;
-            (owned.min_gain(), owned.max_gain())
-        }
-    };
+    // MP3GAIN_MINMAX is the *post-apply* global_gain range (mp3gain
+    // convention); `file` is the already-modified file at this point, so a
+    // fresh scan reflects the applied gain.
+    let post = crate::analyze(file)?;
 
     id3v2::write_id3v2_undo(
         file,
         existing_left + delta_left,
         existing_right + delta_right,
         wrap,
-        min,
-        max,
+        post.min_gain(),
+        post.max_gain(),
     )
 }
 
@@ -577,7 +579,7 @@ mod tests {
     fn prevent_clipping_caps_at_floor_not_round() {
         let opts = opts_with_track(5, 0.9, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert!(prevented);
         assert_eq!(steps, 0);
         let new_peak = 0.9 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -591,7 +593,7 @@ mod tests {
         for &peak in &[0.55_f64, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 0.99] {
             let opts = opts_with_track(20, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(
@@ -607,7 +609,7 @@ mod tests {
     fn prevent_clipping_passthrough_when_safe() {
         let opts = opts_with_track(3, 0.5, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert!(!prevented);
         assert_eq!(steps, 3);
     }
@@ -623,7 +625,7 @@ mod tests {
         // = -2 steps (= -3 dB). Resulting peak = 1.2 * 10^(-3/20) = 0.85.
         let opts = opts_with_track(1, 1.2, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert!(prevented);
         assert!(steps < 0, "expected negative steps, got {steps}");
         let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -640,7 +642,7 @@ mod tests {
     fn prevent_clipping_caps_zero_step_clipping_track() {
         let opts = opts_with_track(0, 1.2, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert!(prevented);
         assert!(steps < 0, "expected attenuation, got {steps}");
         let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -653,7 +655,7 @@ mod tests {
     fn zero_step_non_clipping_track_is_noop() {
         let opts = opts_with_track(0, 0.8, true);
         let (steps, prevented, detected) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
         assert_eq!(steps, 0);
         assert!(!prevented);
         assert!(detected.is_none());
@@ -667,7 +669,7 @@ mod tests {
         for &peak in &[1.001_f64, 1.05, 1.1, 1.2, 1.5, 2.0] {
             let opts = opts_with_track(5, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -4,7 +4,7 @@ use crate::ape::{
     TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
-use crate::frame::{apply_gain_to_data, GainMode, SaturationStats};
+use crate::frame::{apply_gain_to_data, scan_gain_range, GainMode, SaturationStats};
 
 use std::fs;
 use std::path::Path;
@@ -341,7 +341,6 @@ fn apply_gain_with_undo_impl_to_path(
     mode: GainMode,
 ) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
-    let analysis = analyze_data(&data)?;
 
     let mut tag = read_ape_tag(&data).unwrap_or_default();
 
@@ -356,11 +355,13 @@ fn apply_gain_with_undo_impl_to_path(
         wrap,
     );
 
-    if tag.get(TAG_MP3GAIN_MINMAX).is_none() {
-        tag.set_minmax(analysis.min_gain(), analysis.max_gain());
-    }
-
     let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
+
+    // MP3GAIN_MINMAX records the *post-apply* global_gain range (mp3gain
+    // convention). Re-scan the modified buffer and overwrite any prior value;
+    // this also validates that the input was a real MP3 (NoMp3Frames on empty).
+    let (min, max) = scan_gain_range(&data)?;
+    tag.set_minmax(min, max);
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
@@ -417,16 +418,18 @@ fn apply_gain_channel_with_undo(
 
     tag.set_undo_gain(new_left, new_right, false);
 
-    if tag.get(TAG_MP3GAIN_MINMAX).is_none() {
-        tag.set_minmax(analysis.min_gain(), analysis.max_gain());
-    }
-
     let stats = apply_gain_to_data(
         &mut data,
         gain_steps,
         GainMode::Saturating,
         Some(channel.index()),
     );
+
+    // MP3GAIN_MINMAX records the *post-apply* global_gain range (mp3gain
+    // convention); re-scan the modified buffer and overwrite any prior value.
+    if let Ok((min, max)) = scan_gain_range(&data) {
+        tag.set_minmax(min, max);
+    }
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -178,12 +178,12 @@ impl ReplayGainTags {
     }
 
     pub fn set_track(&mut self, gain_db: f64, peak: f64) {
-        self.track_gain = Some(format!("{:+.2} dB", gain_db));
+        self.track_gain = Some(format!("{:+.6} dB", gain_db));
         self.track_peak = Some(format!("{:.6}", peak));
     }
 
     pub fn set_album(&mut self, gain_db: f64, peak: f64) {
-        self.album_gain = Some(format!("{:+.2} dB", gain_db));
+        self.album_gain = Some(format!("{:+.6} dB", gain_db));
         self.album_peak = Some(format!("{:.6}", peak));
     }
 
@@ -1416,9 +1416,9 @@ mod tests {
         tags.set_track(3.5, 0.98765);
         tags.set_album(2.0, 0.99999);
 
-        assert_eq!(tags.track_gain(), Some("+3.50 dB"));
+        assert_eq!(tags.track_gain(), Some("+3.500000 dB"));
         assert_eq!(tags.track_peak(), Some("0.987650"));
-        assert_eq!(tags.album_gain(), Some("+2.00 dB"));
+        assert_eq!(tags.album_gain(), Some("+2.000000 dB"));
         assert_eq!(tags.album_peak(), Some("0.999990"));
 
         let freeform_tags = tags.to_freeform_tags();

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -3,7 +3,7 @@ use colored::*;
 use indicatif::ProgressBar;
 use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions, ClippingDetection};
 use mp3rgain::replaygain::{self, AudioFileType, ReplayGainResult};
-use mp3rgain::{mp4meta, steps_to_db, AacAlbumInfo};
+use mp3rgain::{apply_gain_to_peak, mp4meta, steps_to_db, AacAlbumInfo};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -375,10 +375,20 @@ fn apply_replaygain_aac_with_album_into(
         }
     }
 
+    // Post-apply residual (issue #210), mirroring the MP3 path in
+    // apply_with_options. AAC clamps internally with no saturation tally, so
+    // the loudness shift is the arithmetic applied gain.
+    let applied_db = steps_to_db(actual_steps);
     let mut tags = mp4meta::ReplayGainTags::default();
-    tags.set_track(result.gain_db(), result.peak());
+    tags.set_track(
+        result.gain_db() - applied_db,
+        apply_gain_to_peak(result.peak(), applied_db),
+    );
     if let Some(album) = album_info {
-        tags.set_album(album.album_gain_db, album.album_peak);
+        tags.set_album(
+            album.album_gain_db - applied_db,
+            apply_gain_to_peak(album.album_peak, applied_db),
+        );
     }
 
     match mp4meta::write_replaygain_tags(file, &tags) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -618,29 +618,43 @@ fn test_apply_track_gain_writes_ape_replaygain_tags() {
 #[test]
 fn test_apply_album_gain_writes_ape_album_replaygain_tags() {
     use mp3rgain::apply::{apply_with_options, AacAlbumInfo, ApplyOptions};
-    use mp3rgain::{replaygain, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK};
+    use mp3rgain::{
+        apply_gain_to_peak, replaygain, steps_to_db, TAG_REPLAYGAIN_ALBUM_GAIN,
+        TAG_REPLAYGAIN_ALBUM_PEAK,
+    };
 
     let path = copy_test_file("test_mono.mp3");
     let result = replaygain::analyze_track_with_index(&path, None).unwrap();
 
-    let mut opts = ApplyOptions::new(result.gain_steps());
-    opts.track_result = Some(result);
-    opts.album_info = Some(AacAlbumInfo {
+    let steps = result.gain_steps();
+    let album = AacAlbumInfo {
         album_gain_db: 1.5,
         album_peak: 0.5,
-    });
+    };
+    let mut opts = ApplyOptions::new(steps);
+    opts.track_result = Some(result);
+    opts.album_info = Some(album);
     opts.write_replaygain_tags = true;
-    apply_with_options(&path, &opts).unwrap();
+    let report = apply_with_options(&path, &opts).unwrap();
 
+    // mp3gain writes the post-apply *residual* album values at 6-decimal
+    // precision (issue #210): the album gain/peak shifted by the gain baked
+    // into this track. The fixture applies a modest gain with no global_gain
+    // saturation, so the shift is the arithmetic applied gain.
+    assert_eq!(report.saturated_low + report.saturated_high, 0);
+    let applied_db = steps_to_db(steps);
     let tag = read_ape_tag_from_file(&path).unwrap().expect("APE tag");
     assert_eq!(
-        tag.get(TAG_REPLAYGAIN_ALBUM_GAIN),
-        Some("+1.50 dB"),
+        tag.get(TAG_REPLAYGAIN_ALBUM_GAIN).map(str::to_string),
+        Some(format!("{:+.6} dB", album.album_gain_db - applied_db)),
         "REPLAYGAIN_ALBUM_GAIN missing or malformed"
     );
     assert_eq!(
-        tag.get(TAG_REPLAYGAIN_ALBUM_PEAK),
-        Some("0.500000"),
+        tag.get(TAG_REPLAYGAIN_ALBUM_PEAK).map(str::to_string),
+        Some(format!(
+            "{:.6}",
+            apply_gain_to_peak(album.album_peak, applied_db)
+        )),
         "REPLAYGAIN_ALBUM_PEAK missing or malformed"
     );
 


### PR DESCRIPTION
## Summary

Phase 1 of #210 — bring mp3rgain's APEv2/ID3v2/AAC tags into mp3gain's *post-apply* convention. No audio bytes change; this is metadata only, and it does **not** change how existing tags are *read* (the `MP3GAIN_UNDO` sign flip, which would, is deferred to Phase 2).

### Changes

- **`MP3GAIN_MINMAX` → post-apply.** Re-scan the modified `global_gain` range after applying gain (APE and `-s i` ID3v2), matching mp3gain. Was the pre-apply range.
- **`REPLAYGAIN_*` → post-apply residual, 6-decimal.** mp3gain writes the gain a player should *still* apply on top of the baked-in change; mp3rgain wrote the full pre-apply analysis at 2 decimals, which makes RG-aware players double-correct. Now all backends (APE/ID3v2/AAC) write the residual at 6 decimals. The residual is arithmetic; under `global_gain` saturation or `-w` wrap the modified file is re-analyzed for the true value.
- **Docs.** The migration guide claimed bidirectional cross-tool undo, which is currently broken (opposite `MP3GAIN_UNDO` sign). Corrected to a documented known issue pending the Phase 2 sign flip.
- Removed the now-unused pre-apply analysis cache.

### Verification

Against **mp3gain 1.6.2** on a clean sine fixture, `mp3rgain -r`:

| Tag | mp3gain | mp3rgain |
|---|---|---|
| `MP3GAIN_MINMAX` | `101,227` | `101,227` (identical) |
| `REPLAYGAIN_TRACK_GAIN` | `-0.415000 dB` | `-0.330000 dB` |
| `REPLAYGAIN_TRACK_PEAK` | `0.205757` | `0.203693` |

MINMAX matches byte-for-byte; REPLAYGAIN matches convention (residual, 6-decimal, same sign), differing only by the documented <0.1 dB LAME-vs-Symphonia analyzer gap.

`cargo fmt`, `cargo clippy --all-targets`, and `cargo test` all pass.

## Out of scope (Phase 2)

- `MP3GAIN_UNDO` sign flip (the only read-breaking change) — fixes cross-tool undo.
- `MP3GAIN_ALBUM_MINMAX` and album-residual re-analysis on saturation.