### PR TITLE
fix: harden malformed-input handling and address code review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -4,6 +4,7 @@ use crate::worker::{
 };
 use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{db_to_linear, db_to_steps, would_clip, AacAlbumInfo, Channel};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::TryRecvError;
 
@@ -396,9 +397,13 @@ impl Mp3rgainApp {
         let mut added = 0;
         let mut skipped = 0;
 
+        // Set lookup instead of scanning `files` per added path, which is
+        // O(n²) when dropping a large folder.
+        let mut known: HashSet<PathBuf> = self.files.iter().map(|f| f.path.clone()).collect();
+
         for path in paths {
             if mp3rgain::is_supported_audio_path(&path) && path.is_file() {
-                if self.is_duplicate(&path) {
+                if !known.insert(path.clone()) {
                     skipped += 1;
                     continue;
                 }
@@ -429,10 +434,6 @@ impl Mp3rgainApp {
         }
     }
 
-    fn is_duplicate(&self, path: &Path) -> bool {
-        self.files.iter().any(|f| f.path == path)
-    }
-
     pub fn add_folder(&mut self, folder: PathBuf, recursive: bool) {
         if self.is_processing {
             return;
@@ -453,7 +454,9 @@ impl Mp3rgainApp {
             }
         }
         self.selected_indices.clear();
-        // Removing rows shifts indices, so any queued import scan is stale.
+        // Removing rows shifts indices, so the anchor and any queued import
+        // scan are stale.
+        self.selection_anchor = None;
         self.pending_import_scan.clear();
         self.display_order_dirty = true;
     }

--- a/src/aac.rs
+++ b/src/aac.rs
@@ -493,21 +493,19 @@ fn build_sample_table(data: &[u8]) -> Result<(Vec<SampleEntry>, usize)> {
     let mut entries = Vec::with_capacity(sample_count);
     let mut sample_idx = 0usize;
 
+    // stsc entries have monotonically increasing first_chunk, so walk the
+    // table once with a moving index instead of rescanning it per chunk.
+    let mut stsc_idx = 0usize;
+
     for (chunk_idx, &chunk_offset) in chunk_offsets.iter().enumerate() {
         let chunk_num = chunk_idx + 1; // 1-based
 
-        // Find how many samples in this chunk
-        let samples_in_chunk = {
-            let mut spc = stsc_entries[0].samples_per_chunk;
-            for entry in &stsc_entries {
-                if entry.first_chunk as usize <= chunk_num {
-                    spc = entry.samples_per_chunk;
-                } else {
-                    break;
-                }
-            }
-            spc as usize
-        };
+        while stsc_idx + 1 < stsc_entries.len()
+            && stsc_entries[stsc_idx + 1].first_chunk as usize <= chunk_num
+        {
+            stsc_idx += 1;
+        }
+        let samples_in_chunk = stsc_entries[stsc_idx].samples_per_chunk as usize;
 
         let mut offset_in_chunk = 0u64;
         for _ in 0..samples_in_chunk {
@@ -604,7 +602,8 @@ fn parse_audio_config(data: &[u8], stsd_pos: usize) -> Result<u32> {
     }
     let mp4a_size = read_u32_be(data, entries_start) as usize;
     let mp4a_start = entries_start;
-    let mp4a_end = mp4a_start + mp4a_size;
+    // Clamp: a truncated/malformed file can declare a size past EOF.
+    let mp4a_end = (mp4a_start + mp4a_size).min(data.len());
 
     // sample_rate is at byte 32 within mp4a box:
     //   size(4) + type(4) + reserved(6) + data_ref_index(2) + version(2) +
@@ -634,7 +633,9 @@ fn parse_esds_sample_rate(data: &[u8], start: usize, end: usize) -> Option<u32> 
     // Find esds box
     let (esds_pos, esds_h) = mp4meta::find_box_in_container(data, start, end - start, ESDS)?;
     let esds_content = esds_pos + esds_h.header_size as usize + 4; // skip version/flags
-    let esds_end = esds_pos + esds_h.size as usize;
+                                                                   // Clamp the declared box size to the buffer so a truncated esds cannot
+                                                                   // index past EOF in find_audio_specific_config.
+    let esds_end = (esds_pos + esds_h.size as usize).min(data.len());
 
     let asc_data = find_audio_specific_config(data, esds_content, esds_end)?;
 
@@ -1388,7 +1389,9 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
 
     let existing_undo = mp4meta::read_undo_tags_from_data(&data);
     let existing_gain = crate::ape::parse_undo_values(existing_undo.undo()).0;
-    let new_undo_gain = existing_gain + gain_steps;
+    // Saturate: the existing value comes from an untrusted tag and could be
+    // crafted to overflow i32.
+    let new_undo_gain = existing_gain.saturating_add(gain_steps);
 
     let modified = apply_aac_gain_to_data(&mut data, &analysis, gain_steps);
 

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -309,11 +309,13 @@ fn remove_ape_tag(data: &[u8]) -> Vec<u8> {
     let has_header = (flags & APE_FLAG_HEADER_PRESENT) != 0;
     let header_size = if has_header { 32 } else { 0 };
 
-    let audio_end = if footer_start + 32 >= tag_size + header_size {
-        footer_start + 32 - tag_size - header_size
-    } else {
-        0
-    };
+    // A corrupt tag_size larger than the data before the footer would make
+    // audio_end underflow past the start of the file; treat it as "no valid
+    // tag" (mirroring read_ape_tag) instead of discarding the audio stream.
+    if footer_start + 32 < tag_size + header_size {
+        return data.to_vec();
+    }
+    let audio_end = footer_start + 32 - tag_size - header_size;
 
     let id3v1_start = footer_start + 32;
     let has_id3v1 = data.len() > id3v1_start + 3 && &data[id3v1_start..id3v1_start + 3] == b"TAG";

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -217,11 +217,11 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "w" => opts.wrap_gain = true,
                 "t" => opts.use_temp_file = true,
                 "f" => opts.assume_mpeg2 = true,
-                "v" | "-version" => {
+                "v" => {
                     print_version();
                     std::process::exit(0);
                 }
-                "h" | "-help" => {
+                "h" => {
                     print_usage();
                     std::process::exit(0);
                 }
@@ -286,7 +286,11 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                     eprintln!("{}: unknown option: -{}", "warning".yellow().bold(), flag);
                 }
             }
-        } else if !arg.starts_with("--") {
+        } else if arg.starts_with("--") {
+            // Silently dropping an unknown long option is dangerous
+            // (a typo like --dryrun would modify files), so reject it.
+            anyhow::bail!("unknown option: {}", arg);
+        } else {
             // It's a file
             opts.files.push(PathBuf::from(arg));
         }
@@ -309,6 +313,9 @@ pub fn expand_files_recursive(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     }
 
     result.sort();
+    // Overlapping roots (e.g. `-R music music/album`) yield duplicates,
+    // which would apply gain twice to the same file.
+    result.dedup();
     Ok(result)
 }
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -131,11 +131,9 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
     }
 
     // Print album summary (mp3gain compatible) from the same analysis pass.
-    let summary_report = if !mp3_set.is_empty() {
-        mp3_report.as_ref()
-    } else {
-        mp4_report.as_ref()
-    };
+    // Prefer the MP3 report, but fall back to the MP4 one if every MP3
+    // failed — otherwise the album summary would silently disappear.
+    let summary_report = mp3_report.as_ref().or(mp4_report.as_ref());
 
     if any_ok {
         if let Some(report) = summary_report {

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -185,20 +185,17 @@ impl GainOptions {
             } else {
                 apply_gain_channel_impl(read_from, write_to, channel, self.steps)
             }
-        } else if self.undo {
-            let mode = if self.wrap {
-                GainMode::Wrapping
-            } else {
-                GainMode::Saturating
-            };
-            apply_gain_with_undo_impl_to_path(read_from, write_to, self.steps, mode)
         } else {
             let mode = if self.wrap {
                 GainMode::Wrapping
             } else {
                 GainMode::Saturating
             };
-            apply_gain_simple_to_path(read_from, write_to, self.steps, mode)
+            if self.undo {
+                apply_gain_with_undo_impl_to_path(read_from, write_to, self.steps, mode)
+            } else {
+                apply_gain_simple_to_path(read_from, write_to, self.steps, mode)
+            }
         }
     }
 }
@@ -359,8 +356,8 @@ fn apply_gain_with_undo_impl_to_path(
     let (existing_left, existing_right) = parse_undo_values(tag.get(TAG_MP3GAIN_UNDO));
     let wrap = mode == GainMode::Wrapping;
     tag.set_undo_gain(
-        existing_left - gain_steps,
-        existing_right - gain_steps,
+        existing_left.saturating_sub(gain_steps),
+        existing_right.saturating_sub(gain_steps),
         wrap,
     );
 

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -650,7 +650,7 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
 
     let moov_content_start = moov_pos + moov_header.header_size as usize;
     let moov_content_size = moov_header.content_size() as usize;
-    let moov_end = moov_pos + moov_header.size as usize;
+    let moov_end = box_end(data, moov_pos, moov_header.size as usize, "moov")?;
 
     // Try to find existing ilst or create new metadata structure
     let (new_ilst, ilst_info) =
@@ -668,14 +668,21 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
         } => {
             let new_ilst_is_empty = new_ilst.len() <= 8; // header-only = no tags
 
+            let ilst_end = box_end(data, ilst_pos, ilst_size, "ilst")?;
+
             if new_ilst_is_empty {
                 // Determine what to remove: ilst, or meta, or udta
                 let meta_size = read_box_size(data, meta_pos);
                 let udta_size = read_box_size(data, udta_pos);
+                let meta_end = box_end(data, meta_pos, meta_size, "meta")?;
+                let udta_end = box_end(data, udta_pos, udta_size, "udta")?;
 
                 // meta content = version/flags(4) + hdlr + ilst; if removing ilst
                 // leaves only hdlr, the meta is effectively empty for our purposes.
-                let meta_content_without_ilst = meta_size - ilst_size;
+                let meta_content_without_ilst =
+                    meta_size.checked_sub(ilst_size).ok_or(Error::AacParse {
+                        message: "ilst box larger than enclosing meta".into(),
+                    })?;
                 let hdlr_size = create_hdlr_box().len();
                 let meta_only_has_hdlr_and_ilst = meta_content_without_ilst == 8 + 4 + hdlr_size; // header + ver/flags + hdlr
 
@@ -684,21 +691,21 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
                     // Remove entire udta
                     let size_diff = -(udta_size as i64);
                     result.extend_from_slice(&data[..udta_pos]);
-                    result.extend_from_slice(&data[udta_pos + udta_size..]);
+                    result.extend_from_slice(&data[udta_end..]);
                     update_box_size(&mut result, moov_pos, size_diff);
                 } else if meta_only_has_hdlr_and_ilst {
                     // meta contains only hdlr+ilst but udta has other boxes too
                     // Remove entire meta
                     let size_diff = -(meta_size as i64);
                     result.extend_from_slice(&data[..meta_pos]);
-                    result.extend_from_slice(&data[meta_pos + meta_size..]);
+                    result.extend_from_slice(&data[meta_end..]);
                     update_box_size(&mut result, moov_pos, size_diff);
                     update_box_size(&mut result, udta_pos, size_diff);
                 } else {
                     // meta has other boxes besides hdlr+ilst; just remove ilst
                     let size_diff = -(ilst_size as i64);
                     result.extend_from_slice(&data[..ilst_pos]);
-                    result.extend_from_slice(&data[ilst_pos + ilst_size..]);
+                    result.extend_from_slice(&data[ilst_end..]);
                     update_box_size(&mut result, moov_pos, size_diff);
                     update_box_size(&mut result, udta_pos, size_diff);
                     update_box_size(&mut result, meta_pos, size_diff);
@@ -711,7 +718,7 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
 
                 result.extend_from_slice(&data[..ilst_pos]);
                 result.extend_from_slice(&new_ilst);
-                result.extend_from_slice(&data[ilst_pos + old_ilst_size..]);
+                result.extend_from_slice(&data[ilst_end..]);
 
                 update_box_size(&mut result, moov_pos, size_diff);
                 update_box_size(&mut result, udta_pos, size_diff);
@@ -724,7 +731,7 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
             udta_pos,
         } => {
             // meta exists but has no ilst — append ilst at end of existing meta
-            let meta_end = meta_pos + meta_size;
+            let meta_end = box_end(data, meta_pos, meta_size, "meta")?;
             let size_diff = new_ilst.len() as i64;
 
             result.extend_from_slice(&data[..meta_end]);
@@ -743,7 +750,7 @@ fn rebuild_mp4_with_ilst(data: &[u8], make_ilst: impl Fn(&[u8]) -> Vec<u8>) -> R
             let meta_box = create_meta_box(&new_ilst);
             let size_diff = meta_box.len() as i64;
 
-            let udta_end = udta_pos + udta_size;
+            let udta_end = box_end(data, udta_pos, udta_size, "udta")?;
 
             // Write data before udta end
             result.extend_from_slice(&data[..udta_end]);
@@ -1028,6 +1035,17 @@ fn read_box_size(data: &[u8], box_pos: usize) -> usize {
     read_u32_be(data, box_pos) as usize
 }
 
+/// Validate that a box declared at `pos` with `size` fits within `data`,
+/// returning its end offset. Declared sizes come from the file and a
+/// malformed/truncated MP4 can overrun the buffer.
+fn box_end(data: &[u8], pos: usize, size: usize, what: &str) -> Result<usize> {
+    pos.checked_add(size)
+        .filter(|&end| end <= data.len())
+        .ok_or_else(|| Error::AacParse {
+            message: format!("{what} box size exceeds file size"),
+        })
+}
+
 fn update_box_size(data: &mut [u8], box_pos: usize, size_diff: i64) {
     if box_pos + 4 > data.len() {
         return;
@@ -1060,7 +1078,7 @@ fn update_chunk_offsets(
         None => return Ok(()),
     };
 
-    let moov_end = moov_pos + moov_header.size as usize;
+    let moov_end = (moov_pos + moov_header.size as usize).min(data.len());
 
     // Recursively find and update stco/co64 boxes within moov
     update_offsets_recursive(data, moov_pos + 8, moov_end, size_diff, original_moov_end)?;
@@ -1091,6 +1109,9 @@ fn update_offsets_recursive(
         if size == 0 || pos + size as usize > end {
             break;
         }
+        // Never walk entries past the declaring box: a corrupt entry_count
+        // would otherwise rewrite bytes of the following boxes as offsets.
+        let this_box_end = pos + size as usize;
 
         match box_type {
             STCO => {
@@ -1102,7 +1123,7 @@ fn update_offsets_recursive(
 
                     let mut offset_pos = entry_count_pos + 4;
                     for _ in 0..entry_count {
-                        if offset_pos + 4 > data.len() {
+                        if offset_pos + 4 > this_box_end {
                             break;
                         }
                         let offset = read_u32_be(data, offset_pos);
@@ -1124,7 +1145,7 @@ fn update_offsets_recursive(
 
                     let mut offset_pos = entry_count_pos + 4;
                     for _ in 0..entry_count {
-                        if offset_pos + 8 > data.len() {
+                        if offset_pos + 8 > this_box_end {
                             break;
                         }
                         let offset = read_u64_be(data, offset_pos);

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -343,7 +343,7 @@ fn apply_replaygain_aac_with_album_into(
     // AAC tag writing is fail-soft, so we drive it ourselves below.
     apply_opts.write_replaygain_tags = false;
 
-    let mut actual_steps = requested_steps;
+    let mut actual_steps = 0;
     let mut warning_msg: Option<String> = None;
     let mut gain_modified: usize = 0;
 
@@ -364,6 +364,9 @@ fn apply_replaygain_aac_with_album_into(
             );
         }
         Err(e) => {
+            // No gain was baked into the bitstream, so actual_steps stays 0
+            // — otherwise the residual tags written below would claim a
+            // loudness shift that never happened.
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 eprintln!(
                     "  {} {} - bitstream gain failed: {} (tags still written)",


### PR DESCRIPTION
Full-codebase review pass (CLI + GUI) focused on potential bugs, robustness against malformed input, performance, and simplification.

## Bug fixes

### Data-loss / correctness
- **ape**: `remove_ape_tag` clamped `audio_end` to 0 when a footer declared a corrupt oversized `tag_size`, so any tag write (`-r`, undo, delete) on such a file discarded the **entire audio stream**. It now treats an inconsistent size as "no valid tag", mirroring the existing guard in `read_ape_tag`.
- **aac**: when the bitstream gain apply failed (fail-soft path), the ReplayGain tags were still computed against the *requested* steps, so the written track/album gain and peak claimed a loudness shift that never happened (and JSON reported it as applied). Tags are now computed against zero applied steps.

### Panic / corruption on malformed MP4s
- Clamp declared box sizes to the buffer in `esds`/`mp4a` parsing and in `rebuild_mp4_with_ilst` (moov/udta/meta/ilst), returning `AacParse` errors instead of slice-index panics on truncated or crafted files.
- Bound stco/co64 entry walks to their declaring box: a corrupt `entry_count` could previously rewrite bytes of neighboring boxes as chunk offsets (silent file corruption).
- Saturating arithmetic when accumulating undo values parsed from untrusted tags (debug-build overflow panic).

### CLI
- Unknown `--long` options are now rejected instead of silently ignored — previously `--dryrun` (typo of `--dry-run`) was dropped and files were modified.
- `-R` recursive expansion dedups overlapping roots (e.g. `-R music music/album`), which previously applied gain twice to the same files.
- Album summary no longer disappears when every MP3 fails but M4As succeed.

### GUI
- Reset the selection anchor when rows are removed, so the next shift-click doesn't select a range anchored to an unrelated row.

## Performance
- `build_sample_table` walks the stsc table once with a moving index instead of rescanning per chunk — was O(chunks × stsc entries), a DoS vector on crafted files and slow on long iTunes-encoded tracks.
- GUI duplicate check on file add uses a `HashSet` — was O(n²) when dropping large folders on an existing list.

## Cleanup
- Removed unreachable `-version`/`-help` match arms (the branch excludes `--` args).
- Deduplicated `GainMode` selection in `GainOptions::apply`.

## Verification
- `cargo test --release`: 123 tests pass (incl. reference golden tests)
- `cargo clippy --release`: clean; `cargo fmt` both crates
- mp3rgui release build passes
- Smoke tests: `--dryrun` now errors with exit 1; apply→undo roundtrip on fixtures is byte-identical