### PR TITLE
Refactor: deduplicate command loops, GUI modals, and document undo tag conventions

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -238,6 +238,11 @@ pub struct Mp3rgainApp {
     /// Set whenever the sort key or any row data changes.
     display_order_dirty: bool,
 
+    /// Reusable set mirror of `selected_indices`, refreshed by
+    /// `rebuild_selection_set` at the start of each table frame. Kept on the
+    /// app so its allocation is reused instead of rebuilt per frame.
+    pub selection_set: HashSet<usize>,
+
     /// File indices added since the last import scan, awaiting an automatic
     /// stored-tag read (issue #203). Drained by `start_import_scan` on the
     /// next idle frame.
@@ -288,6 +293,7 @@ impl Mp3rgainApp {
             sort_descending: false,
             display_order_cache: Vec::new(),
             display_order_dirty: true,
+            selection_set: HashSet::new(),
             pending_import_scan: Vec::new(),
             pending_drops: Vec::new(),
             show_filename_only: settings.show_filename_only,
@@ -315,15 +321,30 @@ impl Mp3rgainApp {
         self.display_order_dirty = true;
     }
 
-    /// Indices into `self.files` in current display (sort) order, served
-    /// from the cache. The returned Vec is a clone so the table can iterate
-    /// it while mutably borrowing `self` for click handling.
-    pub fn display_order(&mut self) -> Vec<usize> {
+    /// Recompute the cached display order if stale. Call before
+    /// [`Self::display_order`] each frame; split from the getter so the
+    /// table can borrow the cache without cloning it per frame.
+    pub fn ensure_display_order(&mut self) {
         if self.display_order_dirty {
             self.display_order_cache = self.compute_display_order();
             self.display_order_dirty = false;
         }
-        self.display_order_cache.clone()
+    }
+
+    /// Indices into `self.files` in current display (sort) order, served
+    /// from the cache. [`Self::ensure_display_order`] must run first.
+    pub fn display_order(&self) -> &[usize] {
+        &self.display_order_cache
+    }
+
+    /// Refresh `selection_set` from `selected_indices`, reusing its
+    /// allocation. Called once per table frame; row rendering then does set
+    /// lookups instead of `Vec::contains` (issue #190) without rebuilding a
+    /// fresh `HashSet` every frame.
+    pub fn rebuild_selection_set(&mut self) {
+        self.selection_set.clear();
+        self.selection_set
+            .extend(self.selected_indices.iter().copied());
     }
 
     /// Sort `0..files.len()` by the active column. String columns

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -19,73 +19,92 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     render_channel_gain_modal(app, ctx);
 }
 
+/// Shared scaffolding for the small centered modals: fixed window chrome,
+/// Cancel button, open-flag handling, and the commit button (label and
+/// optional fill differ per modal). `body` renders the modal contents and
+/// returns whether commit is enabled. Returns true when the commit button
+/// was clicked, with the open flag already cleared, so the caller just runs
+/// its action.
+fn modal(
+    ctx: &egui::Context,
+    title: &str,
+    open_flag: &mut bool,
+    commit_label: &str,
+    commit_fill: Option<egui::Color32>,
+    body: impl FnOnce(&mut egui::Ui) -> bool,
+) -> bool {
+    if !*open_flag {
+        return false;
+    }
+    let mut open = true;
+    let mut close_via_cancel = false;
+    let mut close_via_commit = false;
+    egui::Window::new(title)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            let can_commit = body(ui);
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    close_via_cancel = true;
+                }
+                let mut button = egui::Button::new(commit_label);
+                if let Some(fill) = commit_fill {
+                    button = button.fill(fill);
+                }
+                if ui.add_enabled(can_commit, button).clicked() {
+                    close_via_commit = true;
+                }
+            });
+        });
+    if !open || close_via_cancel || close_via_commit {
+        *open_flag = false;
+    }
+    close_via_commit
+}
+
 /// Modal for the `-l`-equivalent "Apply Channel Gain" action. MP3 only
 /// (the apply pipeline rejects AAC files with `Error::ChannelGainOnAac`).
 fn render_channel_gain_modal(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     if !app.channel_gain_modal.open {
         return;
     }
-    let count = if app.selected_indices.is_empty() {
-        app.files.len()
-    } else {
-        app.selected_indices.len()
-    };
-    let mut open = true;
-    let mut close_via_cancel = false;
-    let mut close_via_apply = false;
-    egui::Window::new("Apply channel gain")
-        .collapsible(false)
-        .resizable(false)
-        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .open(&mut open)
-        .show(ctx, |ui| {
+    let count = app.target_indices().len();
+    let modal_state = &mut app.channel_gain_modal;
+    let committed = modal(
+        ctx,
+        "Apply channel gain",
+        &mut modal_state.open,
+        "Apply",
+        None,
+        |ui| {
             ui.label(format!("Target: {} file(s) (MP3 only)", count));
             ui.add_space(4.0);
             ui.horizontal(|ui| {
                 ui.label("Channel:");
-                ui.selectable_value(
-                    &mut app.channel_gain_modal.channel,
-                    mp3rgain::Channel::Left,
-                    "Left",
-                );
-                ui.selectable_value(
-                    &mut app.channel_gain_modal.channel,
-                    mp3rgain::Channel::Right,
-                    "Right",
-                );
+                ui.selectable_value(&mut modal_state.channel, mp3rgain::Channel::Left, "Left");
+                ui.selectable_value(&mut modal_state.channel, mp3rgain::Channel::Right, "Right");
             });
             ui.horizontal(|ui| {
                 ui.label("Steps:");
                 ui.add(
-                    egui::DragValue::new(&mut app.channel_gain_modal.steps)
+                    egui::DragValue::new(&mut modal_state.steps)
                         .range(-64..=64)
                         .speed(1),
                 );
-                let db = mp3rgain::steps_to_db(app.channel_gain_modal.steps);
+                let db = mp3rgain::steps_to_db(modal_state.steps);
                 ui.label(format!("= {:+.2} dB", db));
             });
             ui.label("Stereo / Dual Channel MP3s only. Joint-Stereo files will warn.");
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
-                if ui.button("Cancel").clicked() {
-                    close_via_cancel = true;
-                }
-                let can_apply = app.channel_gain_modal.steps != 0;
-                if ui
-                    .add_enabled(can_apply, egui::Button::new("Apply"))
-                    .clicked()
-                {
-                    close_via_apply = true;
-                }
-            });
-        });
-    if !open || close_via_cancel {
-        app.channel_gain_modal.open = false;
-    }
-    if close_via_apply {
+            modal_state.steps != 0
+        },
+    );
+    if committed {
         let channel = app.channel_gain_modal.channel;
         let steps = app.channel_gain_modal.steps;
-        app.channel_gain_modal.open = false;
         app.start_apply_channel_gain(ctx, channel, steps);
     }
 }
