### PR TITLE
feat(mp3rgui): filename-only display and single-album options

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -638,7 +638,10 @@ impl Mp3rgainApp {
                         .parent()
                         .map(|p| p.to_path_buf())
                         .unwrap_or_else(PathBuf::new);
-                    groups.entry(parent).or_default().push((idx, f.path.clone()));
+                    groups
+                        .entry(parent)
+                        .or_default()
+                        .push((idx, f.path.clone()));
                 }
             }
             groups.into_values().collect()

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -155,6 +155,12 @@ enum WorkerKind {
 struct PersistedSettings {
     apply_options: ApplyOptionsUi,
     target_volume: f64,
+    // `serde(default)` so settings saved by older builds (which lack these
+    // keys) still deserialize instead of falling back to full defaults.
+    #[serde(default)]
+    show_filename_only: bool,
+    #[serde(default)]
+    single_album: bool,
 }
 
 impl Default for PersistedSettings {
@@ -162,6 +168,8 @@ impl Default for PersistedSettings {
         Self {
             apply_options: ApplyOptionsUi::default(),
             target_volume: 89.0,
+            show_filename_only: false,
+            single_album: false,
         }
     }
 }
@@ -229,6 +237,16 @@ pub struct Mp3rgainApp {
     /// stored-tag read (issue #203). Drained by `start_import_scan` on the
     /// next idle frame.
     pending_import_scan: Vec<usize>,
+
+    /// When true, the Path/File column shows only the file name; the full
+    /// path stays available on hover (issue #223). Off = full path, the
+    /// pre-existing behavior.
+    pub show_filename_only: bool,
+
+    /// When true, Album Analysis / Apply Album Gain treat every loaded file
+    /// as a single album regardless of directory (issue #224). Off = each
+    /// folder is its own album, the default (issue #159).
+    pub single_album: bool,
 }
 
 impl Mp3rgainApp {
@@ -261,6 +279,8 @@ impl Mp3rgainApp {
             display_order_cache: Vec::new(),
             display_order_dirty: true,
             pending_import_scan: Vec::new(),
+            show_filename_only: settings.show_filename_only,
+            single_album: settings.single_album,
         }
     }
 
@@ -593,22 +613,36 @@ impl Mp3rgainApp {
             }
         }
 
-        let mut groups: std::collections::BTreeMap<PathBuf, Vec<(usize, PathBuf)>> =
-            std::collections::BTreeMap::new();
-        for &idx in &targets {
-            if let Some(f) = self.files.get(idx) {
-                let parent = f
-                    .path
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(PathBuf::new);
-                groups
-                    .entry(parent)
-                    .or_default()
-                    .push((idx, f.path.clone()));
+        let group_jobs: Vec<Vec<(usize, PathBuf)>> = if self.single_album {
+            // Issue #224: treat every target as one album regardless of
+            // directory, so multi-disc sets in subfolders share one album
+            // gain. A single group produces one album_info for the batch.
+            let jobs: Vec<(usize, PathBuf)> = targets
+                .iter()
+                .filter_map(|&idx| self.files.get(idx).map(|f| (idx, f.path.clone())))
+                .collect();
+            if jobs.is_empty() {
+                Vec::new()
+            } else {
+                vec![jobs]
             }
-        }
-        let group_jobs: Vec<Vec<(usize, PathBuf)>> = groups.into_values().collect();
+        } else {
+            // Issue #159: group by parent directory so each folder is its
+            // own album.
+            let mut groups: std::collections::BTreeMap<PathBuf, Vec<(usize, PathBuf)>> =
+                std::collections::BTreeMap::new();
+            for &idx in &targets {
+                if let Some(f) = self.files.get(idx) {
+                    let parent = f
+                        .path
+                        .parent()
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_else(PathBuf::new);
+                    groups.entry(parent).or_default().push((idx, f.path.clone()));
+                }
+            }
+            groups.into_values().collect()
+        };
         let total: usize = group_jobs.iter().map(|g| g.len()).sum();
 
         self.begin_worker(
@@ -654,7 +688,7 @@ impl Mp3rgainApp {
         self.begin_worker(
             WorkerKind::TrackApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "track gain", ui_opts),
+            worker::spawn_apply(ctx.clone(), jobs, "track gain", ui_opts, false),
         );
     }
 
@@ -821,7 +855,7 @@ impl Mp3rgainApp {
         self.begin_worker(
             WorkerKind::TrackApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "manual gain", ui_opts),
+            worker::spawn_apply(ctx.clone(), jobs, "manual gain", ui_opts, false),
         );
     }
 
@@ -860,7 +894,7 @@ impl Mp3rgainApp {
         self.begin_worker(
             WorkerKind::TrackApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "channel gain", ui_opts),
+            worker::spawn_apply(ctx.clone(), jobs, "channel gain", ui_opts, false),
         );
     }
 
@@ -933,10 +967,11 @@ impl Mp3rgainApp {
         }
         let count = jobs.len();
         let ui_opts = self.apply_options;
+        let single_album = self.single_album;
         self.begin_worker(
             WorkerKind::AlbumApply,
             count,
-            worker::spawn_apply(ctx.clone(), jobs, "album gain", ui_opts),
+            worker::spawn_apply(ctx.clone(), jobs, "album gain", ui_opts, single_album),
         );
     }
 
