### PR TITLE
fix: continue dry-run batch when predict_apply fails on a file

### DIFF
--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -47,10 +47,30 @@ fn process_apply_into(
                 let mut apply_opts = ApplyOptions::new(steps);
                 apply_opts.prevent_clipping = opts.prevent_clipping;
                 apply_opts.wrap = opts.wrap_gain;
-                let report = predict_apply(file, &apply_opts)?;
-                let warning =
-                    emit_clipping_warning_headroom(steps, &report, opts, dry_run_prefix, filename);
-                (report.actual_steps, warning)
+                match predict_apply(file, &apply_opts) {
+                    Ok(report) => {
+                        let warning = emit_clipping_warning_headroom(
+                            steps,
+                            &report,
+                            opts,
+                            dry_run_prefix,
+                            filename,
+                        );
+                        (report.actual_steps, warning)
+                    }
+                    Err(e) => {
+                        if opts.output_format == OutputFormat::Text && !opts.quiet {
+                            eprintln!("  {} {} - {}", "x".red(), filename, e);
+                        }
+                        return Ok(JsonFileResult {
+                            file: file.display().to_string(),
+                            status: Some(FileStatus::Error),
+                            error: Some(e.to_string()),
+                            dry_run: Some(true),
+                            ..Default::default()
+                        });
+                    }
+                }
             };
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(


### PR DESCRIPTION
In dry-run mode with clipping checks, `predict_apply` errors propagated via `?`, aborting the whole batch — and in the parallel path, `collect::<Result<Vec<_>>>()?` discarded results already collected for other files. A real run converts apply errors into per-file `FileStatus::Error` and continues.

This converts `predict_apply` errors in the dry-run path of `process_apply_into` into the same per-file error `JsonFileResult` used by the real-run `Err` branch, so both the serial and parallel paths continue over the remaining files.

Verified with a batch of a valid fixture, a nonexistent path, and a corrupt file: the erroring files report per-file errors while the valid file still gets its `[DRY RUN]` result and exit stays clean instead of aborting.

Fixes #230