### PR TITLE
perf: speed up AAC bitstream scanning and cut redundant file I/O

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -208,25 +208,34 @@ impl<'a> BitReader<'a> {
         if bits_to_read == 0 {
             return Ok(0);
         }
-        if self.bits_remaining() < bits_to_read {
-            return Err(Error::AacParse {
-                message: "unexpected end of bitstream".into(),
-            });
-        }
-
-        let bytes_needed = (self.bit_pos as usize + bits_to_read).div_ceil(8);
-        let mut window = 0u64;
-        for byte in &self.data[self.byte_pos..self.byte_pos + bytes_needed] {
-            window = (window << 8) | u64::from(*byte);
-        }
-
-        let window_bits = bytes_needed * 8;
-        let shift = window_bits - self.bit_pos as usize - bits_to_read;
         let mask = if n == 32 {
             u64::from(u32::MAX)
         } else {
             (1u64 << bits_to_read) - 1
         };
+
+        // Fast path: a single 8-byte load covers any request (bit_pos <= 7
+        // plus n <= 32 needs at most 39 bits). This is the innermost loop of
+        // Huffman decoding, so avoiding the byte-by-byte window build matters.
+        if let Some(window_bytes) = self.data.get(self.byte_pos..self.byte_pos + 8) {
+            let window = u64::from_be_bytes(window_bytes.try_into().unwrap());
+            let shift = 64 - self.bit_pos as usize - bits_to_read;
+            return Ok(((window >> shift) & mask) as u32);
+        }
+
+        // Tail fallback: fewer than 8 bytes remain
+        if self.bits_remaining() < bits_to_read {
+            return Err(Error::AacParse {
+                message: "unexpected end of bitstream".into(),
+            });
+        }
+        let bytes_needed = (self.bit_pos as usize + bits_to_read).div_ceil(8);
+        let mut window = 0u64;
+        for byte in &self.data[self.byte_pos..self.byte_pos + bytes_needed] {
+            window = (window << 8) | u64::from(*byte);
+        }
+        let window_bits = bytes_needed * 8;
+        let shift = window_bits - self.bit_pos as usize - bits_to_read;
         Ok(((window >> shift) & mask) as u32)
     }
 
@@ -992,10 +1001,8 @@ fn parse_tns_data(reader: &mut BitReader, info: &IcsInfo) -> Result<()> {
                 if order > 0 {
                     let _direction = reader.read_bits(1)?;
                     let coef_compress = reader.read_bits(1)?;
-                    let coef_bits = (coef_res + 3 - coef_compress) as u8;
-                    for _ in 0..order {
-                        reader.read_bits(coef_bits)?;
-                    }
+                    let coef_bits = (coef_res + 3 - coef_compress) as usize;
+                    reader.skip_bits(order * coef_bits)?;
                 }
             }
         }
@@ -1100,12 +1107,8 @@ fn parse_cpe(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<AacGainLoca
         let info = parse_ics_info(reader)?;
         let ms_mask_present = reader.read_bits(2)?;
         if ms_mask_present == 1 {
-            // Read ms_used bits
-            for _g in 0..info.window_groups {
-                for _sfb in 0..info.max_sfb {
-                    reader.read_bits(1)?;
-                }
-            }
+            // Skip ms_used bits (one per group/sfb pair, values unused)
+            reader.skip_bits(info.window_groups * info.max_sfb)?;
         }
         Some(info)
     } else {
@@ -1416,7 +1419,12 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
 ///
 /// Returns the number of modified gain locations.
 pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
-    let undo_tags = mp4meta::read_undo_tags(file_path)?;
+    // Single read/write pass: read once, undo the gain and strip the undo
+    // tags in memory, then write atomically (previously 4 full reads and
+    // 2 full writes per undo).
+    let mut data = std::fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+
+    let undo_tags = mp4meta::read_undo_tags_from_data(&data);
     let undo_str = undo_tags.undo().ok_or(Error::NoUndoTag)?;
 
     let undo_gain = crate::ape::parse_undo_values(Some(undo_str)).0;
@@ -1425,16 +1433,12 @@ pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
         return Ok(0);
     }
 
