### PR TITLE
feat: write MP3GAIN_ALBUM_MINMAX in album mode (mp3gain parity, #210)

### DIFF
--- a/src/ape.rs
+++ b/src/ape.rs
@@ -397,6 +397,19 @@ pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> 
     Ok(())
 }
 
+/// Add (or replace) the `MP3GAIN_ALBUM_MINMAX` item in `file_path`'s APEv2
+/// tag, preserving all other items. mp3gain writes this album-wide
+/// post-apply `global_gain` range (`min,max`) in album (`-a`) mode (issue
+/// #210); the same value is stored on every file in the album.
+pub fn write_ape_album_minmax(file_path: &Path, min: u8, max: u8) -> Result<()> {
+    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+    let mut tag = read_ape_tag(&data).unwrap_or_default();
+    tag.set(TAG_MP3GAIN_ALBUM_MINMAX, &format!("{},{}", min, max));
+    let new_data = replace_ape_tag(&data, &tag);
+    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
+    Ok(())
+}
+
 /// Delete APEv2 tag from file
 pub fn delete_ape_tag(file_path: &Path) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
@@ -530,5 +543,24 @@ mod tests {
         assert_eq!(out.get(TAG_REPLAYGAIN_TRACK_PEAK), Some("0.250000"));
         // Album fields were None, so they must not be written.
         assert_eq!(out.get(TAG_REPLAYGAIN_ALBUM_GAIN), None);
+    }
+
+    /// Issue #210: write_ape_album_minmax adds MP3GAIN_ALBUM_MINMAX as `min,max`
+    /// while preserving the items the apply step already wrote.
+    #[test]
+    fn write_ape_album_minmax_sets_and_preserves() {
+        let mut tag = ApeTag::new();
+        tag.set_undo_gain(-15, -15, false);
+        tag.set_minmax(131, 225);
+        let data = replace_ape_tag(&vec![0u8; 20_000], &tag);
+        let path = write_temp("album_minmax.mp3", &data);
+
+        write_ape_album_minmax(&path, 126, 225).unwrap();
+
+        let out = read_ape_tag_from_file(&path).unwrap().unwrap();
+        assert_eq!(out.get(TAG_MP3GAIN_ALBUM_MINMAX), Some("126,225"));
+        // Pre-existing per-file items are untouched.
+        assert_eq!(out.get(TAG_MP3GAIN_UNDO), Some("-015,-015,N"));
+        assert_eq!(out.get(TAG_MP3GAIN_MINMAX), Some("131,225"));
     }
 }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::cli::options::{Options, OutputFormat};
+use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
@@ -172,6 +172,28 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Aggregate the post-apply `global_gain` range across the album's MP3 files
+/// and stamp `MP3GAIN_ALBUM_MINMAX` (`min,max`) onto each, matching mp3gain's
+/// `-a` mode (issue #210). AAC files are skipped — the MP3 analyzer rejects
+/// them and mp3gain has no AAC. Tag-write failures are swallowed: this is
+/// metadata parity, not something that should fail the gain operation.
+fn write_album_minmax(files: &[PathBuf], indices: &[usize]) {
+    let mut album_min = u8::MAX;
+    let mut album_max = u8::MIN;
+    let mut mp3_files: Vec<&Path> = Vec::new();
+    for &idx in indices {
+        let file = files[idx].as_path();
+        if let Ok(analysis) = mp3rgain::analyze(file) {
+            album_min = album_min.min(analysis.min_gain());
+            album_max = album_max.max(analysis.max_gain());
+            mp3_files.push(file);
+        }
+    }
+    for file in mp3_files {
+        let _ = mp3rgain::write_ape_album_minmax(file, album_min, album_max);
+    }
 }
 
 pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
@@ -477,6 +499,15 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             }
 
             progress_finish(pb);
