### PR TITLE
Make tag writes atomic via temp file and rename

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1409,7 +1409,7 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
     );
 
     let final_data = mp4meta::update_mp4_undo_metadata(&data, &undo_tags)?;
-    mp4meta::atomic_write(write_to, &final_data)?;
+    crate::apply::atomic_write(write_to, &final_data)?;
 
     Ok(modified)
 }
@@ -1441,7 +1441,7 @@ pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
     let modified = apply_aac_gain_to_data(&mut data, &analysis, -undo_gain);
 
     let final_data = mp4meta::update_mp4_undo_metadata(&data, &mp4meta::UndoTags::default())?;
-    mp4meta::atomic_write(file_path, &final_data)?;
+    crate::apply::atomic_write(file_path, &final_data)?;
 
     Ok(modified)
 }

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -355,8 +355,7 @@ pub(crate) fn replace_ape_tag(data: &[u8], tag: &ApeTag) -> Vec<u8> {
 pub fn write_ape_tag(file_path: &Path, tag: &ApeTag) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
     let new_data = replace_ape_tag(&data, tag);
-    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
-    Ok(())
+    crate::apply::atomic_write(file_path, &new_data)
 }
 
 /// ReplayGain analysis values written into an APEv2 tag (issue #204).
@@ -395,8 +394,7 @@ pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> 
     }
 
     let new_data = replace_ape_tag(&data, &tag);
-    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
-    Ok(())
+    crate::apply::atomic_write(file_path, &new_data)
 }
 
 /// Add (or replace) the `MP3GAIN_ALBUM_MINMAX` item in `file_path`'s APEv2
@@ -408,8 +406,7 @@ pub fn write_ape_album_minmax(file_path: &Path, min: u8, max: u8) -> Result<()> 
     let mut tag = read_ape_tag(&data).unwrap_or_default();
     tag.set(TAG_MP3GAIN_ALBUM_MINMAX, &format!("{},{}", min, max));
     let new_data = replace_ape_tag(&data, &tag);
-    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
-    Ok(())
+    crate::apply::atomic_write(file_path, &new_data)
 }
 
 /// Delete APEv2 tag from file
