### PR TITLE
Exit non-zero when any per-file operation fails

### DIFF
--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -10,7 +10,9 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
-use crate::commands::utils::{create_json_summary, print_dry_run_notice, update_counters};
+use crate::commands::utils::{
+    create_json_summary, exit_if_failed, print_dry_run_notice, update_counters,
+};
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
 use crate::progress::{
@@ -171,6 +173,7 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
         print_dry_run_notice(opts);
     }
 
+    exit_if_failed(failed);
     Ok(())
 }
 
@@ -375,6 +378,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 } else if !opts.quiet {
                     println!("  {} No adjustment needed", ".".cyan());
                 }
+                exit_if_failed(failure_count);
                 return Ok(());
             }
 
@@ -506,6 +510,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             } else {
                 print_dry_run_notice(opts);
             }
+            exit_if_failed(failed);
         }
         Err(e) => {
             if opts.output_format == OutputFormat::Json {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -107,7 +107,16 @@ pub fn finish_with_summary(
     } else {
         print_dry_run_notice(opts);
     }
+    exit_if_failed(failed);
     Ok(())
+}
+
+/// Exit non-zero when any per-file operation failed, so scripts can detect
+/// partial failures (issue #228).
+pub fn exit_if_failed(failed: usize) {
+    if failed > 0 {
+        std::process::exit(1);
+    }
 }
 
 /// Epilogue for read-only commands (check tags, max amplitude): JSON output


### PR DESCRIPTION
Per-file processors convert errors into `FileStatus::Error` and return `Ok`, so runs with failed files exited 0 (e.g. `mp3rgain -g 2 missing.mp3`).

This adds an `exit_if_failed` helper in `src/commands/utils.rs` and calls it from:
- `finish_with_summary` (covers apply, channel apply, undo, delete tags)
- the end of `cmd_track_gain`
- the end of `cmd_album_gain`, including the `steps == 0` early return where `--skip-errors` may have skipped files

The process now exits 1 whenever `failed > 0`, after all output (text or JSON summary) has been printed. Successful runs still exit 0.

Note: this is a behavior change for scripts — partial failures previously exited 0 and now exit 1. Should land in a minor release and be mentioned in the release notes.

Verified manually:
- `mp3rgain -g 2 /nonexistent.mp3` → exit 1
- `mp3rgain -g 2 <fixture>` → exit 0
- `-r` with missing file → exit 1; with fixture → exit 0
- `-a --skip-errors <fixture> /nonexistent.mp3` → exit 1; `-a` with fixtures → exit 0
- `cargo build` and `cargo test` pass

Fixes #228