### PR TITLE
Fix TSV apply output: no re-read, real gain range, header

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -153,6 +153,12 @@ pub struct ApplyReport {
     /// MP3 global_gain values that clamped at 255 (distortion) during a
     /// saturating apply (issue #207).
     pub saturated_high: usize,
+
+    /// Post-apply (max, min) global_gain range across the modified MP3
+    /// frames, recorded during the apply pass so callers don't need to
+    /// re-read the file (issue #231). `None` for AAC, channel-specific
+    /// applies, dry runs, and zero-frame applies.
+    pub gain_range: Option<(u8, u8)>,
 }
 
 /// Per-strategy clipping signal.
@@ -293,6 +299,9 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
         restore_timestamp(file_path, mtime);
     }
 
+    let gain_range = (!is_aac && opts.channel.is_none() && saturation.frames > 0)
+        .then_some((saturation.max_gain, saturation.min_gain));
+
     Ok(ApplyReport {
         modified,
         actual_steps,
@@ -300,6 +309,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
         clipping_detected,
         saturated_low: saturation.saturated_low,
         saturated_high: saturation.saturated_high,
+        gain_range,
     })
 }
 
@@ -322,6 +332,7 @@ pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyRepor
         clipping_detected,
         saturated_low: 0,
         saturated_high: 0,
+        gain_range: None,
     })
 }
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::{analyze, steps_to_db, Channel};
+use mp3rgain::{steps_to_db, Channel};
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
@@ -28,6 +28,10 @@ pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
     let db_value = steps_to_db(steps);
     let dry_run_prefix = opts.dry_run_prefix();
 
+    if opts.output_format == OutputFormat::Tsv {
+        println!("File\tMP3 gain\tdB gain\tMax Amplitude\tMax global_gain\tMin global_gain");
+    }
+
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         println!(
             "{}{} {} {} step(s) ({:+.1} dB) to {} file(s)",
@@ -51,18 +55,17 @@ pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
     let (json_results, successful, failed) = for_each_file(files, opts, |file| {
         let (result, mut text) = process_apply(file, steps, opts)?;
         if opts.output_format == OutputFormat::Tsv {
-            if let Ok(info) = analyze(file) {
-                writeln!(
-                    text,
-                    "{}\t{}\t{:.1}\t{:.6}\t{}\t{}",
-                    get_filename(file),
-                    steps,
-                    db_value,
-                    1.0,
-                    info.max_gain(),
-                    info.min_gain()
-                )?;
-            }
+            // Max Amplitude is unknown without a full decode; emit "-"
+            // instead of fabricating a value (issue #231).
+            writeln!(
+                text,
+                "{}\t{}\t{:.6}\t-\t{}\t{}",
+                get_filename(file),
+                steps,
+                db_value,
+                result.max_gain.unwrap_or(255),
+                result.min_gain.unwrap_or(0)
+            )?;
         }
         Ok((Some(result), text))
     })?;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -410,11 +410,27 @@ pub(crate) enum GainMode {
 /// original value is lost — i.e. the apply is no longer losslessly
 /// reversible at those locations (issue #207). Wrapping mode never
 /// saturates, so both counts stay 0.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SaturationStats {
     pub frames: usize,
     pub saturated_low: usize,
     pub saturated_high: usize,
+    /// Post-apply minimum global_gain across the touched locations.
+    pub min_gain: u8,
+    /// Post-apply maximum global_gain across the touched locations.
+    pub max_gain: u8,
+}
+
+impl Default for SaturationStats {
+    fn default() -> Self {
+        Self {
+            frames: 0,
+            saturated_low: 0,
+            saturated_high: 0,
+            min_gain: 255,
+            max_gain: 0,
+        }
+    }
 }
 
 impl SaturationStats {
@@ -479,6 +495,8 @@ pub(crate) fn apply_gain_to_data(
                     if mode == GainMode::Saturating {
                         stats.tally(current_gain, gain_steps);
                     }
+                    stats.min_gain = stats.min_gain.min(new_gain);
+                    stats.max_gain = stats.max_gain.max(new_gain);
                     write_gain_at(data, loc, new_gain);
                 }
             }
@@ -492,6 +510,8 @@ pub(crate) fn apply_gain_to_data(
                         let new_gain =
                             adjust_gain_value(current_gain, gain_steps, GainMode::Saturating);
                         stats.tally(current_gain, gain_steps);
+                        stats.min_gain = stats.min_gain.min(new_gain);
+                        stats.max_gain = stats.max_gain.max(new_gain);
                         write_gain_at(data, loc, new_gain);
                     }
                 }

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -113,6 +113,8 @@ fn process_apply_into(
                 frames: Some(report.modified),
                 gain_applied_steps: Some(report.actual_steps),
                 gain_applied_db: Some(steps_to_db(report.actual_steps)),
+                max_gain: report.gain_range.map(|(max, _)| max),
+                min_gain: report.gain_range.map(|(_, min)| min),
                 warning: warning_msg,
                 ..Default::default()
             })


### PR DESCRIPTION
## Summary

`-o tsv` apply output re-read every file via a second `analyze()` call just for the global_gain range, emitted a hardcoded `1.0` in the Max Amplitude column (false data), and printed no TSV header.

- Record the post-apply global_gain range during the apply pass itself (`SaturationStats` -> `ApplyReport::gain_range`), so no second read is needed. The range is also exposed as `max_gain`/`min_gain` in JSON apply output.
- Print the same TSV header as `cmd_info` (`File\tMP3 gain\tdB gain\tMax Amplitude\tMax global_gain\tMin global_gain`).
- Emit `-` in the Max Amplitude column instead of the fake `1.0` (the real amplitude is unknown without a full decode).

## Output format change

TSV apply output now has a header row, the amplitude column shows `-` instead of `1.0`, and the dB gain column uses 6 decimals to match `cmd_info`. Scripts parsing the old format may need adjusting.

## Verification

- `cargo fmt`, `cargo build`, `cargo test` all pass.
- Applied gain with `-o tsv` on fixture copies; the emitted post-apply gain range matches an independent `mp3rgain -o tsv` info scan of the modified file (`212/138` for `test_vbr.mp3`).

Fixes #231