@@ -418,9 +415,7 @@ pub fn delete_ape_tag(file_path: &Path) -> Result<()> {
 
     let audio_data = remove_ape_tag(&data);
 
-    fs::write(file_path, &audio_data).map_err(|e| Error::io_write(file_path, e))?;
-
-    Ok(())
+    crate::apply::atomic_write(file_path, &audio_data)
 }
 
 /// Format MP3GAIN_UNDO tag value: `+LLL,+RRR,W|N`.

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -502,10 +502,15 @@ pub(crate) fn temp_sibling_path(file: &Path, ext: &str) -> std::path::PathBuf {
 /// `original` (issue #227).
 pub(crate) fn persist_temp(original: &Path, temp: &Path) -> Result<()> {
     let finish = || -> std::io::Result<()> {
+        // fsync needs a writable handle on Windows, and must happen before
+        // the permission copy in case the original mode is read-only.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(temp)?
+            .sync_all()?;
         if let Ok(meta) = std::fs::metadata(original) {
             std::fs::set_permissions(temp, meta.permissions())?;
         }
-        std::fs::File::open(temp)?.sync_all()?;
         std::fs::rename(temp, original)
     };
     finish().map_err(|e| Error::io_write(original, e))

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -82,7 +82,9 @@ pub struct ApplyOptions {
     /// `-p`: restore the file's mtime after writing.
     pub preserve_timestamp: bool,
 
-    /// `-t`: write through a sibling temp file and rename atomically.
+    /// `-t`: historically opted into temp-file writes. All file rewrites now
+    /// go through a sibling temp file + atomic rename unconditionally
+    /// (issue #227), so the flag is accepted but has no effect.
     pub use_temp_file: bool,
 
     /// Record an undo tag (APE for MP3, MP4 freeform for AAC, ID3v2 TXXX
@@ -169,8 +171,8 @@ pub enum ClippingDetection {
 /// Does, in order:
 /// 1. Optional clipping check (headroom-based for `-g`/`-l`, peak-based
 ///    when [`ApplyOptions::track_result`] is set).
-/// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, with optional temp
-///    file + atomic rename.
+/// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, via temp file +
+///    atomic rename.
 /// 3. ID3v2 undo tag write (MP3 + [`ApplyOptions::use_id3v2`]).
 /// 4. ReplayGain tag write (AAC mp4 metadata, MP3 ID3v2 TXXX with
 ///    [`ApplyOptions::use_id3v2`], or MP3 APEv2 by default — issue #204).
@@ -416,7 +418,7 @@ fn apply_aac_bytes(
     opts: &ApplyOptions,
     analysis: AacAnalysisCache,
 ) -> Result<usize> {
-    with_temp_file(file_path, opts.use_temp_file, |r, w| {
+    with_temp_file(file_path, |r, w| {
         if opts.write_undo {
             aac::apply_aac_gain_with_undo_to_path_with_analysis(r, w, steps, analysis)
         } else {
@@ -443,7 +445,7 @@ fn apply_mp3_ape_bytes(
     steps: i32,
     opts: &ApplyOptions,
 ) -> Result<SaturationStats> {
-    with_temp_file(file_path, opts.use_temp_file, |r, w| {
+    with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps)
             .wrap(opts.wrap)
             .undo(opts.write_undo);
@@ -460,24 +462,26 @@ fn apply_mp3_id3v2_bytes(
     opts: &ApplyOptions,
 ) -> Result<SaturationStats> {
     // APE undo is never written in `-s i` mode; the undo goes into a
-    // TXXX:MP3GAIN_UNDO frame instead, written below.
-    let stats = with_temp_file(file_path, opts.use_temp_file, |r, w| {
+    // TXXX:MP3GAIN_UNDO frame instead. The frame is written onto the temp
+    // file before the rename so gain + undo tag land in one visible write —
+    // a failed tag write leaves the original untouched (issue #227).
+    with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps).wrap(opts.wrap).undo(false);
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
         }
-        gain.apply_to_path_with_stats(r, w)
-    })?;
+        let stats = gain.apply_to_path_with_stats(r, w)?;
 
-    if opts.write_undo {
-        let (delta_left, delta_right) = match opts.channel {
-            Some(Channel::Left) => (steps, 0),
-            Some(Channel::Right) => (0, steps),
-            None => (steps, steps),
-        };
-        write_id3v2_undo_after_apply(file_path, delta_left, delta_right, opts.wrap)?;
-    }
-    Ok(stats)
+        if opts.write_undo {
+            let (delta_left, delta_right) = match opts.channel {
+                Some(Channel::Left) => (steps, 0),
+                Some(Channel::Right) => (0, steps),
+                None => (steps, steps),
+            };
+            write_id3v2_undo_after_apply(w, delta_left, delta_right, opts.wrap)?;
+        }
+        Ok(stats)
+    })
 }
 
 /// Build a unique `.mp3rgain_temp_*` sibling path for `file`. Shared by the
@@ -494,26 +498,47 @@ pub(crate) fn temp_sibling_path(file: &Path, ext: &str) -> std::path::PathBuf {
     ))
 }
 
-fn with_temp_file<T, F>(file: &Path, use_temp: bool, operation: F) -> Result<T>
+/// Copy `original`'s permissions onto `temp`, fsync it, and rename it over
+/// `original` (issue #227).
+pub(crate) fn persist_temp(original: &Path, temp: &Path) -> Result<()> {
+    let finish = || -> std::io::Result<()> {
+        if let Ok(meta) = std::fs::metadata(original) {
+            std::fs::set_permissions(temp, meta.permissions())?;
+        }
+        std::fs::File::open(temp)?.sync_all()?;
+        std::fs::rename(temp, original)
+    };
+    finish().map_err(|e| Error::io_write(original, e))
+}
+
+/// Atomically replace `path`'s contents: write a sibling temp file, copy
+/// permissions, fsync, rename. A failure leaves the original untouched
+/// (issue #227).
+pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("tmp");
+    let temp = temp_sibling_path(path, ext);
+    let result = std::fs::write(&temp, data)
+        .map_err(|e| Error::io_write(path, e))
+        .and_then(|_| persist_temp(path, &temp));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
+fn with_temp_file<T, F>(file: &Path, operation: F) -> Result<T>
 where
     F: FnOnce(&Path, &Path) -> Result<T>,
 {
-    if !use_temp {
-        return operation(file, file);
-    }
-
     let temp_path = temp_sibling_path(file, "mp3");
-
-    match operation(file, &temp_path) {
-        Ok(value) => {
-            std::fs::rename(&temp_path, file).map_err(|e| Error::io_write(file, e))?;
-            Ok(value)
-        }
-        Err(e) => {
-            let _ = std::fs::remove_file(&temp_path);
-            Err(e)
-        }
+    let result = operation(file, &temp_path).and_then(|value| {
+        persist_temp(file, &temp_path)?;
+        Ok(value)
+    });
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
     }
+    result
 }
 
 /// Restore a previously-captured modified-time on `file`.

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -47,7 +47,7 @@ pub struct Options {
     pub dry_run: bool,               // -n or --dry-run
     pub output_format: OutputFormat, // -o <format>
     pub wrap_gain: bool,             // -w: wrap gain values
-    pub use_temp_file: bool,         // -t: use temp file for writing
+    pub use_temp_file: bool,         // -t: accepted for compatibility (writes are always atomic)
     pub assume_mpeg2: bool,          // -f: assume MPEG 2 Layer III
     pub skip_errors: bool,           // --skip-errors: skip files that fail to analyze
 

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -43,7 +43,7 @@ pub fn print_usage() {
     println!("    -c          Ignore clipping warnings");
     println!("    -k          Prevent clipping (automatically limit gain)");
     println!("    -w          Wrap gain values (instead of clamping)");
-    println!("    -t          Use temp file for writing (safer, required for some ops)");
+    println!("    -t          Use temp file for writing (always on; kept for compatibility)");
     println!("    -f          Assume MPEG 2 Layer III (compatibility, no effect)");
     println!("    -q          Quiet mode (less output)");
     println!("    -R          Process directories recursively");

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -264,7 +264,7 @@ pub fn undo_gain(file_path: &Path) -> Result<usize> {
     tag.remove(TAG_MP3GAIN_MINMAX);
 
     let new_data = replace_ape_tag(&data, &tag);
-    fs::write(file_path, &new_data).map_err(|e| Error::io_write(file_path, e))?;
+    crate::apply::atomic_write(file_path, &new_data)?;
 
     Ok(frames)
 }

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -79,7 +79,7 @@ fn is_frame_encodable(frame: &id3::Frame) -> bool {
         .is_ok()
 }
 
-fn write_tag(path: &Path, tag: &id3::Tag) -> Result<()> {
+fn write_tag_direct(path: &Path, tag: &id3::Tag) -> Result<()> {
     let mut sanitized = tag.clone();
     sanitized.frames_vec_mut().retain(is_frame_encodable);
     sanitized
@@ -87,6 +87,20 @@ fn write_tag(path: &Path, tag: &id3::Tag) -> Result<()> {
         .map_err(|e| Error::Id3v2Error {
             message: e.to_string(),
         })
+}
+
+/// Rewrite the tag atomically: copy the file to a sibling temp, write the tag
+/// there, then fsync + rename over the original (issue #227).
+fn write_tag(path: &Path, tag: &id3::Tag) -> Result<()> {
+    let temp = crate::apply::temp_sibling_path(path, "mp3");
+    let result = std::fs::copy(path, &temp)
+        .map_err(|e| Error::io_write(path, e))
+        .and_then(|_| write_tag_direct(&temp, tag))
+        .and_then(|_| crate::apply::persist_temp(path, &temp));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
 }
 
 fn get_txxx(tag: &id3::Tag, description: &str) -> Option<String> {
@@ -207,15 +221,24 @@ pub fn undo_gain_id3v2(path: &Path) -> Result<usize> {
 
     let mut data = std::fs::read(path).map_err(|e| Error::io_read(path, e))?;
     let frames = apply_undo_to_data(&mut data, left, right, parse_undo_wrap(undo_str));
-    std::fs::write(path, &data).map_err(|e| Error::io_write(path, e))?;
 
-    // Remove undo and minmax tags
-    let mut tag = read_tag(path)?;
-    remove_txxx_ci(&mut tag, TAG_MP3GAIN_UNDO);
-    remove_txxx_ci(&mut tag, TAG_MP3GAIN_MINMAX);
-    write_tag(path, &tag)?;
-
-    Ok(frames)
+    // Revert the audio and strip the undo/minmax frames in one visible write
+    // (temp + rename) so a failed tag rewrite can't leave the delta applied
+    // with the undo tag still present (issue #227).
+    let temp = crate::apply::temp_sibling_path(path, "mp3");
+    let result = std::fs::write(&temp, &data)
+        .map_err(|e| Error::io_write(path, e))
+        .and_then(|_| {
+            let mut tag = read_tag(&temp)?;
+            remove_txxx_ci(&mut tag, TAG_MP3GAIN_UNDO);
+            remove_txxx_ci(&mut tag, TAG_MP3GAIN_MINMAX);
+            write_tag_direct(&temp, &tag)
+        })
+        .and_then(|_| crate::apply::persist_temp(path, &temp));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result.map(|_| frames)
 }
 
 #[cfg(test)]

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -596,7 +596,7 @@ fn undo_tags_from_freeform(freeform_tags: &[FreeformTag]) -> UndoTags {
 pub fn write_undo_tags(file_path: &Path, tags: &UndoTags) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
     let new_data = update_mp4_undo_metadata(&data, tags)?;
-    atomic_write(file_path, &new_data)
+    crate::apply::atomic_write(file_path, &new_data)
 }
 
 /// Delete undo tags from MP4/M4A file
@@ -609,25 +609,7 @@ pub fn delete_undo_tags(file_path: &Path) -> Result<()> {
 pub fn write_replaygain_tags(file_path: &Path, tags: &ReplayGainTags) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
     let new_data = update_mp4_metadata(&data, tags)?;
-    atomic_write(file_path, &new_data)
-}
-
-/// Atomic write: write to a temp file then rename over the original.
-/// Falls back to direct write if rename fails (e.g., cross-filesystem).
-pub(crate) fn atomic_write(file_path: &Path, data: &[u8]) -> Result<()> {
-    let temp_path = crate::apply::temp_sibling_path(file_path, "m4a");
-
-    if let Err(e) = fs::write(&temp_path, data) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(Error::io_write(&temp_path, e));
-    }
-
-    if let Err(_rename_err) = fs::rename(&temp_path, file_path) {
-        let _ = fs::remove_file(&temp_path);
-        fs::write(file_path, data).map_err(|e| Error::io_write(file_path, e))?;
-    }
-
-    Ok(())
+    crate::apply::atomic_write(file_path, &new_data)
 }
 
 /// Update MP4 metadata with new ReplayGain tags


### PR DESCRIPTION
## Problem

All APE/ID3v2/MP4 tag writes went through `fs::read` -> mutate -> `fs::write` in place. `fs::write` truncates first, so a crash, kill, or ENOSPC mid-write left a truncated file — and `-t` only covered the gain-apply step, not the subsequent tag writes. Additionally, `with_temp_file` did not fsync the temp file before rename and lost custom file permissions, and `undo_gain_id3v2` wrote the reverted audio before removing the `MP3GAIN_UNDO` frame (a failed tag rewrite meant a retried undo double-applied the delta; the apply direction had the mirrored problem).

## Design choice

Rather than plumbing the `-t` flag into every tag-write call site, **all full-file rewrites now go through temp + rename unconditionally**. Since every tag write already rewrote the entire file, the atomic path has the same I/O cost as before — there is no meaningful trade-off, only strictly better crash behavior, and it avoids threading an option through `ape.rs` / `id3v2.rs` / `gain.rs` / `mp4meta.rs`. `-t` is still accepted for compatibility but is now always on (help text updated).

## Changes

- `src/apply.rs`: new shared `persist_temp` (copy original's permissions onto temp, `sync_all`, rename) and `atomic_write` (temp sibling + `persist_temp`, cleans up on failure). `with_temp_file` is now unconditional and uses `persist_temp`. The ID3v2 undo frame is written onto the temp file *before* the rename, so gain + undo tag land in one visible write.
- `src/id3v2.rs`: `write_tag` copies the file to a temp sibling, writes the tag there, then fsync + rename. `undo_gain_id3v2` reverts the audio and strips the undo/minmax frames in a single visible write.
- `src/ape.rs`, `src/gain.rs`: APE tag writes / APE undo use `atomic_write` (APE undo was already a single combined tag+audio pass).
- `src/mp4meta.rs`, `src/aac.rs`: the old `mp4meta::atomic_write` (no fsync, no permission copy, silent non-atomic fallback) is replaced by the shared helper.

## Verification

- `cargo build`, `cargo test` (all suites), and the mp3rgui build pass.
- Manual round-trip on a fixture copy in /tmp: apply `-g -2` then `-u` with and without `-t`, and in `-s i` (ID3v2) mode — `cmp` confirms byte-identical restoration in all three cases.
- `chmod 600` before applying with `-t`: mode is still 600 after apply and after undo (previously reset to the default umask).
- No leftover `.mp3rgain_temp_*` files after any operation.

Fixes #227