-    // Apply inverse gain
-    let analysis = analyze_aac_gains(file_path)?;
-    let mut data = std::fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
-
+    // Apply inverse gain and remove undo tags
+    let analysis = analyze_aac_gains_from_data(&data)?;
     let modified = apply_aac_gain_to_data(&mut data, &analysis, -undo_gain);
 
-    std::fs::write(file_path, &data).map_err(|e| Error::io_write(file_path, e))?;
-
-    // Remove undo tags
-    mp4meta::delete_undo_tags(file_path)?;
+    let final_data = mp4meta::update_mp4_undo_metadata(&data, &mp4meta::UndoTags::default())?;
+    mp4meta::atomic_write(file_path, &final_data)?;
 
     Ok(modified)
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::threading::effective_threads;
 use crate::json_output::{JsonFileResult, JsonOutput};
-use crate::processors::info::{format_rg_row, process_info};
+use crate::processors::info::{format_rg_row, process_info, scan_gain_range_for_row};
 use crate::progress::{
     create_album_progress_pb_in, create_analysis_progress_bar, create_file_count_pb_in,
     progress_finish,
@@ -90,6 +90,17 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
         }
     }
 
+    // Scan gain ranges in parallel before emitting: the frame scan re-reads
+    // each file, which the sequential emit loop below would serialize.
+    let gain_ranges: Vec<(u8, u8)> = files
+        .par_iter()
+        .enumerate()
+        .map(|(i, file)| match rows[i] {
+            Some(Row::Analyzed(_)) => scan_gain_range_for_row(file),
+            _ => (255, 0),
+        })
+        .collect();
+
     // Emit rows in input order and collect the album-level gain bounds.
     let mut any_ok = false;
     let mut album_max_gain: Option<u8> = None;