+
+            // MP3GAIN_ALBUM_MINMAX: the album-wide post-apply global_gain range,
+            // matching mp3gain's album (`-a`) mode (issue #210). Written to every
+            // MP3 file after all gain is applied (the range is only known once the
+            // whole album is done). APEv2 only — mp3gain has no AAC, and `-s i`
+            // uses ID3v2; best-effort, so a tag hiccup never fails the album.
+            if !opts.dry_run && opts.stored_tag_mode != StoredTagMode::Skip && !opts.use_id3v2 {
+                write_album_minmax(files, &successful_indices);
+            }
 
             if opts.output_format == OutputFormat::Json {
                 let output = JsonOutput {

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::{
-    id3v2, mp4meta, read_ape_tag_from_file, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
-    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
-    TAG_REPLAYGAIN_TRACK_PEAK,
+    id3v2, mp4meta, read_ape_tag_from_file, TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX,
+    TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
+    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
@@ -18,6 +18,7 @@ use crate::util::get_filename;
 struct CheckTagInfo<'a> {
     undo: Option<&'a str>,
     minmax: Option<&'a str>,
+    album_minmax: Option<&'a str>,
     track_gain: Option<&'a str>,
     track_peak: Option<&'a str>,
     album_gain: Option<&'a str>,
@@ -31,6 +32,7 @@ impl CheckTagInfo<'_> {
     fn has_any(&self) -> bool {
         self.undo.is_some()
             || self.minmax.is_some()
+            || self.album_minmax.is_some()
             || self.track_gain.is_some()
             || self.track_peak.is_some()
             || self.album_gain.is_some()
@@ -53,6 +55,9 @@ impl CheckTagInfo<'_> {
                 if let Some(v) = self.minmax {
                     writeln!(out, "  {:<25}{}", format!("{}:", self.minmax_label), v).ok();
                 }
+                if let Some(v) = self.album_minmax {
+                    writeln!(out, "  {:<25}{}", "MP3GAIN_ALBUM_MINMAX:", v).ok();
+                }
                 if let Some(v) = self.track_gain {
                     writeln!(out, "  REPLAYGAIN_TRACK_GAIN: {}", v).ok();
                 }
@@ -74,14 +79,15 @@ impl CheckTagInfo<'_> {
             OutputFormat::Tsv => {
                 writeln!(
                     out,
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     filename,
                     self.undo.unwrap_or("-"),
                     self.minmax.unwrap_or("-"),
                     self.track_gain.unwrap_or("-"),
                     self.track_peak.unwrap_or("-"),
                     self.album_gain.unwrap_or("-"),
-                    self.album_peak.unwrap_or("-")
+                    self.album_peak.unwrap_or("-"),
+                    self.album_minmax.unwrap_or("-")
                 )
                 .ok();
                 None
@@ -217,6 +223,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
         let info = CheckTagInfo {
             undo: undo_tags.undo(),
             minmax: undo_tags.minmax(),
+            album_minmax: None,
             track_gain: rg_tags.track_gain(),
             track_peak: rg_tags.track_peak(),
             album_gain: rg_tags.album_gain(),
@@ -233,6 +240,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
                 let info = CheckTagInfo {
                     undo: rg.undo.as_deref(),
                     minmax: rg.minmax.as_deref(),
+                    album_minmax: None,
                     track_gain: rg.track_gain.as_deref(),
                     track_peak: rg.track_peak.as_deref(),
                     album_gain: rg.album_gain.as_deref(),
@@ -267,6 +275,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
                 let info = CheckTagInfo {
                     undo: tag.get(TAG_MP3GAIN_UNDO),
                     minmax: tag.get(TAG_MP3GAIN_MINMAX),
+                    album_minmax: tag.get(TAG_MP3GAIN_ALBUM_MINMAX),
                     track_gain: tag.get(TAG_REPLAYGAIN_TRACK_GAIN),
                     track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK),
                     album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN),
@@ -282,6 +291,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
                 let info = CheckTagInfo {
                     undo: None,
                     minmax: None,
+                    album_minmax: None,
                     track_gain: None,
                     track_peak: None,
                     album_gain: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,10 @@ pub use analysis::{
     Mp3Analysis, MpegVersion,
 };
 pub use ape::{
-    delete_ape_tag, read_ape_tag, read_ape_tag_from_file, write_ape_tag, ApeItem, ApeTag,
-    TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN,
-    TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
+    delete_ape_tag, read_ape_tag, read_ape_tag_from_file, write_ape_album_minmax, write_ape_tag,
+    ApeItem, ApeTag, TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
+    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
+    TAG_REPLAYGAIN_TRACK_PEAK,
 };
 pub use apply::{
     apply_with_options, predict_apply, AacAlbumInfo, ApplyOptions, ApplyReport, ClippingDetection,


### PR DESCRIPTION
## Summary

Phase 2b of #210 — the final parity item. mp3gain's album (`-a`) mode records **`MP3GAIN_ALBUM_MINMAX`**: the album-wide *post-apply* `global_gain` range, stored identically on every track. mp3rgain wrote per-file `MP3GAIN_MINMAX` but not the album-wide range.

### Changes

- After the album apply loop, aggregate each MP3's post-apply `global_gain` min/max into an album-wide range and write `MP3GAIN_ALBUM_MINMAX` (`min,max`) to each file.
- **APEv2 only** — mp3gain has no AAC, and `-s i` uses ID3v2. Best-effort: a tag-write hiccup never fails the gain operation.
- `-s c` (check stored tags) now displays `MP3GAIN_ALBUM_MINMAX` (text and TSV).
- New `ape::write_ape_album_minmax` helper + unit test.

### Verification

Against **mp3gain 1.6.2** on a two-file album (`-a`):

| File | `MP3GAIN_MINMAX` | `MP3GAIN_ALBUM_MINMAX` |
|------|------------------|------------------------|
| track 1 | `131,225` | `126,225` |
| track 2 | `126,225` | `126,225` |

mp3rgain produces the **byte-identical** album range on every track (album min = `min(131,126)=126`, max = `225`). `cargo fmt`, `cargo clippy --all-targets`, `cargo test`, and `scripts/compatibility-test.sh` all pass.

### Scope note

The album ReplayGain **residual** stays arithmetic (exact absent `global_gain` saturation, which is rare and already warned about). A post-apply album re-analysis for the saturating case was deemed not worth the extra full-album pass.

---

This closes out the #210 convergence work: Phase 1 (post-apply residual ReplayGain + MINMAX, #211), Phase 2a (MP3GAIN_UNDO sign / cross-tool undo, #212), and now Phase 2b (album MINMAX). mp3rgain's APEv2 tags now match mp3gain's convention end-to-end.