### PR TITLE
Align info/display gain with apply paths for -d and -m

### DIFF
--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -23,7 +23,7 @@ pub fn print_usage() {
         "    -g <i>      Apply gain of i steps (each step = {} dB)",
         GAIN_STEP_DB
     );
-    println!("    -d <n>      Apply gain of n dB (rounded to nearest step)");
+    println!("    -d <n>      Modify suggested/target gain by n dB (rounded to nearest step)");
     println!("    -l <c> <g>  Apply gain to left (0) or right (1) channel only");
     println!("    -m <i>      Modify suggested gain by integer i");
     println!("    -r          Apply Track gain (ReplayGain analysis)");
@@ -61,7 +61,7 @@ pub fn print_usage() {
     println!("    mp3rgain song.mp3              Show file info");
     println!("    mp3rgain -g 2 song.mp3         Apply +2 steps (+3.0 dB)");
     println!("    mp3rgain -g -3 song.mp3        Apply -3 steps (-4.5 dB)");
-    println!("    mp3rgain -d 4.5 song.mp3       Apply +4.5 dB (rounds to +3 steps)");
+    println!("    mp3rgain -r -d 4.5 song.mp3    Apply track gain, target +4.5 dB louder");
     println!("    mp3rgain -r song.mp3           Analyze and apply track gain");
     println!("    mp3rgain -a *.mp3              Analyze and apply album gain");
     println!("    mp3rgain -r -m 2 *.mp3         Apply track gain + 2 steps");

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::*;
 use indicatif::MultiProgress;
 use mp3rgain::replaygain::{self, AlbumAnalysisReport, ReplayGainResult};
-use mp3rgain::{db_to_steps, mp4meta, peak_to_pcm_sample};
+use mp3rgain::{mp4meta, peak_to_pcm_sample, steps_to_db};
 use rayon::prelude::*;
 use std::cell::Cell;
 use std::io::{self, Write};
@@ -137,8 +137,10 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
     if any_ok {
         if let Some(report) = summary_report {
-            let album_gain_db = report.album.album_gain_db() + opts.gain_modifier_db;
-            let album_gain_steps = db_to_steps(album_gain_db);
+            // Match the apply path (-a): album_gain_steps() + gain_modifier_steps()
+            let modifier_steps = opts.gain_modifier_steps();
+            let album_gain_steps = report.album.album_gain_steps() + modifier_steps;
+            let album_gain_db = report.album.album_gain_db() + steps_to_db(modifier_steps);
             let album_max_amp = peak_to_pcm_sample(report.album.album_peak());
 
             match opts.output_format {

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::*;
 use indicatif::ProgressBar;
 use mp3rgain::replaygain::{self, ReplayGainResult};
-use mp3rgain::{analyze, db_to_steps, mp4meta, peak_to_pcm_sample};
+use mp3rgain::{analyze, mp4meta, peak_to_pcm_sample, steps_to_db};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -37,9 +37,11 @@ pub fn format_rg_row(
     let max_amp = rg_result.peak();
     let (max_gain, min_gain) = gain_range;
 
-    // Calculate gain with modifier (mp3gain compatible: -d modifies suggested gain)
-    let gain_db = rg_result.gain_db() + opts.gain_modifier_db;
-    let gain_steps = db_to_steps(gain_db);
+    // Calculate gain with modifier, matching the apply paths (-m steps + -d dB,
+    // combined into steps via gain_modifier_steps)
+    let modifier_steps = opts.gain_modifier_steps();
+    let gain_steps = rg_result.gain_steps() + modifier_steps;
+    let gain_db = rg_result.gain_db() + steps_to_db(modifier_steps);
 
     // Max Amplitude scaled to 32768 (mp3gain format for beets)
     // beets divides by 32768, so we output peak * 32768


### PR DESCRIPTION
Fixes three inconsistencies between the info/display paths and the apply paths:

- **Default info path ignored -m**: `processors/info.rs` added only `gain_modifier_db`; it now uses `gain_modifier_steps()` (combined `-m` + quantized `-d`), matching the apply paths. The displayed dB change reflects the same quantized modifier.
- **Album summary rounding**: `commands/info.rs` computed `db_to_steps(gain + modifier)` (single rounding); it now computes `album_gain_steps() + gain_modifier_steps()`, matching what `-a` actually applies.
- **Misleading -d help text**: `-d` help and example claimed bare `-d` applies gain; reworded to mp3gain-compatible "modify suggested/target gain" semantics and changed the example to use `-r -d`.

`cargo fmt`, `cargo build`, and `cargo test` all pass (123 tests, 0 failures).

Fixes #229