### PR TITLE
fix(mp3rgui): recompute clip flags for stored-tags rows on Target change

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -78,6 +78,10 @@ pub struct FileEntry {
     /// Pre-existing ReplayGain / undo tags read from the file, populated by
     /// the "Check Stored Tags" action. `None` = not scanned yet.
     pub stored_tags: Option<StoredTagsView>,
+    /// Peaks parsed from stored ReplayGain tags on import (issue #233).
+    /// Fallback for clip recomputation when `track_result` is None.
+    pub stored_track_peak: Option<f64>,
+    pub stored_album_peak: Option<f64>,
 }
 
 /// State for the "Apply Manual Gain" modal. `open` toggles visibility;
@@ -374,12 +378,14 @@ impl Mp3rgainApp {
             if let Some(g) = file.album_gain {
                 file.album_gain = Some(g + delta);
             }
-            if let Some(track) = file.track_result.as_ref() {
-                let peak = track.peak();
+            let analyzed_peak = file.track_result.as_ref().map(|t| t.peak());
+            if let Some(peak) = analyzed_peak.or(file.stored_track_peak) {
                 file.track_clip = file
                     .track_gain
                     .map(|g| would_clip(peak, g))
                     .unwrap_or(false);
+            }
+            if let Some(peak) = analyzed_peak.or(file.stored_album_peak) {
                 file.album_clip = file
                     .album_gain
                     .map(|g| would_clip(peak, g))
@@ -1185,6 +1191,8 @@ impl Mp3rgainApp {
                     file.track_gain = None;
                     file.track_clip = false;
                     file.track_result = None;
+                    file.stored_track_peak = None;
+                    file.stored_album_peak = None;
                     file.status = FileStatus::Analyzed;
                 }
             }
@@ -1245,6 +1253,7 @@ impl Mp3rgainApp {
             if let Some(peak) = view.track_peak.as_deref().and_then(parse_linear) {
                 file.clipping = peak >= 1.0;
                 file.track_clip = would_clip(peak, gain);
+                file.stored_track_peak = Some(peak);
             }
             found = true;
         }
@@ -1254,6 +1263,7 @@ impl Mp3rgainApp {
             file.album_gain = Some(album_gain);
             if let Some(peak) = view.album_peak.as_deref().and_then(parse_linear) {
                 file.album_clip = would_clip(peak, album_gain);
+                file.stored_album_peak = Some(peak);
             }
             found = true;
         }
@@ -1295,6 +1305,23 @@ impl Mp3rgainApp {
                 .map(|g| would_clip(new_peak, g))
                 .unwrap_or(false);
             file.track_result = Some(track.with_peak(new_peak));
+        } else {
+            let scale = db_to_linear(db_applied);
+            if let Some(new_peak) = file.stored_track_peak.map(|p| p * scale) {
+                file.stored_track_peak = Some(new_peak);
+                file.clipping = new_peak >= 1.0;
+                file.track_clip = file
+                    .track_gain
+                    .map(|g| would_clip(new_peak, g))
+                    .unwrap_or(false);
+            }
+            if let Some(new_peak) = file.stored_album_peak.map(|p| p * scale) {
+                file.stored_album_peak = Some(new_peak);
+                file.album_clip = file
+                    .album_gain
+                    .map(|g| would_clip(new_peak, g))
+                    .unwrap_or(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Rows imported from stored ReplayGain tags keep `track_result = None`, so `recompute_targets_if_changed` and `shift_displayed_values` skipped clip recomputation for them. Changing Target (or applying manual gain) shifted the gain columns but left `track_clip` / `album_clip` / `clipping` stale.

Fix per the issue suggestion: parse and cache the tag peaks on import.

- Add `stored_track_peak` / `stored_album_peak` to `FileEntry`, populated by `populate_from_stored_tags`.
- `recompute_targets_if_changed` falls back to the cached stored peaks when no analysis result exists (track peak for Clip(T), album peak for Clip(A), matching import behavior).
- `shift_displayed_values` scales the cached stored peaks and refreshes clip flags when `track_result` is None, mirroring the analyzed path.
- `MaxAmplitudeFound` clears the cached peaks along with the other RG-derived state so a max-amp scan doesn't leave stale peaks behind.

Fixes #233