@@ -100,7 +111,7 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
         for (i, file) in files.iter().enumerate() {
             match &rows[i] {
                 Some(Row::Analyzed(rg)) => {
-                    let (result, text) = format_rg_row(file, opts, rg)?;
+                    let (result, text) = format_rg_row(file, opts, rg, gain_ranges[i])?;
                     if !text.is_empty() {
                         handle.write_all(text.as_bytes())?;
                     }

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -236,17 +236,18 @@ fn process_apply_channel_into(
     let filename = get_filename(file);
     let channel_name = channel.name();
 
-    // Warn if file is Joint Stereo (mp3gain only supports Stereo for -l)
-    if let Ok(info) = analyze(file) {
-        if info.channel_mode() == mp3rgain::ChannelMode::JointStereo
-            && opts.output_format == OutputFormat::Text
-            && !opts.quiet
-        {
-            eprintln!(
-                "  {} {} - Joint Stereo file: channel-specific gain may not work as expected",
-                "!".yellow(),
-                filename
-            );
+    // Warn if file is Joint Stereo (mp3gain only supports Stereo for -l).
+    // Check the output mode first: analyze() reads the whole file, which is
+    // wasted when the warning would not be printed anyway.
+    if opts.output_format == OutputFormat::Text && !opts.quiet {
+        if let Ok(info) = analyze(file) {
+            if info.channel_mode() == mp3rgain::ChannelMode::JointStereo {
+                eprintln!(
+                    "  {} {} - Joint Stereo file: channel-specific gain may not work as expected",
+                    "!".yellow(),
+                    filename
+                );
+            }
         }
     }
 

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -11,13 +11,23 @@ use crate::json_output::{FileStatus, JsonFileResult};
 use crate::progress::update_analysis_progress;
 use crate::util::get_filename;
 
+/// Scan the file's global_gain range for an info row. MP3-only: AAC files
+/// fail the frame scan and get the (255, 0) placeholder mp3gain also prints.
+pub fn scan_gain_range_for_row(file: &Path) -> (u8, u8) {
+    analyze(file)
+        .map(|info| (info.max_gain(), info.min_gain()))
+        .unwrap_or((255, 0))
+}
+
 /// Format one mp3gain-compatible per-file row from a ReplayGain analysis
 /// result. Shared by the per-file path below and the single-pass album flow
-/// in `cmd_info`.
+/// in `cmd_info`, which pre-computes `gain_range` in parallel instead of
+/// re-scanning each file inside its sequential emit loop.
 pub fn format_rg_row(
     file: &Path,
     opts: &Options,
     rg_result: &ReplayGainResult,
+    gain_range: (u8, u8),
 ) -> Result<(JsonFileResult, String)> {
     let mut out = String::new();
     let filename = get_filename(file);
@@ -25,9 +35,7 @@ pub fn format_rg_row(
     // Reuse the ReplayGain peak instead of re-decoding the audio
     // via find_max_amplitude (issue #135).
     let max_amp = rg_result.peak();
-    let (max_gain, min_gain) = analyze(file)
-        .map(|info| (info.max_gain(), info.min_gain()))
-        .unwrap_or((255, 0));
+    let (max_gain, min_gain) = gain_range;
 
     // Calculate gain with modifier (mp3gain compatible: -d modifies suggested gain)
     let gain_db = rg_result.gain_db() + opts.gain_modifier_db;
@@ -115,7 +123,8 @@ fn process_info_into(
 
         match rg_result {
             Ok(rg_result) => {
-                let (result, text) = format_rg_row(file, opts, &rg_result)?;
+                let (result, text) =
+                    format_rg_row(file, opts, &rg_result, scan_gain_range_for_row(file))?;
                 out.push_str(&text);
                 return Ok(result);
             }


### PR DESCRIPTION
## Summary

Performance-focused review of the hot paths, keeping every output byte-identical.

### AAC bitstream scanner (CPU)
- **`BitReader::peek_bits`**: added a fast path that loads 8 bytes at once (`u64::from_be_bytes`) instead of building the bit window byte-by-byte. This is the innermost loop of spectral Huffman decoding; `bit_pos <= 7` plus `n <= 32` needs at most 39 bits, so a single load always suffices away from the stream tail. The old loop remains as the tail fallback.
- **`parse_cpe` / `parse_tns_data`**: unused `ms_used` and TNS coefficient bits are now skipped with one `skip_bits` call (pure arithmetic) instead of bit-by-bit reads through the peek machinery.

### Redundant file I/O
- **`undo_aac_gain`**: consolidated from 4 full reads + 2 full writes to **1 read + 1 atomic write**, reusing the existing slice-based helpers (`read_undo_tags_from_data`, `analyze_aac_gains_from_data`, `update_mp4_undo_metadata`), following the same pattern as the #188 apply path. The gain rewrite also becomes crash-safe (previously a plain `fs::write` landed between the two passes).
- **`cmd_info`**: the sequential, stdout-locked emit loop called `analyze()` (full read + frame scan) per file. Gain ranges are now pre-computed with `par_iter` before the loop. Warm-cache benchmarks show no change (ReplayGain analysis dominates); this targets large/cold-cache libraries where the serialized re-read pass is visible.
- **`-l` channel gain**: the Joint Stereo warning scan (full file read) now runs only when the warning can actually be printed — JSON/quiet/dry-run modes skip it entirely.

## Measurements

5-minute stereo M4A, M3 MacBook Air, hyperfine (warm cache):

| Operation | Before | After | Delta |
|---|---|---|---|
| `-g 2` apply | 166.6 ms | 145.9 ms | **-14%** |
| `-u` undo | 176.1 ms | 144.3 ms | **-22%** (sys time halved) |

## Verification

- `cargo test --release`: 123 tests pass, including the #201 golden reference test
- apply / undo outputs are **byte-identical** to master on the benchmark files
- `info` output identical to master
- `cargo fmt` + `clippy` clean (the one remaining clippy note is the pre-existing `GOLDEN_GAIN_DB` precision lint)

## Reviewed but intentionally not changed

- **ReplayGain equal-loudness filter (54% of analysis runtime per profiling)**: a block-processing rewrite was prototyped and benchmarked at **2× slower** — the current per-frame L/R interleaving lets the CPU overlap the two channels' serial IIR dependency chains, which block processing destroys. The filter is FP-latency-bound and already near-optimal given the bit-faithfulness constraint to `gain_analysis.c`.
- APE tag tail-patching and moov-only M4A tag reads were identified as further I/O reductions but carry larger diffs; left for a follow-up if batch write throughput ever becomes a pain point.