@@ -95,53 +114,33 @@ fn render_manual_gain_modal(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     if !app.manual_gain_modal.open {
         return;
     }
-    let count = if app.selected_indices.is_empty() {
-        app.files.len()
-    } else {
-        app.selected_indices.len()
-    };
-    let mut open = true;
-    let mut close_via_cancel = false;
-    let mut close_via_apply = false;
-    egui::Window::new("Apply manual gain")
-        .collapsible(false)
-        .resizable(false)
-        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .open(&mut open)
-        .show(ctx, |ui| {
+    let count = app.target_indices().len();
+    let modal_state = &mut app.manual_gain_modal;
+    let committed = modal(
+        ctx,
+        "Apply manual gain",
+        &mut modal_state.open,
+        "Apply",
+        None,
+        |ui| {
             ui.label(format!("Target: {} file(s)", count));
             ui.add_space(4.0);
             ui.horizontal(|ui| {
                 ui.label("Steps:");
                 ui.add(
-                    egui::DragValue::new(&mut app.manual_gain_modal.steps)
+                    egui::DragValue::new(&mut modal_state.steps)
                         .range(-64..=64)
                         .speed(1),
                 );
-                let db = mp3rgain::steps_to_db(app.manual_gain_modal.steps);
+                let db = mp3rgain::steps_to_db(modal_state.steps);
                 ui.label(format!("= {:+.2} dB", db));
             });
             ui.label("1 step = 1.5 dB. Negative values lower the volume.");
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
-                if ui.button("Cancel").clicked() {
-                    close_via_cancel = true;
-                }
-                let can_apply = app.manual_gain_modal.steps != 0;
-                if ui
-                    .add_enabled(can_apply, egui::Button::new("Apply"))
-                    .clicked()
-                {
-                    close_via_apply = true;
-                }
-            });
-        });
-    if !open || close_via_cancel {
-        app.manual_gain_modal.open = false;
-    }
-    if close_via_apply {
+            modal_state.steps != 0
+        },
+    );
+    if committed {
         let steps = app.manual_gain_modal.steps;
-        app.manual_gain_modal.open = false;
         app.start_apply_manual_gain(ctx, steps);
     }
 }
