### PR TITLE
fix: match mp3gain's MP3GAIN_UNDO sign so cross-tool undo works (#210)

### DIFF
--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -22,14 +22,16 @@ mp3rgain -r -k -d 0 -s s -o file.mp3
 ```
 
 The CLI surface, the TSV output format, and the APEv2 undo tag are all
-mp3gain-compatible.
+mp3gain-compatible. You can mix the two tools on the same file — gain written
+by mp3gain can be undone by mp3rgain and vice versa.
 
-> **Note on cross-tool undo:** each tool reliably undoes *its own* changes, but
-> undoing an mp3gain-written file with `mp3rgain -u` (or vice versa) is currently
-> broken because the two tools store the `mp3gain_undo` value with opposite signs
-> — see [Behaviour differences](#behaviour-differences) and
-> [#210](https://github.com/M-Igashi/mp3rgain/issues/210). Undo the file with the
-> same tool that applied the gain.
+> **Upgrading from mp3rgain ≤ 2.8.x?** Releases up to 2.8.x stored the
+> `mp3gain_undo` value with the *opposite* sign from mp3gain. That is fixed in
+> this version ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)), so a
+> file gain-adjusted by an **older mp3rgain** must be undone by that older
+> version (or re-analyzed) — undoing it with this version would double the gain.
+> Files written by mp3gain, or by this version onward, undo correctly with
+> either tool.
 
 ## Drop-in alias
 
@@ -58,7 +60,7 @@ flags are accepted with the same semantics; mp3rgain adds a few extensions.
 | `-g <i>` | Apply gain of `i` steps (1 step = 1.5 dB) | Bit-identical output (see compatibility report) |
 | `-d <n>` | Modify suggested gain by `n` dB (applied with `-r` / `-a`) | mp3gain-compatible since v1.2.1 |
 | `-m <i>` | Modify suggested gain by `i` steps | |
-| `-u` | Undo gain changes (reads APEv2 `mp3gain_undo`) | Reliably undoes mp3rgain's own files; cross-tool undo is currently broken ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)) |
+| `-u` | Undo gain changes (reads APEv2 `mp3gain_undo`) | Reads tags written by either tool ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)); see the note on upgrading from mp3rgain ≤ 2.8.x |
 | `-x` | Print max amplitude only | |
 | `-k` | Prevent clipping (auto-limit gain) | |
 | `-c` | Ignore clipping warnings | |
@@ -115,7 +117,7 @@ For new integrations, prefer `-o json`, which is structured and stable.
 
 | Tag location | mp3gain | mp3rgain | Interop |
 |--------------|---------|----------|---------|
-| APEv2 `mp3gain_undo` (MP3) | Written | Written | ⚠️ Opposite sign convention — each tool undoes its own files, but cross-tool undo is currently broken ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)) |
+| APEv2 `mp3gain_undo` (MP3) | Written | Written | Bidirectional — either tool can undo the other's changes ([#210](https://github.com/M-Igashi/mp3rgain/issues/210); files written by mp3rgain ≤ 2.8.x used the opposite sign) |
 | APEv2 `mp3gain_minmax` (MP3) | Written | Written | Same |
 | APEv2 ReplayGain (`mp3gain_album_*`, `replaygain_*`) | Written | Written | Same |
 | ID3v2 TXXX/RVA2 ReplayGain | Not written | Written with `-s i` | Standard ReplayGain readers (foobar2000, mpd, etc.) recognise it |
@@ -130,7 +132,7 @@ These are the only behaviour differences worth knowing about:
 
 | Area | Difference | Impact |
 |------|------------|--------|
-| Cross-tool undo | `mp3gain` stores the *undo* delta in `mp3gain_undo`; `mp3rgain` stores the *applied* delta (opposite sign) | Each tool undoes its own files correctly. Running `mp3rgain -u` on an `mp3gain`-written file (or vice versa) **doubles** the gain instead of undoing it. Tracked in [#210](https://github.com/M-Igashi/mp3rgain/issues/210); undo with the same tool that applied the gain |
+| Undo of files from mp3rgain ≤ 2.8.x | Those releases stored `mp3gain_undo` with the opposite sign; fixed in this version ([#210](https://github.com/M-Igashi/mp3rgain/issues/210)) | Undo a file gain-adjusted by an older mp3rgain with that **older** version (or re-analyze). Undoing it with this version would double the gain. mp3gain-written files and files from this version onward are unaffected |
 | Undo cleanup | mp3gain leaves empty APEv2 tags after `-u`; mp3rgain removes them | Audio data is identical; only the tag block differs |
 | ReplayGain analysis | mp3gain uses LAME; mp3rgain uses Symphonia + native Rust | Track/album gain values may differ by <0.1 dB. The *applied* gain is bit-identical for any given step value |
 | Format coverage | mp3gain handles MP3 only | mp3rgain also handles AAC/M4A/.mp4 (lossless `global_gain` rewrite, the same idea aacgain used) |

--- a/scripts/compatibility-test.sh
+++ b/scripts/compatibility-test.sh
@@ -187,9 +187,73 @@ test_gain_steps() {
 # (used with ReplayGain), while mp3rgain's -d directly applies dB gain.
 # This is a documented difference, not a compatibility issue.
 
-# Note: Undo test removed because mp3gain and mp3rgain handle APE tags
-# differently after undo (mp3gain keeps empty tags, mp3rgain removes them).
-# The core undo functionality works correctly - only tag cleanup differs.
+# Extract "<Max global_gain>,<Min global_gain>" from the analysis output.
+# These two columns fully capture a file's lossless-gain state, so they are
+# the right thing to compare for an undo round-trip — unaffected by the
+# container/tag-block byte differences between the two tools' file rewrites.
+gg_range() {
+    awk -F'\t' 'NR==2 {print $5 "," $6; exit}'
+}
+
+# Cross-tool undo: the MP3GAIN_UNDO sign convention must match mp3gain so that
+# `-u` reverses the *other* tool's gain (issue #210). A wrong sign re-applies
+# the gain (doubling it) instead of cancelling it, which shows up as a
+# global_gain range that does not return to the original.
+run_cross_undo() {
+    local test_name="$1"
+    local mp3_file="$2"
+    local apply_bin="$3"
+    local undo_bin="$4"
+    local gain="$5"
+
+    local basename
+    basename=$(basename "$mp3_file")
+    local orig="${TEMP_DIR}/xu_orig_${basename}"
+    local work="${TEMP_DIR}/xu_work_${basename}"
+    cp "$mp3_file" "$orig"
+    cp "$mp3_file" "$work"
+
+    if ! "$apply_bin" -g "$gain" "$work" > /dev/null 2>&1; then
+        log "  ${YELLOW}SKIP${NC}: $test_name (apply failed)"
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        return 0
+    fi
+    if ! "$undo_bin" -u "$work" > /dev/null 2>&1; then
+        log "  ${RED}FAIL${NC}: $test_name (undo failed)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+
+    local gg_orig gg_work
+    gg_orig=$("$MP3RGAIN_BIN" -o tsv "$orig" 2>/dev/null | gg_range)
+    gg_work=$("$MP3RGAIN_BIN" -o tsv "$work" 2>/dev/null | gg_range)
+    if [ -n "$gg_orig" ] && [ "$gg_orig" = "$gg_work" ]; then
+        log "  ${GREEN}PASS${NC}: $test_name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+        return 0
+    else
+        log "  ${RED}FAIL${NC}: $test_name - global_gain not restored"
+        log "    original: $gg_orig"
+        log "    restored: $gg_work"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+test_cross_tool_undo() {
+    local mp3_file="$1"
+    local basename
+    basename=$(basename "$mp3_file" .mp3)
+
+    log ""
+    log "Testing cross-tool undo on: $basename"
+
+    # A small attenuation is losslessly reversible on every fixture (no
+    # global_gain saturation at the 0/255 boundary), so a clean restore
+    # isolates the undo-sign convention from saturation effects.
+    run_cross_undo "mp3gain applies, mp3rgain undoes" "$mp3_file" "$MP3GAIN_BIN" "$MP3RGAIN_BIN" -3
+    run_cross_undo "mp3rgain applies, mp3gain undoes" "$mp3_file" "$MP3RGAIN_BIN" "$MP3GAIN_BIN" -3
+}
 
 # Test clipping prevention
 test_clipping_prevention() {
@@ -329,6 +393,7 @@ main() {
         test_gain_steps "$mp3"
         test_clipping_prevention "$mp3"
         test_channel_gain "$mp3"
+        test_cross_tool_undo "$mp3"
     done
 
     # Cross-check the ReplayGain analysis (recommended gain) against mp3gain.

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -545,10 +545,13 @@ fn write_id3v2_undo_after_apply(
     // fresh scan reflects the applied gain.
     let post = crate::analyze(file)?;
 
+    // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue #210):
+    // applying `+delta` makes the stored undo `-delta`, accumulating by
+    // subtraction onto any prior undo value.
     id3v2::write_id3v2_undo(
         file,
-        existing_left + delta_left,
-        existing_right + delta_right,
+        existing_left - delta_left,
+        existing_right - delta_right,
         wrap,
         post.min_gain(),
         post.max_gain(),

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -228,6 +228,11 @@ pub fn apply_gain_db(file_path: &Path, gain_db: f64) -> Result<usize> {
 ///
 /// Equal deltas take the whole-file path (honoring `wrap`); unequal deltas
 /// are undone per channel (channel gain is always saturating).
+///
+/// `left`/`right` are the stored `MP3GAIN_UNDO` deltas in mp3gain's
+/// convention — the gain to *re-add* to restore the original — so they are
+/// applied directly (issue #210). This is what makes cross-tool undo work:
+/// mp3gain stores `-N` after applying `+N`, and we apply that `-N` as-is.
 pub(crate) fn apply_undo_to_data(data: &mut [u8], left: i32, right: i32, wrap: bool) -> usize {
     if left == right {
         let mode = if wrap {
@@ -235,10 +240,10 @@ pub(crate) fn apply_undo_to_data(data: &mut [u8], left: i32, right: i32, wrap: b
         } else {
             GainMode::Saturating
         };
-        apply_gain_to_data(data, -left, mode, None).frames
+        apply_gain_to_data(data, left, mode, None).frames
     } else {
-        let left_frames = apply_gain_to_data(data, -left, GainMode::Saturating, Some(0)).frames;
-        let right_frames = apply_gain_to_data(data, -right, GainMode::Saturating, Some(1)).frames;
+        let left_frames = apply_gain_to_data(data, left, GainMode::Saturating, Some(0)).frames;
+        let right_frames = apply_gain_to_data(data, right, GainMode::Saturating, Some(1)).frames;
         left_frames.max(right_frames)
     }
 }
@@ -347,11 +352,15 @@ fn apply_gain_with_undo_impl_to_path(
     // Accumulate into BOTH channel slots independently: a prior `-l`
     // channel apply may have left them asymmetric, and collapsing them
     // into a single value corrupts the right channel's undo history.
+    //
+    // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue #210):
+    // the value to re-add to restore the original. Applying `+gain_steps`
+    // makes the stored undo `-gain_steps`, so it accumulates by subtraction.
     let (existing_left, existing_right) = parse_undo_values(tag.get(TAG_MP3GAIN_UNDO));
     let wrap = mode == GainMode::Wrapping;
     tag.set_undo_gain(
-        existing_left + gain_steps,
-        existing_right + gain_steps,
+        existing_left - gain_steps,
+        existing_right - gain_steps,
         wrap,
     );
 
@@ -411,9 +420,10 @@ fn apply_gain_channel_with_undo(
 
     let (existing_left, existing_right) = parse_undo_values(tag.get(TAG_MP3GAIN_UNDO));
 
+    // Undo delta accumulates by subtraction (mp3gain convention, issue #210).
     let (new_left, new_right) = match channel {
-        Channel::Left => (existing_left + gain_steps, existing_right),
-        Channel::Right => (existing_left, existing_right + gain_steps),
+        Channel::Left => (existing_left - gain_steps, existing_right),
+        Channel::Right => (existing_left, existing_right - gain_steps),
     };
 
     tag.set_undo_gain(new_left, new_right, false);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -447,8 +447,11 @@ fn test_whole_file_apply_preserves_asymmetric_undo_values() {
         .unwrap();
     GainOptions::new(-1).undo(true).apply(&path).unwrap();
 
+    // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue #210):
+    // applying -3 then -1 to the left and -1 to the right yields undo deltas
+    // +4 / +1 (the gain to re-add to restore the original).
     let tag = read_ape_tag_from_file(&path).unwrap().unwrap();
-    assert_eq!(tag.get(TAG_MP3GAIN_UNDO), Some("-004,-001,N"));
+    assert_eq!(tag.get(TAG_MP3GAIN_UNDO), Some("+004,+001,N"));
 
     undo_gain(&path).unwrap();
     assert_eq!(fs::read(&path).unwrap(), original);


### PR DESCRIPTION
## Summary

Phase 2a of #210 — the one correctness bug. `mp3gain` stores `MP3GAIN_UNDO` as the **undo** delta (the value to re-add to restore the original, so `+N` applied is recorded as `-N`). mp3rgain stored the **applied** delta (`+N`), so `mp3rgain -u` on an `mp3gain`-written file re-applied the gain instead of cancelling it — **doubling** it (and the reverse failed the same way).

This flips mp3rgain's MP3 convention to mp3gain's, fixing cross-tool undo.

### Changes

- **Write:** `MP3GAIN_UNDO` now stores the negated (undo) delta; it accumulates by subtraction. (APE: `gain.rs`; ID3v2: `apply.rs` — they share `format_undo_value`.)
- **Read:** `apply_undo_to_data` applies the stored value directly instead of negating it.
- Self-undo still round-trips — both sides flip consistently.
- **AAC is unchanged.** `mp3gain`/`aacgain` don't read mp3rgain's AAC tags, so its internal undo convention has no interop partner; flipping it would only break existing AAC files for no benefit.
- **Docs:** the migration guide now states cross-tool undo works, with an upgrade caveat for files tagged by mp3rgain ≤ 2.8.x.
- **Test:** adds a cross-tool undo regression test to `scripts/compatibility-test.sh`.

### Verification

Against **mp3gain 1.6.2**, applying with one tool and undoing with the other restores the original `global_gain` in **both** directions (apply +N → undo → original). The new compatibility-test case compares the restored `global_gain` range (immune to the two tools' cosmetic tag-block rewrite differences). `cargo fmt`, `cargo clippy --all-targets`, and `cargo test` all pass.

## ⚠️ Breaking change

Libraries gain-adjusted by **mp3rgain ≤ 2.8.x** stored `MP3GAIN_UNDO` with the old (opposite) sign. Undoing such a file with this version would **double** the gain. Undo them with the older version, or re-analyze. Files written by `mp3gain`, or by this version onward, undo correctly with either tool. This warrants a **minor/major version bump** and a prominent release note.

## Out of scope (Phase 2b)

- `MP3GAIN_ALBUM_MINMAX` and album-residual re-analysis on saturation (parity nice-to-have).