@@ -1362,6 +1397,8 @@ impl eframe::App for Mp3rgainApp {
         let settings = PersistedSettings {
             apply_options: self.apply_options,
             target_volume: self.target_volume,
+            show_filename_only: self.show_filename_only,
+            single_album: self.single_album,
         };
         eframe::set_value(storage, SETTINGS_KEY, &settings);
     }

--- a/mp3rgui/src/ui/options.rs
+++ b/mp3rgui/src/ui/options.rs
@@ -44,6 +44,21 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                          The Status column shows the steps that would be applied. \
                          CLI -n.",
                     );
+
+                ui.separator();
+
+                ui.checkbox(&mut app.single_album, "Single album")
+                    .on_hover_text(
+                        "Treat all loaded files as one album for Album Analysis / \
+                         Apply Album Gain, ignoring subfolders (e.g. multi-disc sets). \
+                         Off = each folder is its own album.",
+                    );
+
+                ui.checkbox(&mut app.show_filename_only, "Filename only")
+                    .on_hover_text(
+                        "Show only the file name in the Path/File column instead of \
+                         the full path. The full path is still shown on hover.",
+                    );
             });
         });
     });

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -157,8 +157,15 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
 
                         row.col(|ui| {
                             let path_text = file.path.to_string_lossy();
+                            // Issue #223: optionally show just the file name;
+                            // the full path stays on hover either way.
+                            let label_text: &str = if app.show_filename_only {
+                                file.filename.as_str()
+                            } else {
+                                path_text.as_ref()
+                            };
                             let resp = ui
-                                .selectable_label(is_selected, path_text.as_ref())
+                                .selectable_label(is_selected, label_text)
                                 .on_hover_text(path_text.as_ref());
                             if resp.clicked() {
                                 let mode = ui.input(|i| {

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -421,6 +421,10 @@ pub fn spawn_apply(
     jobs: Vec<ApplyJob>,
     action_label: &'static str,
     ui_opts: ApplyOptionsUi,
+    // When true (album-gain apply with issue #224 enabled), the album-wide
+    // MINMAX range is stamped across the whole batch instead of per folder.
+    // Ignored by track/manual/channel gain, whose jobs carry no album_info.
+    single_album: bool,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
@@ -509,17 +513,23 @@ pub fn spawn_apply(
 
         // Album-wide MP3GAIN_ALBUM_MINMAX, written once the whole album has
         // been applied (mp3gain parity, issue #210). No-op for track/manual
-        // gain (empty list) and for the dry-run / ID3v2 paths. The GUI treats
-        // each folder as its own album (issue #159), so aggregate and stamp
-        // the range per parent directory rather than across the whole batch.
+        // gain (empty list) and for the dry-run / ID3v2 paths. By default the
+        // GUI treats each folder as its own album (issue #159), so the range
+        // is stamped per parent directory; in single-album mode (issue #224)
+        // it spans the whole batch to match the one shared album gain.
         if !album_minmax_paths.is_empty() {
-            let mut by_folder: BTreeMap<PathBuf, Vec<&Path>> = BTreeMap::new();
-            for p in &album_minmax_paths {
-                let parent = p.parent().map(Path::to_path_buf).unwrap_or_default();
-                by_folder.entry(parent).or_default().push(p.as_path());
-            }
-            for group in by_folder.values() {
-                write_album_minmax(group);
+            if single_album {
+                let all: Vec<&Path> = album_minmax_paths.iter().map(PathBuf::as_path).collect();
+                write_album_minmax(&all);
+            } else {
+                let mut by_folder: BTreeMap<PathBuf, Vec<&Path>> = BTreeMap::new();
+                for p in &album_minmax_paths {
+                    let parent = p.parent().map(Path::to_path_buf).unwrap_or_default();
+                    by_folder.entry(parent).or_default().push(p.as_path());
+                }
+                for group in by_folder.values() {
+                    write_album_minmax(group);
+                }
             }
         }
 


### PR DESCRIPTION
Implements two GUI feature requests from the Hydrogenaudio forum (user "doubleXP" / Christian).

## Changes

Two opt-in toggles added to the Options panel, both persisted across launches:

- **Filename only** (closes #223) — the Path/File column shows just the file name instead of the full path. The full path is still shown on hover. The old mp3gain GUI had this; useful on Windows with long paths.
- **Single album** (closes #224) — Album Analysis / Apply Album Gain treat all loaded files as one album, ignoring subfolders (e.g. multi-disc sets in `Disc 1` / `Disc 2`). Off keeps the per-folder default (#159), so nothing changes for existing users.

The single-album flag is threaded through to the apply worker so the album-wide `MP3GAIN_ALBUM_MINMAX` range is stamped across the whole batch instead of per folder when enabled.

## Notes

- `FileEntry` already carried a `filename` field, so #223 is a display switch only.
- New `PersistedSettings` fields use `#[serde(default)]` so settings saved by older builds still deserialize.
- Both default to off — no behavior change unless the user opts in.

## Verification

- `cargo fmt -- --check` — clean
- `cargo build --manifest-path mp3rgui/Cargo.toml` — ok
- `cargo test --manifest-path mp3rgui/Cargo.toml` — ok
- `cargo clippy --manifest-path mp3rgui/Cargo.toml` — no warnings