@@ -152,38 +151,22 @@ fn render_delete_confirm(app: &mut Mp3rgainApp, ctx: &egui::Context) {
         return;
     }
     let count = app.target_indices().len();
-    let mut open = true;
-    let mut close_via_cancel = false;
-    let mut close_via_confirm = false;
-    egui::Window::new("Delete stored tags")
-        .collapsible(false)
-        .resizable(false)
-        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .open(&mut open)
-        .show(ctx, |ui| {
+    let committed = modal(
+        ctx,
+        "Delete stored tags",
+        &mut app.confirm_delete_tags,
+        "Delete",
+        Some(egui::Color32::DARK_RED),
+        |ui| {
             ui.label(format!(
                 "Delete stored ReplayGain / undo tags from {} file(s)?",
                 count
             ));
             ui.label("This cannot be undone.");
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
-                if ui.button("Cancel").clicked() {
-                    close_via_cancel = true;
-                }
-                if ui
-                    .add(egui::Button::new("Delete").fill(egui::Color32::DARK_RED))
-                    .clicked()
-                {
-                    close_via_confirm = true;
-                }
-            });
-        });
-    if !open || close_via_cancel {
-        app.confirm_delete_tags = false;
-    }
-    if close_via_confirm {
-        app.confirm_delete_tags = false;
+            true
+        },
+    );
+    if committed {
         app.start_delete_tags(ctx);
     }
 }

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -68,13 +68,22 @@ fn sort_header(
 }
 
 pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
-    let display_order = app.display_order();
+    app.ensure_display_order();
+    // Set lookup instead of `Vec::contains` per row, which made selection
+    // O(rows × selected) per frame; the set allocation is reused across
+    // frames instead of rebuilt (issue #190).
+    app.rebuild_selection_set();
+    // Defer click handling: the row closure borrows `app.files`, so it
+    // can't also mutate `app.selected_indices` during the iteration.
+    // Capture the requested action and apply it after the table.
+    let mut pending_click: Option<(usize, ClickMode)> = None;
+    let mut pending_reveal: Option<std::path::PathBuf> = None;
     // Horizontal scrolling only — vertical scrolling is the table's own,
     // so `body.rows` can virtualize off-screen rows (issue #190). An outer
     // vertical scroll area would hand the table unbounded height and force
     // every row to be laid out each frame.
     egui::ScrollArea::horizontal().show(ui, |ui| {
-        egui_extras::TableBuilder::new(ui)
+        let table = egui_extras::TableBuilder::new(ui)
             .striped(true)
             .resizable(true)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
@@ -131,21 +140,16 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                 header.col(|ui| {
                     sort_header(ui, app, "Status", SortColumn::Status, "");
                 });
-            })
-            .body(|body| {
-                // Defer click handling: the row closure borrows `app.files`,
-                // so it can't also mutate `app.selected_indices` during the
-                // iteration. Capture the requested action and apply it after
-                // the loop.
-                let mut pending_click: Option<(usize, ClickMode)> = None;
-                let mut pending_reveal: Option<std::path::PathBuf> = None;
-                // Set lookup instead of `Vec::contains` per row, which made
-                // selection O(rows × selected) per frame (issue #190).
-                let selected: std::collections::HashSet<usize> =
-                    app.selected_indices.iter().copied().collect();
-                // `rows` (vs per-row `body.row`) lays out only the rows
-                // inside the viewport; fixed 18.0 height makes it a drop-in.
-                body.rows(18.0, display_order.len(), |mut row| {
+            });
+        // Borrowed after the header (which needs `app` mutably for sort
+        // clicks); the body only reads `app`, so the cache and set can be
+        // borrowed instead of cloned per frame.
+        let display_order = app.display_order();
+        let selected = &app.selection_set;
+        table.body(|body| {
+            // `rows` (vs per-row `body.row`) lays out only the rows
+            // inside the viewport; fixed 18.0 height makes it a drop-in.
+            body.rows(18.0, display_order.len(), |mut row| {
                     let Some(&idx) = display_order.get(row.index()) else {
                         return;
                     };
@@ -240,13 +244,13 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                         row.col(|ui| {
                             ui.label(file.status.label());
                         });
-                });
-                if let Some((idx, mode)) = pending_click {
-                    app.click_row(idx, mode);
-                }
-                if let Some(path) = pending_reveal {
-                    app.reveal_in_file_manager(&path);
-                }
             });
+        });
     });
+    if let Some((idx, mode)) = pending_click {
+        app.click_row(idx, mode);
+    }
+    if let Some(path) = pending_reveal {
+        app.reveal_in_file_manager(&path);
+    }
 }

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -534,13 +534,6 @@ pub fn spawn_apply(
             }
         }
 
-        let applied = applied.load(Ordering::Relaxed);
-        let errors = errors.load(Ordering::Relaxed);
-        let suffix = if errors > 0 {
-            format!(", {} error(s)", errors)
-        } else {
-            String::new()
-        };
         let verb = if ui_opts.dry_run {
             "Dry-ran"
         } else {
@@ -550,7 +543,11 @@ pub fn spawn_apply(
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!("{} {} on {} file(s){}", verb, action_label, applied, suffix),
+                message: format_result_message(
+                    &format!("{} {} on", verb, action_label),
+                    applied.load(Ordering::Relaxed),
+                    errors.load(Ordering::Relaxed),
+                ),
             },
         );
     });
@@ -733,20 +730,14 @@ pub fn spawn_delete_tags(
             return;
         }
 
-        let errors = errors.load(Ordering::Relaxed);
-        let suffix = if errors > 0 {
-            format!(", {} error(s)", errors)
-        } else {
-            String::new()
-        };
         send(
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!(
-                    "Deleted stored tags from {} file(s){}",
+                message: format_result_message(
+                    "Deleted stored tags from",
                     deleted.load(Ordering::Relaxed),
-                    suffix
+                    errors.load(Ordering::Relaxed),
                 ),
             },
         );
@@ -811,20 +802,14 @@ pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>
             return;
         }
 
-        let errors = errors.load(Ordering::Relaxed);
-        let suffix = if errors > 0 {
-            format!(", {} error(s)", errors)
-        } else {
-            String::new()
-        };
         send(
             &tx,
             &ctx,
             WorkerEvent::Done {
-                message: format!(
-                    "Max amplitude scanned on {} file(s){}",
+                message: format_result_message(
+                    "Max amplitude scanned on",
                     found.load(Ordering::Relaxed),
-                    suffix
+                    errors.load(Ordering::Relaxed),
                 ),
             },
         );
@@ -993,6 +978,9 @@ fn send(tx: &Sender<WorkerEvent>, ctx: &egui::Context, event: WorkerEvent) {
     ctx.request_repaint();
 }
 
+/// Build the final status message: `"<action> <count> file(s)"` plus a
+/// `", N error(s)"` suffix when any job failed. `action` carries any
+/// worker-specific phrasing (e.g. "Applied Track Gain on").
 fn format_result_message(action: &str, count: usize, errors: usize) -> String {
     if errors > 0 {
         format!("{} {} file(s), {} error(s)", action, count, errors)

--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1389,6 +1389,10 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
 
     let existing_undo = mp4meta::read_undo_tags_from_data(&data);
     let existing_gain = crate::ape::parse_undo_values(existing_undo.undo()).0;
+    // AAC convention: the undo tag stores the cumulative *applied* gain, so
+    // it accumulates by *addition* and `undo_aac_gain` negates it. This is
+    // the opposite sign of the MP3 MP3GAIN_UNDO delta — see the note on
+    // `crate::ape::format_undo_value`.
     // Saturate: the existing value comes from an untrusted tag and could be
     // crafted to overflow i32.
     let new_undo_gain = existing_gain.saturating_add(gain_steps);
@@ -1430,6 +1434,9 @@ pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
     let undo_tags = mp4meta::read_undo_tags_from_data(&data);
     let undo_str = undo_tags.undo().ok_or(Error::NoUndoTag)?;
 
+    // AAC convention: the tag stores the cumulative *applied* gain, so undo
+    // applies `-undo_gain` below. MP3 stores the already-negated delta and
+    // applies it as-is — see the note on `crate::ape::format_undo_value`.
     let undo_gain = crate::ape::parse_undo_values(Some(undo_str)).0;
 
     if undo_gain == 0 {

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -418,7 +418,21 @@ pub fn delete_ape_tag(file_path: &Path) -> Result<()> {
     crate::apply::atomic_write(file_path, &audio_data)
 }
 
-/// Format MP3GAIN_UNDO tag value: `+LLL,+RRR,W|N`.
+/// Format an undo tag value: `+LLL,+RRR,W|N`.
+///
+/// CAUTION — the sign convention of the numeric fields differs by container,
+/// and both are load-bearing on-disk formats (do NOT unify them):
+///
+/// - **MP3** (APEv2 / ID3v2 `MP3GAIN_UNDO`): stores the *undo delta* — the
+///   negative of the cumulative applied gain, i.e. the value to re-apply
+///   as-is to restore the original (mp3gain convention, issue #210).
+///   Apply accumulates by *subtracting* the applied steps; undo applies the
+///   stored value directly. See `gain.rs`.
+/// - **AAC** (MP4 freeform undo tag): stores the cumulative *applied* gain;
+///   undo *negates* the stored value before applying. See `aac.rs`.
+///
+/// Changing either convention would corrupt round-trips on files tagged by
+/// older versions or by mp3gain itself.
 pub fn format_undo_value(left_gain: i32, right_gain: i32, wrap: bool) -> String {
     let wrap_flag = if wrap { "W" } else { "N" };
     format!("{:+04},{:+04},{}", left_gain, right_gain, wrap_flag)
@@ -431,7 +445,11 @@ pub fn parse_undo_wrap(undo_str: Option<&str>) -> bool {
         .is_some_and(|s| s.trim().eq_ignore_ascii_case("W"))
 }
 
-/// Parse MP3GAIN_UNDO tag value into (left_gain, right_gain)
+/// Parse an undo tag value into (left_gain, right_gain).
+///
+/// The meaning of the returned values depends on the container the tag came
+/// from — MP3 stores the undo delta, AAC stores the applied gain. See the
+/// sign-convention note on [`format_undo_value`].
 pub fn parse_undo_values(undo_str: Option<&str>) -> (i32, i32) {
     match undo_str {
         Some(v) => {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -10,12 +10,9 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::threading::effective_threads;
-use crate::json_output::{JsonFileResult, JsonOutput};
+use crate::commands::utils::{finish_without_summary, for_each_file_with_analysis_bar};
 use crate::processors::info::{format_rg_row, process_info, scan_gain_range_for_row};
-use crate::progress::{
-    create_album_progress_pb_in, create_analysis_progress_bar, create_file_count_pb_in,
-    progress_finish,
-};
+use crate::progress::create_album_progress_pb_in;
 use crate::util::get_filename;
 
 pub fn cmd_info(files: &[PathBuf], opts: &Options) -> Result<()> {
@@ -244,77 +241,10 @@ fn analyze_set(
 
 /// Basic per-file info (JSON output or builds without the replaygain feature).
 fn cmd_info_basic(files: &[PathBuf], opts: &Options) -> Result<()> {
-    let threads = effective_threads(opts);
-    let parallel = threads > 1 && files.len() > 1;
+    let (json_results, _, _) =
+        for_each_file_with_analysis_bar(files, opts, |file, analysis_pb| {
+            process_info(file, opts, analysis_pb).map(|(r, t)| (Some(r), t))
+        })?;
 
-    let mp = MultiProgress::new();
-    let file_pb = create_file_count_pb_in(&mp, files.len(), opts);
-
-    let json_results: Vec<JsonFileResult> = if parallel {
-        // Skip per-file byte progress bars in parallel mode: they would
-        // interleave across concurrent files. The file-count bar still runs.
-        let file_pb_ref = file_pb.as_ref();
-        let collected: Vec<(JsonFileResult, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String)> {
-                let r = process_info(file, opts, None)?;
-                if let Some(pb) = file_pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Emit captured stdout in input order so TSV/Text output stays
-        // deterministic regardless of completion order.
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        collected.into_iter().map(|(r, _)| r).collect()
-    } else {
-        let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-        for file in files {
-            let filename = get_filename(file);
-            if let Some(ref pb) = file_pb {
-                pb.set_message(filename.to_string());
-            }
-
-            let analysis_pb = create_analysis_progress_bar(&mp, file, opts);
-            let (result, text) = process_info(file, opts, analysis_pb.as_ref())?;
-            progress_finish(analysis_pb);
-
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-
-            json_results.push(result);
-
-            if let Some(ref pb) = file_pb {
-                pb.inc(1);
-            }
-        }
-        json_results
-    };
-
-    if let Some(pb) = file_pb {
-        pb.finish_and_clear();
-    }
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: None,
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    }
-
-    Ok(())
+    finish_without_summary(json_results, opts)
 }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -11,13 +11,14 @@ use std::path::{Path, PathBuf};
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
-    create_json_summary, exit_if_failed, print_dry_run_notice, update_counters,
+    create_json_summary, exit_if_failed, finish_with_summary, for_each_file_with_analysis_bar,
+    print_dry_run_notice, update_counters,
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
 use crate::progress::{
-    create_album_progress_pb_in, create_analysis_progress_bar, create_file_count_pb_in,
-    create_progress_bar, progress_finish, progress_inc, progress_set_message,
+    create_album_progress_pb_in, create_progress_bar, progress_finish, progress_inc,
+    progress_set_message,
 };
 use crate::util::get_filename;
 
@@ -87,94 +88,12 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let threads = effective_threads(opts);
-    let parallel = threads > 1 && files.len() > 1;
+    let (json_results, successful, failed) =
+        for_each_file_with_analysis_bar(files, opts, |file, analysis_pb| {
+            process_track_gain(file, opts, analysis_pb).map(|(r, t)| (Some(r), t))
+        })?;
 
-    let mp = MultiProgress::new();
-    let file_pb = create_file_count_pb_in(&mp, files.len(), opts);
-
-    let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
-    let mut successful = 0;
-    let mut failed = 0;
-
-    if parallel {
-        let file_pb_ref = file_pb.as_ref();
-        let collected: Vec<(JsonFileResult, String)> = files
-            .par_iter()
-            .map(|file| -> Result<(JsonFileResult, String)> {
-                let r = process_track_gain(file, opts, None)?;
-                if let Some(pb) = file_pb_ref {
-                    pb.set_message(get_filename(file).to_string());
-                    pb.inc(1);
-                }
-                Ok(r)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let stdout = io::stdout();
-        let mut handle = stdout.lock();
-        for (_, text) in &collected {
-            if !text.is_empty() {
-                handle.write_all(text.as_bytes())?;
-            }
-        }
-        drop(handle);
-
-        for (result, _) in collected {
-            update_counters(&result, &mut successful, &mut failed);
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-        }
-    } else {
-        for file in files {
-            let filename = get_filename(file);
-            if let Some(ref pb) = file_pb {
-                pb.set_message(filename.to_string());
-            }
-
-            let analysis_pb = create_analysis_progress_bar(&mp, file, opts);
-            let (result, text) = process_track_gain(file, opts, analysis_pb.as_ref())?;
-            progress_finish(analysis_pb);
-
-            if !text.is_empty() {
-                print!("{}", text);
-            }
-
-            update_counters(&result, &mut successful, &mut failed);
-
-            if opts.output_format == OutputFormat::Json {
-                json_results.push(result);
-            }
-
-            if let Some(ref pb) = file_pb {
-                pb.inc(1);
-            }
-        }
-    }
-
-    if let Some(pb) = file_pb {
-        pb.finish_and_clear();
-    }
-
-    if opts.output_format == OutputFormat::Json {
-        let output = JsonOutput {
-            files: Some(json_results),
-            album: None,
-            summary: Some(create_json_summary(
-                files.len(),
-                successful,
-                failed,
-                opts.dry_run,
-            )),
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_dry_run_notice(opts);
-    }
-
-    exit_if_failed(failed);
-    Ok(())
+    finish_with_summary(files.len(), json_results, successful, failed, opts)
 }
 
 pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use colored::*;
+use indicatif::{MultiProgress, ProgressBar};
 use rayon::prelude::*;
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
@@ -7,7 +8,10 @@ use std::path::{Path, PathBuf};
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::threading::effective_threads;
 use crate::json_output::{FileStatus, JsonFileResult, JsonOutput, JsonSummary};
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::progress::{
+    create_analysis_progress_bar, create_file_count_pb_in, create_progress_bar, progress_finish,
+    progress_inc, progress_set_message,
+};
 use crate::util::get_filename;
 
 /// Run `per_file` over every file — in parallel when `-j` allows it — with
@@ -26,7 +30,39 @@ pub fn for_each_file<F>(
 where
     F: Fn(&Path) -> Result<(Option<JsonFileResult>, String)> + Sync,
 {
-    let pb = create_progress_bar(files.len(), opts);
+    for_each_file_impl(files, opts, false, |file, _| per_file(file))
+}
+
+/// [`for_each_file`] variant for the analysis-heavy commands (track gain,
+/// basic info): the serial path additionally shows a per-file byte-level
+/// analysis bar, passed to `per_file`. Parallel runs skip it (concurrent
+/// byte bars would interleave); only the file-count bar runs there.
+pub fn for_each_file_with_analysis_bar<F>(
+    files: &[PathBuf],
+    opts: &Options,
+    per_file: F,
+) -> Result<(Vec<JsonFileResult>, usize, usize)>
+where
+    F: Fn(&Path, Option<&ProgressBar>) -> Result<(Option<JsonFileResult>, String)> + Sync,
+{
+    for_each_file_impl(files, opts, true, per_file)
+}
+
+fn for_each_file_impl<F>(
+    files: &[PathBuf],
+    opts: &Options,
+    analysis_bars: bool,
+    per_file: F,
+) -> Result<(Vec<JsonFileResult>, usize, usize)>
+where
+    F: Fn(&Path, Option<&ProgressBar>) -> Result<(Option<JsonFileResult>, String)> + Sync,
+{
+    let mp = MultiProgress::new();
+    let pb = if analysis_bars {
+        create_file_count_pb_in(&mp, files.len(), opts)
+    } else {
+        create_progress_bar(files.len(), opts)
+    };
     let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
     let mut successful = 0;
     let mut failed = 0;
@@ -38,7 +74,7 @@ where
         let collected: Vec<(Option<JsonFileResult>, String)> = files
             .par_iter()
             .map(|file| -> Result<(Option<JsonFileResult>, String)> {
-                let r = per_file(file)?;
+                let r = per_file(file, None)?;
                 if let Some(pb) = pb_ref {
                     pb.set_message(get_filename(file).to_string());
                     pb.inc(1);
@@ -66,7 +102,14 @@ where
         for file in files {
             progress_set_message(&pb, get_filename(file));
 
-            let (result, text) = per_file(file)?;
+            let analysis_pb = if analysis_bars {
+                create_analysis_progress_bar(&mp, file, opts)
+            } else {
+                None
+            };
+            let (result, text) = per_file(file, analysis_pb.as_ref())?;
+            progress_finish(analysis_pb);
+
             if !text.is_empty() {
                 print!("{}", text);
             }

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -353,6 +353,8 @@ fn apply_gain_with_undo_impl_to_path(
     // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue #210):
     // the value to re-add to restore the original. Applying `+gain_steps`
     // makes the stored undo `-gain_steps`, so it accumulates by subtraction.
+    // NOTE: AAC uses the opposite sign (stores the applied gain) — see the
+    // convention note on `crate::ape::format_undo_value`.
     let (existing_left, existing_right) = parse_undo_values(tag.get(TAG_MP3GAIN_UNDO));
     let wrap = mode == GainMode::Wrapping;
     tag.set_undo_gain(


### PR DESCRIPTION
Behavior-preserving refactor addressing the five cleanups from the code review:

- **for_each_file reuse**: `cmd_track_gain` and `cmd_info_basic` now run through the shared `for_each_file` driver via a new `for_each_file_with_analysis_bar` variant, which keeps the serial-path per-file analysis bar (`MultiProgress` + file-count bar) and drops ~140 duplicated lines. Exit-code handling (#239) and dry-run continuation (#242) are preserved.
- **GUI modal skeletons**: `render_channel_gain_modal` / `render_manual_gain_modal` / `render_delete_confirm` share a `modal()` helper (window chrome, Cancel, commit button, open-flag handling); the target count now comes from `target_indices()` in all three.
- **GUI result messages**: `spawn_apply`, `spawn_delete_tags`, and `spawn_find_max_amplitude` now build their ", N error(s)" suffix through `format_result_message`, matching `spawn_track_analysis`.
- **Undo tag sign conventions**: documented (not unified — unifying would break round-trips with existing tags and mp3gain). `format_undo_value` / `parse_undo_values` carry the container-specific convention note, cross-referenced from the MP3 (`gain.rs`) and AAC (`aac.rs`) call sites.
- **GUI per-frame allocations**: the table borrows the cached display order (`ensure_display_order` + `&[usize]` getter) instead of cloning it every frame, and the selection `HashSet` is reused across frames instead of rebuilt.

Verified against a pre-refactor binary on the fixture files: plain info (text/TSV/JSON, serial and parallel), `-r` dry-run and real apply — stdout/stderr, exit codes (including exit 1 with a nonexistent file in the batch, which still continues past the failure), and resulting file bytes are all identical. `cargo test` (125 tests) passes; both crates build warning-free and are `cargo fmt` clean.

Fixes #237