### PR TITLE
Reduce redundant full-file passes in the apply paths

### DIFF
--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -448,14 +448,21 @@ pub fn spawn_apply(
         } else {
             Vec::new()
         };
+        // Post-apply (max, min) global_gain range per album file, taken from
+        // the apply reports so the MINMAX step below doesn't re-analyze every
+        // file (issue #232).
+        let gain_ranges: Mutex<BTreeMap<PathBuf, (u8, u8)>> = Mutex::new(BTreeMap::new());
 
         {
             let tx = tx.clone();
             let ctx = ctx.clone();
             let (applied, errors) = (&applied, &errors);
+            let gain_ranges = &gain_ranges;
             run_job_pool(jobs, &cancel_w, move |job: ApplyJob| {
                 send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
+                let album_member =
+                    !ui_opts.dry_run && !ui_opts.use_id3v2 && job.album_info.is_some();
                 let opts = build_apply_options(
                     job.steps,
                     job.track_result,
@@ -470,6 +477,11 @@ pub fn spawn_apply(
                 };
                 match result {
                     Ok(report) => {
+                        if album_member {
+                            if let Some(range) = report.gain_range {
+                                gain_ranges.lock().unwrap().insert(job.path.clone(), range);
+                            }
+                        }
                         applied.fetch_add(1, Ordering::Relaxed);
                         if ui_opts.dry_run {
                             send(
@@ -519,14 +531,22 @@ pub fn spawn_apply(
         // is stamped per parent directory; in single-album mode (issue #224)
         // it spans the whole batch to match the one shared album gain.
         if !album_minmax_paths.is_empty() {
+            type MinmaxEntry<'a> = (&'a Path, Option<(u8, u8)>);
+            let gain_ranges = gain_ranges.into_inner().unwrap();
             if single_album {
-                let all: Vec<&Path> = album_minmax_paths.iter().map(PathBuf::as_path).collect();
+                let all: Vec<MinmaxEntry> = album_minmax_paths
+                    .iter()
+                    .map(|p| (p.as_path(), gain_ranges.get(p).copied()))
+                    .collect();
                 write_album_minmax(&all);
             } else {
-                let mut by_folder: BTreeMap<PathBuf, Vec<&Path>> = BTreeMap::new();
+                let mut by_folder: BTreeMap<PathBuf, Vec<MinmaxEntry>> = BTreeMap::new();
                 for p in &album_minmax_paths {
                     let parent = p.parent().map(Path::to_path_buf).unwrap_or_default();
-                    by_folder.entry(parent).or_default().push(p.as_path());
+                    by_folder
+                        .entry(parent)
+                        .or_default()
+                        .push((p.as_path(), gain_ranges.get(p).copied()));
                 }
                 for group in by_folder.values() {
                     write_album_minmax(group);

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -124,6 +124,21 @@ impl ApeTag {
         let value = format!("{},{}", min, max);
         self.set(TAG_MP3GAIN_MINMAX, &value);
     }
+
+    /// Set the `REPLAYGAIN_*` items present in `rg` (issue #232).
+    pub(crate) fn set_replaygain(&mut self, rg: &ApeReplayGain) {
+        let fields: [(&str, &Option<String>); 4] = [
+            (TAG_REPLAYGAIN_TRACK_GAIN, &rg.track_gain),
+            (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
+            (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
+            (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
+        ];
+        for (key, value) in fields {
+            if let Some(v) = value {
+                self.set(key, v);
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for ApeTag {
@@ -380,19 +395,7 @@ pub struct ApeReplayGain {
 pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> {
     let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
     let mut tag = read_ape_tag(&data).unwrap_or_default();
-
-    let fields: [(&str, &Option<String>); 4] = [
-        (TAG_REPLAYGAIN_TRACK_GAIN, &rg.track_gain),
-        (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
-        (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
-        (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
-    ];
-    for (key, value) in fields {
-        if let Some(v) = value {
-            tag.set(key, v);
-        }
-    }
-
+    tag.set_replaygain(rg);
     let new_data = replace_ape_tag(&data, &tag);
     crate::apply::atomic_write(file_path, &new_data)
 }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -105,6 +105,13 @@ pub struct ApplyOptions {
     /// Channel) instead of all channels. AAC has no per-channel apply
     /// path; setting this on an AAC file is an error.
     pub channel: Option<Channel>,
+
+    /// Skip the pre-apply clipping check entirely. For callers that will
+    /// never surface [`ApplyReport::clipping_detected`] (`-c` / `-q`, or the
+    /// channel path), the headroom check's full-file `analyze()` is pure
+    /// waste (issue #232). Ignored when [`Self::prevent_clipping`] is on —
+    /// `-k` needs the check to cap the gain.
+    pub skip_clipping_check: bool,
 }
 
 impl ApplyOptions {
@@ -123,6 +130,7 @@ impl ApplyOptions {
             write_replaygain_tags: false,
             use_id3v2: false,
             channel: None,
+            skip_clipping_check: false,
         }
     }
 }
@@ -178,11 +186,12 @@ pub enum ClippingDetection {
 /// 1. Optional clipping check (headroom-based for `-g`/`-l`, peak-based
 ///    when [`ApplyOptions::track_result`] is set).
 /// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, via temp file +
-///    atomic rename.
-/// 3. ID3v2 undo tag write (MP3 + [`ApplyOptions::use_id3v2`]).
-/// 4. ReplayGain tag write (AAC mp4 metadata, MP3 ID3v2 TXXX with
-///    [`ApplyOptions::use_id3v2`], or MP3 APEv2 by default — issue #204).
-/// 5. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
+///    atomic rename. The MP3 undo and ReplayGain tags (ID3v2 TXXX with
+///    [`ApplyOptions::use_id3v2`], APEv2 by default — issue #204) are
+///    folded into the same write (issues #227, #232).
+/// 3. Remaining ReplayGain tag writes: AAC mp4 metadata, and the APEv2
+///    re-write for wrap/saturated or channel applies.
+/// 4. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
 pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
     let is_aac = mp4meta::is_aac_file(file_path);
 
@@ -208,90 +217,55 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 
     // 2) Apply gain to bytes. MP3 reports global_gain saturation (issue
     // #207); AAC clamps in its own path and isn't tallied here.
+    //
+    // The MP3 paths fold the tag writes into the same visible write as the
+    // gain apply (issue #232): ID3v2 writes undo + minmax + ReplayGain TXXX
+    // frames onto the temp file before the rename, and the APE path embeds
+    // the arithmetic `REPLAYGAIN_*` items in the tag the gain apply already
+    // rewrites. Wrap mode and channel applies keep the separate APE
+    // ReplayGain write in step 3 below.
     let mut saturation = SaturationStats::default();
+    let mut ape_rg_folded = false;
     let modified = if is_aac {
         apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
     } else if opts.use_id3v2 {
         saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts)?;
         saturation.frames
     } else {
-        saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts)?;
+        let folded_rg = if opts.write_replaygain_tags && opts.channel.is_none() && !opts.wrap {
+            compute_rg_residual(file_path, opts, actual_steps, false).map(|r| r.to_ape())
+        } else {
+            None
+        };
+        ape_rg_folded = folded_rg.is_some();
+        saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts, folded_rg)?;
         saturation.frames
     };
 
-    // 3) ReplayGain tag write.
+    // 3) Remaining ReplayGain tag writes.
     //
-    // AAC writes to mp4 freeform metadata; MP3 writes ID3v2 TXXX frames in
-    // `-s i` mode, otherwise APEv2 `REPLAYGAIN_*` items (the default,
-    // mp3gain-compatible mode — issue #204). Only the container differs.
-    //
-    // mp3gain stores the *post-apply residual* — the gain a player should
-    // still apply on top of the gain already baked into global_gain — at
-    // 6-decimal precision, not the pre-apply analysis value (issue #210).
-    // Absent global_gain saturation, applying N steps shifts loudness by
-    // exactly N*1.5 dB, so the residual is arithmetic; under saturation (or
-    // `-w` wrap) the shift is not uniform, so re-analyze the modified file
-    // for the true post-apply values. AAC clamps internally and is always
-    // treated arithmetically (mp3gain has no AAC, so it is interop-neutral).
-    if opts.write_replaygain_tags {
-        if let Some(track) = opts.track_result.as_ref() {
-            let needs_reanalysis = !is_aac
-                && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
-
-            let arithmetic = || {
-                let db = steps_to_db(actual_steps);
-                (
-                    track.gain_db() - db,
-                    apply_gain_to_peak(track.peak(), db),
-                    db,
-                )
-            };
-            let (track_gain_db, track_peak, applied_db) = if needs_reanalysis {
-                match crate::replaygain::analyze_track(file_path) {
-                    Ok(post) => (
-                        post.gain_db(),
-                        post.peak(),
-                        track.gain_db() - post.gain_db(),
-                    ),
-                    Err(_) => arithmetic(),
-                }
-            } else {
-                arithmetic()
-            };
-
-            // Album residual: the same loudness shift applies to the album
-            // gain/peak (the album value is uniform across the set).
-            let album_residual = opts.album_info.map(|a| {
-                (
-                    a.album_gain_db - applied_db,
-                    apply_gain_to_peak(a.album_peak, applied_db),
-                )
-            });
-
-            if is_aac {
+    // AAC writes to mp4 freeform metadata (always arithmetic — AAC clamps
+    // internally, and mp3gain has no AAC, so it is interop-neutral). The MP3
+    // paths were handled in step 2, except: under saturation or `-w` wrap the
+    // loudness shift is not uniform, so the modified file is re-analyzed for
+    // the true post-apply residual and the APE items rewritten; channel
+    // applies keep the legacy separate write.
+    if opts.write_replaygain_tags && !opts.use_id3v2 {
+        let needs_reanalysis =
+            !is_aac && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
+        if is_aac {
+            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, false) {
                 let mut tags = mp4meta::ReplayGainTags::default();
-                tags.set_track(track_gain_db, track_peak);
-                if let Some((album_gain, album_peak)) = album_residual {
+                tags.set_track(res.track_gain_db, res.track_peak);
+                if let Some((album_gain, album_peak)) = res.album {
                     tags.set_album(album_gain, album_peak);
                 }
                 mp4meta::write_replaygain_tags(file_path, &tags)?;
-            } else if opts.use_id3v2 {
-                let rg = id3v2::Id3v2ReplayGain {
-                    track_gain: Some(format!("{:+.6} dB", track_gain_db)),
-                    track_peak: Some(format!("{:.6}", track_peak)),
-                    album_gain: album_residual.map(|(g, _)| format!("{:+.6} dB", g)),
-                    album_peak: album_residual.map(|(_, p)| format!("{:.6}", p)),
-                    ..Default::default()
-                };
-                id3v2::write_id3v2_replaygain(file_path, &rg)?;
-            } else {
-                let rg = ape::ApeReplayGain {
-                    track_gain: Some(format!("{:+.6} dB", track_gain_db)),
-                    track_peak: Some(format!("{:.6}", track_peak)),
-                    album_gain: album_residual.map(|(g, _)| format!("{:+.6} dB", g)),
-                    album_peak: album_residual.map(|(_, p)| format!("{:.6}", p)),
-                };
-                ape::write_ape_replaygain(file_path, &rg)?;
+            }
+        } else if !ape_rg_folded || needs_reanalysis {
+            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
+            {
+                ape::write_ape_replaygain(file_path, &res.to_ape())?;
             }
         }
     }
@@ -345,7 +319,7 @@ fn check_clipping(
     aac_analysis: &mut AacAnalysisCache,
 ) -> Result<(i32, bool, Option<ClippingDetection>)> {
     let steps = opts.steps;
-    if opts.wrap {
+    if opts.wrap || (opts.skip_clipping_check && !opts.prevent_clipping) {
         return Ok((steps, false, None));
     }
 
@@ -451,10 +425,93 @@ fn apply_aac_bytes(
     })
 }
 
+/// Post-apply residual ReplayGain values — the gain a player should still
+/// apply on top of the gain already baked into global_gain, stored at
+/// 6-decimal precision per mp3gain convention (issue #210).
+struct RgResidual {
+    track_gain_db: f64,
+    track_peak: f64,
+    album: Option<(f64, f64)>,
+}
+
+impl RgResidual {
+    fn to_ape(&self) -> ape::ApeReplayGain {
+        ape::ApeReplayGain {
+            track_gain: Some(format!("{:+.6} dB", self.track_gain_db)),
+            track_peak: Some(format!("{:.6}", self.track_peak)),
+            album_gain: self.album.map(|(g, _)| format!("{:+.6} dB", g)),
+            album_peak: self.album.map(|(_, p)| format!("{:.6}", p)),
+        }
+    }
+
+    fn to_id3v2(&self) -> id3v2::Id3v2ReplayGain {
+        id3v2::Id3v2ReplayGain {
+            track_gain: Some(format!("{:+.6} dB", self.track_gain_db)),
+            track_peak: Some(format!("{:.6}", self.track_peak)),
+            album_gain: self.album.map(|(g, _)| format!("{:+.6} dB", g)),
+            album_peak: self.album.map(|(_, p)| format!("{:.6}", p)),
+            ..Default::default()
+        }
+    }
+}
+
+/// Compute the residual track/album ReplayGain after applying `actual_steps`.
+///
+/// Absent global_gain saturation, applying N steps shifts loudness by exactly
+/// N*1.5 dB, so the residual is arithmetic. With `reanalyze` (wrap mode or a
+/// saturating apply) the shift is not uniform, so the already-modified file at
+/// `modified_path` is re-analyzed for the true post-apply values, falling back
+/// to arithmetic on analysis failure.
+fn compute_rg_residual(
+    modified_path: &Path,
+    opts: &ApplyOptions,
+    actual_steps: i32,
+    reanalyze: bool,
+) -> Option<RgResidual> {
+    let track = opts.track_result.as_ref()?;
+
+    let arithmetic = || {
+        let db = steps_to_db(actual_steps);
+        (
+            track.gain_db() - db,
+            apply_gain_to_peak(track.peak(), db),
+            db,
+        )
+    };
+    let (track_gain_db, track_peak, applied_db) = if reanalyze {
+        match crate::replaygain::analyze_track(modified_path) {
+            Ok(post) => (
+                post.gain_db(),
+                post.peak(),
+                track.gain_db() - post.gain_db(),
+            ),
+            Err(_) => arithmetic(),
+        }
+    } else {
+        arithmetic()
+    };
+
+    // Album residual: the same loudness shift applies to the album gain/peak
+    // (the album value is uniform across the set).
+    let album = opts.album_info.map(|a| {
+        (
+            a.album_gain_db - applied_db,
+            apply_gain_to_peak(a.album_peak, applied_db),
+        )
+    });
+
+    Some(RgResidual {
+        track_gain_db,
+        track_peak,
+        album,
+    })
+}
+
 fn apply_mp3_ape_bytes(
     file_path: &Path,
     steps: i32,
     opts: &ApplyOptions,
+    replaygain: Option<ape::ApeReplayGain>,
 ) -> Result<SaturationStats> {
     with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps)
@@ -462,6 +519,9 @@ fn apply_mp3_ape_bytes(
             .undo(opts.write_undo);
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
+        }
+        if let Some(rg) = replaygain {
+            gain = gain.replaygain(rg);
         }
         gain.apply_to_path_with_stats(r, w)
     })
@@ -472,10 +532,11 @@ fn apply_mp3_id3v2_bytes(
     steps: i32,
     opts: &ApplyOptions,
 ) -> Result<SaturationStats> {
-    // APE undo is never written in `-s i` mode; the undo goes into a
-    // TXXX:MP3GAIN_UNDO frame instead. The frame is written onto the temp
-    // file before the rename so gain + undo tag land in one visible write —
-    // a failed tag write leaves the original untouched (issue #227).
+    // APE undo is never written in `-s i` mode; undo/minmax and the
+    // REPLAYGAIN_* values go into TXXX frames instead. All frames are written
+    // onto the temp file before the rename so gain + tags land in one visible
+    // write — a failed tag write leaves the original untouched (issues #227,
+    // #232).
     with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps).wrap(opts.wrap).undo(false);
         if let Some(ch) = opts.channel {
@@ -483,13 +544,52 @@ fn apply_mp3_id3v2_bytes(
         }
         let stats = gain.apply_to_path_with_stats(r, w)?;
 
+        let mut rg = id3v2::Id3v2ReplayGain::default();
+
         if opts.write_undo {
             let (delta_left, delta_right) = match opts.channel {
                 Some(Channel::Left) => (steps, 0),
                 Some(Channel::Right) => (0, steps),
                 None => (steps, steps),
             };
-            write_id3v2_undo_after_apply(w, delta_left, delta_right, opts.wrap)?;
+            let existing = id3v2::read_id3v2_replaygain(w).unwrap_or_default();
+            let (existing_left, existing_right) = ape::parse_undo_values(existing.undo.as_deref());
+
+            // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue
+            // #210): applying `+delta` makes the stored undo `-delta`,
+            // accumulating by subtraction onto any prior undo value.
+            rg.undo = Some(ape::format_undo_value(
+                existing_left - delta_left,
+                existing_right - delta_right,
+                opts.wrap,
+            ));
+
+            // MP3GAIN_MINMAX is the *post-apply* global_gain range (mp3gain
+            // convention). A full apply already tracked it in the saturation
+            // stats (issue #231); channel and zero-step applies only touch a
+            // subset (or nothing), so scan the modified temp file instead.
+            let (min, max) = if opts.channel.is_none() && stats.frames > 0 {
+                (stats.min_gain, stats.max_gain)
+            } else {
+                let post = crate::analyze(w)?;
+                (post.min_gain(), post.max_gain())
+            };
+            rg.minmax = Some(format!("{},{}", min, max));
+        }
+
+        if opts.write_replaygain_tags {
+            let reanalyze = opts.wrap || stats.saturated_low > 0 || stats.saturated_high > 0;
+            if let Some(res) = compute_rg_residual(w, opts, steps, reanalyze) {
+                let values = res.to_id3v2();
+                rg.track_gain = values.track_gain;
+                rg.track_peak = values.track_peak;
+                rg.album_gain = values.album_gain;
+                rg.album_peak = values.album_peak;
+            }
+        }
+
+        if rg.undo.is_some() || rg.track_gain.is_some() {
+            id3v2::write_id3v2_replaygain_direct(w, &rg)?;
         }
         Ok(stats)
     })
@@ -572,33 +672,6 @@ pub fn read_mtime(path: &Path) -> Option<SystemTime> {
     std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
 }
 
-fn write_id3v2_undo_after_apply(
-    file: &Path,
-    delta_left: i32,
-    delta_right: i32,
-    wrap: bool,
-) -> Result<()> {
-    let existing_rg = id3v2::read_id3v2_replaygain(file).unwrap_or_default();
-    let (existing_left, existing_right) = ape::parse_undo_values(existing_rg.undo.as_deref());
-
-    // MP3GAIN_MINMAX is the *post-apply* global_gain range (mp3gain
-    // convention); `file` is the already-modified file at this point, so a
-    // fresh scan reflects the applied gain.
-    let post = crate::analyze(file)?;
-
-    // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue #210):
-    // applying `+delta` makes the stored undo `-delta`, accumulating by
-    // subtraction onto any prior undo value.
-    id3v2::write_id3v2_undo(
-        file,
-        existing_left - delta_left,
-        existing_right - delta_right,
-        wrap,
-        post.min_gain(),
-        post.max_gain(),
-    )
-}
-
 /// Aggregate the post-apply `global_gain` range across an album's MP3 files
 /// and write `MP3GAIN_ALBUM_MINMAX` (`min,max`) to each, matching mp3gain's
 /// album (`-a`) mode (issue #210).
@@ -608,19 +681,29 @@ fn write_id3v2_undo_after_apply(
 /// the CLI (`cmd_album_gain`) and the GUI apply worker so both frontends stay
 /// in parity (the GUI path was missing it in 2.9.0).
 ///
+/// Each file is paired with the `(max, min)` range from
+/// [`ApplyReport::gain_range`] so the apply pass's scan is reused instead of
+/// re-analyzing every file (issue #232); files without one (AAC members,
+/// zero-frame applies, failed applies) fall back to a fresh `analyze()`.
+///
 /// AAC members are skipped — the MP3 analyzer rejects them and mp3gain has no
 /// AAC. Best-effort: a failed scan or tag write on one file is ignored so a
 /// metadata hiccup never fails the album operation. Intended for the default
 /// APEv2 path; skip the call when writing ID3v2 (`-s i`) or when stored-tag
 /// writing is disabled.
-pub fn write_album_minmax(files: &[&Path]) {
+pub fn write_album_minmax(files: &[(&Path, Option<(u8, u8)>)]) {
     let mut album_min = u8::MAX;
     let mut album_max = u8::MIN;
     let mut mp3_files: Vec<&Path> = Vec::new();
-    for &file in files {
-        if let Ok(analysis) = crate::analyze(file) {
-            album_min = album_min.min(analysis.min_gain());
-            album_max = album_max.max(analysis.max_gain());
+    for &(file, range) in files {
+        let range = range.or_else(|| {
+            crate::analyze(file)
+                .ok()
+                .map(|a| (a.max_gain(), a.min_gain()))
+        });
+        if let Some((max, min)) = range {
+            album_min = album_min.min(min);
+            album_max = album_max.max(max);
             mp3_files.push(file);
         }
     }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -386,41 +386,48 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
             let mut successful = 0;
             let mut failed = 0;
+            // Post-apply (max, min) global_gain range per file, taken from the
+            // apply pass so the album MINMAX step below doesn't re-analyze
+            // every file (issue #232).
+            let mut range_by_idx: Vec<Option<(u8, u8)>> = vec![None; files.len()];
 
             if parallel {
                 let pb_ref = pb.as_ref();
                 // Process only successfully-analyzed files in parallel.
-                let collected: Vec<(usize, JsonFileResult, String)> = successful_indices
+                type Collected = (usize, JsonFileResult, String, Option<(u8, u8)>);
+                let collected: Vec<Collected> = successful_indices
                     .par_iter()
                     .enumerate()
-                    .map(
-                        |(track_idx, &file_idx)| -> Result<(usize, JsonFileResult, String)> {
-                            let file = &files[file_idx];
-                            let track_result = &album_result.tracks()[track_idx];
-                            let (result, text) = process_apply_replaygain_with_album(
-                                file,
-                                steps,
-                                track_result,
-                                opts,
-                                Some(&album_info),
-                            )?;
-                            if let Some(pb) = pb_ref {
-                                pb.set_message(get_filename(file).to_string());
-                                pb.inc(1);
-                            }
-                            Ok((file_idx, result, text))
-                        },
-                    )
+                    .map(|(track_idx, &file_idx)| -> Result<Collected> {
+                        let file = &files[file_idx];
+                        let track_result = &album_result.tracks()[track_idx];
+                        let (result, text, range) = process_apply_replaygain_with_album(
+                            file,
+                            steps,
+                            track_result,
+                            opts,
+                            Some(&album_info),
+                        )?;
+                        if let Some(pb) = pb_ref {
+                            pb.set_message(get_filename(file).to_string());
+                            pb.inc(1);
+                        }
+                        Ok((file_idx, result, text, range))
+                    })
                     .collect::<Result<Vec<_>>>()?;
 
                 let stdout = io::stdout();
                 let mut handle = stdout.lock();
-                for (_, _, text) in &collected {
+                for (_, _, text, _) in &collected {
                     if !text.is_empty() {
                         handle.write_all(text.as_bytes())?;
                     }
                 }
                 drop(handle);
+
+                for (file_idx, _, _, range) in &collected {
+                    range_by_idx[*file_idx] = *range;
+                }
 
                 // Re-assemble json_results in input file order, interleaving
                 // failures with successes so the JSON output stays aligned
@@ -428,7 +435,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 if opts.output_format == OutputFormat::Json {
                     let mut by_index: Vec<Option<JsonFileResult>> =
                         (0..files.len()).map(|_| None).collect();
-                    for (file_idx, result, _) in &collected {
+                    for (file_idx, result, _, _) in &collected {
                         by_index[*file_idx] = Some(result.clone());
                     }
                     for (i, slot) in by_index.iter_mut().enumerate() {
@@ -443,7 +450,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                         json_results.push(entry);
                     }
                 } else {
-                    for (_, result, _) in collected {
+                    for (_, result, _, _) in collected {
                         update_counters(&result, &mut successful, &mut failed);
                     }
                     failed += failure_count;
@@ -456,7 +463,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                     let result = match file_to_track[i] {
                         Some(track_idx) => {
                             let track_result = &album_result.tracks()[track_idx];
-                            let (result, text) = process_apply_replaygain_with_album(
+                            let (result, text, range) = process_apply_replaygain_with_album(
                                 file,
                                 steps,
                                 track_result,
@@ -466,6 +473,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                             if !text.is_empty() {
                                 print!("{}", text);
                             }
+                            range_by_idx[i] = range;
                             result
                         }
                         None => failure_json_result(file, failure_msgs[i].clone()),
@@ -488,9 +496,9 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             // whole album is done). APEv2 only — mp3gain has no AAC, and `-s i`
             // uses ID3v2; best-effort, so a tag hiccup never fails the album.
             if !opts.dry_run && opts.stored_tag_mode != StoredTagMode::Skip && !opts.use_id3v2 {
-                let album_files: Vec<&Path> = successful_indices
+                let album_files: Vec<(&Path, Option<(u8, u8)>)> = successful_indices
                     .iter()
-                    .map(|&i| files[i].as_path())
+                    .map(|&i| (files[i].as_path(), range_by_idx[i]))
                     .collect();
                 mp3rgain::write_album_minmax(&album_files);
             }

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,7 +1,7 @@
 use crate::analysis::{analyze_data, ChannelMode};
 use crate::ape::{
-    parse_undo_values, parse_undo_wrap, read_ape_tag, replace_ape_tag, TAG_MP3GAIN_MINMAX,
-    TAG_MP3GAIN_UNDO,
+    parse_undo_values, parse_undo_wrap, read_ape_tag, replace_ape_tag, ApeReplayGain,
+    TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
 use crate::frame::{apply_gain_to_data, scan_gain_range, GainMode, SaturationStats};
@@ -100,6 +100,7 @@ pub struct GainOptions {
     wrap: bool,
     undo: bool,
     channel: Option<Channel>,
+    replaygain: Option<ApeReplayGain>,
 }
 
 impl GainOptions {
@@ -112,6 +113,7 @@ impl GainOptions {
             wrap: false,
             undo: false,
             channel: None,
+            replaygain: None,
         }
     }
 
@@ -140,6 +142,14 @@ impl GainOptions {
     /// Returns an error if the file is mono.
     pub fn channel(mut self, channel: Channel) -> Self {
         self.channel = Some(channel);
+        self
+    }
+
+    /// Fold `REPLAYGAIN_*` items into the same APEv2 tag write as the gain
+    /// apply, avoiding a second full-file rewrite (issue #232). Ignored for
+    /// channel-specific applies.
+    pub(crate) fn replaygain(mut self, rg: ApeReplayGain) -> Self {
+        self.replaygain = Some(rg);
         self
     }
 
@@ -173,7 +183,15 @@ impl GainOptions {
         let same_path = read_from == write_to;
 
         if self.steps == 0 {
-            if !same_path {
+            // No undo/minmax on a zero-step apply (nothing to undo), but the
+            // ReplayGain items still need to be recorded when requested.
+            if let Some(rg) = &self.replaygain {
+                let data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
+                let mut tag = read_ape_tag(&data).unwrap_or_default();
+                tag.set_replaygain(rg);
+                let new_data = replace_ape_tag(&data, &tag);
+                fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
+            } else if !same_path {
                 fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
             }
             return Ok(SaturationStats::default());
@@ -192,9 +210,21 @@ impl GainOptions {
                 GainMode::Saturating
             };
             if self.undo {
-                apply_gain_with_undo_impl_to_path(read_from, write_to, self.steps, mode)
+                apply_gain_with_undo_impl_to_path(
+                    read_from,
+                    write_to,
+                    self.steps,
+                    mode,
+                    self.replaygain.as_ref(),
+                )
             } else {
-                apply_gain_simple_to_path(read_from, write_to, self.steps, mode)
+                apply_gain_simple_to_path(
+                    read_from,
+                    write_to,
+                    self.steps,
+                    mode,
+                    self.replaygain.as_ref(),
+                )
             }
         }
     }
@@ -321,12 +351,20 @@ fn apply_gain_simple_to_path(
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
+    replaygain: Option<&ApeReplayGain>,
 ) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
     let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
-    fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
+    if let Some(rg) = replaygain {
+        let mut tag = read_ape_tag(&data).unwrap_or_default();
+        tag.set_replaygain(rg);
+        let new_data = replace_ape_tag(&data, &tag);
+        fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
+    } else {
+        fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
+    }
 
     Ok(stats)
 }
@@ -341,6 +379,7 @@ fn apply_gain_with_undo_impl_to_path(
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
+    replaygain: Option<&ApeReplayGain>,
 ) -> Result<SaturationStats> {
     let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
@@ -364,10 +403,17 @@ fn apply_gain_with_undo_impl_to_path(
     let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     // MP3GAIN_MINMAX records the *post-apply* global_gain range (mp3gain
-    // convention). Re-scan the modified buffer and overwrite any prior value;
-    // this also validates that the input was a real MP3 (NoMp3Frames on empty).
-    let (min, max) = scan_gain_range(&data)?;
-    tag.set_minmax(min, max);
+    // convention). A full apply touches every gain location, so the stats
+    // already carry the exact range — no re-scan needed (issue #232). The
+    // zero-frame check keeps the old NoMp3Frames validation for non-MP3 input.
+    if stats.frames == 0 {
+        return Err(Error::NoMp3Frames);
+    }
+    tag.set_minmax(stats.min_gain, stats.max_gain);
+
+    if let Some(rg) = replaygain {
+        tag.set_replaygain(rg);
+    }
 
     let new_data = replace_ape_tag(&data, &tag);
     fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -140,30 +140,40 @@ pub fn read_id3v2_replaygain(path: &Path) -> Result<Id3v2ReplayGain> {
     })
 }
 
-/// Write ReplayGain and undo data to ID3v2 TXXX frames (preserves existing ID3v2 data)
-pub fn write_id3v2_replaygain(path: &Path, rg: &Id3v2ReplayGain) -> Result<()> {
-    let mut tag = read_tag(path)?;
-
+fn add_rg_frames(tag: &mut id3::Tag, rg: &Id3v2ReplayGain) {
     let fields: &[(&str, &Option<String>)] = &[
+        (TAG_MP3GAIN_UNDO, &rg.undo),
+        (TAG_MP3GAIN_MINMAX, &rg.minmax),
         (TAG_REPLAYGAIN_TRACK_GAIN, &rg.track_gain),
         (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
         (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
         (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
-        (TAG_MP3GAIN_UNDO, &rg.undo),
-        (TAG_MP3GAIN_MINMAX, &rg.minmax),
     ];
 
     for &(desc, value) in fields {
         if let Some(v) = value {
-            remove_txxx_ci(&mut tag, desc);
+            remove_txxx_ci(tag, desc);
             tag.add_frame(id3::frame::ExtendedText {
                 description: desc.to_string(),
                 value: v.clone(),
             });
         }
     }
+}
 
+/// Write ReplayGain and undo data to ID3v2 TXXX frames (preserves existing ID3v2 data)
+pub fn write_id3v2_replaygain(path: &Path, rg: &Id3v2ReplayGain) -> Result<()> {
+    let mut tag = read_tag(path)?;
+    add_rg_frames(&mut tag, rg);
     write_tag(path, &tag)
+}
+
+/// [`write_id3v2_replaygain`] without the temp+rename dance, for callers that
+/// are already writing onto a not-yet-visible temp file (issue #232).
+pub(crate) fn write_id3v2_replaygain_direct(path: &Path, rg: &Id3v2ReplayGain) -> Result<()> {
+    let mut tag = read_tag(path)?;
+    add_rg_frames(&mut tag, rg);
+    write_tag_direct(path, &tag)
 }
 
 /// Delete all ReplayGain and undo TXXX frames from ID3v2 tag

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -99,6 +99,11 @@ fn process_apply_into(
     apply_opts.use_temp_file = opts.use_temp_file;
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.use_id3v2 = opts.use_id3v2;
+    // Same reasoning as the dry-run branch above: without -k the steps are
+    // never capped, and under -c/-q the clipping warning is never emitted, so
+    // the headroom analyze inside check_clipping feeds nothing observable
+    // (issue #232).
+    apply_opts.skip_clipping_check = !opts.prevent_clipping && (opts.ignore_clipping || opts.quiet);
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
@@ -300,6 +305,10 @@ fn process_apply_channel_into(
     apply_opts.use_temp_file = opts.use_temp_file;
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.use_id3v2 = opts.use_id3v2;
+    // The channel path never surfaces ApplyReport::clipping_detected and -l
+    // has no clipping prevention, so the headroom analyze inside
+    // check_clipping is pure waste (issue #232).
+    apply_opts.skip_clipping_check = true;
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -104,6 +104,7 @@ fn process_track_gain_into(
             }
 
             apply_replaygain_with_album_into(file, modified_steps, &result, opts, None, out)
+                .map(|(r, _)| r)
         }
         Err(e) => {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
@@ -120,16 +121,23 @@ fn process_track_gain_into(
     }
 }
 
+/// Per-file result, buffered text output, and the post-apply `(max, min)`
+/// global_gain range from [`mp3rgain::ApplyReport::gain_range`] so album mode
+/// can build `MP3GAIN_ALBUM_MINMAX` without re-analyzing every file
+/// (issue #232).
+pub type ApplyWithAlbumOutcome = (JsonFileResult, String, Option<(u8, u8)>);
+
 pub fn process_apply_replaygain_with_album(
     file: &Path,
     steps: i32,
     result: &ReplayGainResult,
     opts: &Options,
     album_info: Option<&AacAlbumInfo>,
-) -> Result<(JsonFileResult, String)> {
+) -> Result<ApplyWithAlbumOutcome> {
     let mut out = String::new();
-    let r = apply_replaygain_with_album_into(file, steps, result, opts, album_info, &mut out)?;
-    Ok((r, out))
+    let (r, range) =
+        apply_replaygain_with_album_into(file, steps, result, opts, album_info, &mut out)?;
+    Ok((r, out, range))
 }
 
 fn apply_replaygain_with_album_into(
@@ -139,7 +147,7 @@ fn apply_replaygain_with_album_into(
     opts: &Options,
     album_info: Option<&AacAlbumInfo>,
     out: &mut String,
-) -> Result<JsonFileResult> {
+) -> Result<(JsonFileResult, Option<(u8, u8)>)> {
     let filename = get_filename(file);
     let dry_run_prefix = opts.dry_run_prefix();
     let is_aac = result.file_type() == AudioFileType::Aac;
@@ -166,17 +174,20 @@ fn apply_replaygain_with_album_into(
                 actual_steps,
             )?;
         }
-        return Ok(JsonFileResult {
-            file: file.display().to_string(),
-            status: Some(FileStatus::DryRun),
-            loudness_db: Some(result.loudness_db()),
-            peak: Some(result.peak()),
-            gain_applied_steps: Some(actual_steps),
-            gain_applied_db: Some(steps_to_db(actual_steps)),
-            warning: warning_msg,
-            dry_run: Some(true),
-            ..Default::default()
-        });
+        return Ok((
+            JsonFileResult {
+                file: file.display().to_string(),
+                status: Some(FileStatus::DryRun),
+                loudness_db: Some(result.loudness_db()),
+                peak: Some(result.peak()),
+                gain_applied_steps: Some(actual_steps),
+                gain_applied_db: Some(steps_to_db(actual_steps)),
+                warning: warning_msg,
+                dry_run: Some(true),
+                ..Default::default()
+            },
+            None,
+        ));
     }
 
     // AAC keeps a fail-soft tag-writing path: bitstream gain failures
@@ -192,7 +203,8 @@ fn apply_replaygain_with_album_into(
             album_info,
             dry_run_prefix,
             out,
-        );
+        )
+        .map(|r| (r, None));
     }
 
     // MP3 path: hand the whole pipeline to apply_with_options.
@@ -225,29 +237,35 @@ fn apply_replaygain_with_album_into(
                 )?;
             }
 
-            Ok(JsonFileResult {
-                file: file.display().to_string(),
-                status: Some(FileStatus::Success),
-                frames: Some(report.modified),
-                loudness_db: Some(result.loudness_db()),
-                peak: Some(result.peak()),
-                gain_applied_steps: Some(report.actual_steps),
-                gain_applied_db: Some(steps_to_db(report.actual_steps)),
-                warning: warning_msg,
-                ..Default::default()
-            })
+            Ok((
+                JsonFileResult {
+                    file: file.display().to_string(),
+                    status: Some(FileStatus::Success),
+                    frames: Some(report.modified),
+                    loudness_db: Some(result.loudness_db()),
+                    peak: Some(result.peak()),
+                    gain_applied_steps: Some(report.actual_steps),
+                    gain_applied_db: Some(steps_to_db(report.actual_steps)),
+                    warning: warning_msg,
+                    ..Default::default()
+                },
+                report.gain_range,
+            ))
         }
         Err(e) => {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 eprintln!("  {} {} - {}", "x".red(), filename, e);
             }
 
-            Ok(JsonFileResult {
-                file: file.display().to_string(),
-                status: Some(FileStatus::Error),
-                error: Some(e.to_string()),
-                ..Default::default()
-            })
+            Ok((
+                JsonFileResult {
+                    file: file.display().to_string(),
+                    status: Some(FileStatus::Error),
+                    error: Some(e.to_string()),
+                    ..Default::default()
+                },
+                None,
+            ))
         }
     }
 }


### PR DESCRIPTION
Cuts redundant full-file reads/rewrites in the gain-apply paths. Re-evaluated against current master (after #244 / #246), so some of the issue's original findings were already partially addressed; this PR closes what remained.

## 1. ID3v2 apply (`-s i`)

- The undo frame write no longer runs a full `analyze()` for post-apply MP3GAIN_MINMAX: a full (non-channel, non-zero-step) apply reuses the gain range already tracked by the apply pass (#231). Channel and zero-step applies still scan, but on the temp file inside the same write.
- The undo/MINMAX frames and the `REPLAYGAIN_*` frames are now written in a single tag write on the temp file before the rename (previously the RG frames were a second copy+rewrite+rename of the whole file after #246's merged undo write). This also extends #227's atomicity to the RG frames.

## 2. APE / album mode

- The `REPLAYGAIN_*` items are folded into the APEv2 tag the gain apply already rewrites, removing the second full read+rewrite per file. Wrap mode and saturated applies (which need post-apply reanalysis) and channel applies keep the separate re-write, preserving exact tag values in all cases.
- The APE undo path reuses the apply pass's own gain range for MP3GAIN_MINMAX instead of re-scanning the modified buffer (same frame walk, identical values).
- `write_album_minmax` now takes per-file post-apply `(max, min)` ranges from the apply reports (threaded through the CLI album command and the GUI worker), falling back to `analyze()` only for files without one (AAC members, zero-frame or failed applies). For an N-track album this removes N full-file analyze passes.
- Not done: the issue's `set_len` + append idea for `MP3GAIN_ALBUM_MINMAX` — it would trade away #227's atomic temp+rename write, so that pass (1 read + 1 write per file, only known after the whole album is applied) is kept as-is.

## 3. Channel apply / `-c` / `-q`

- New `ApplyOptions::skip_clipping_check`: the channel path never surfaces `ApplyReport::clipping_detected` and `-l` has no `-k` cap, so the headroom `analyze()` inside `check_clipping` was pure waste — now skipped.
- The non-dry-run manual-gain path now skips the same check under `-c`/`-q` (without `-k`), fixing the inconsistency where the dry-run branch already skipped it. The flag is ignored when `prevent_clipping` is set.
- The Joint Stereo warning's `analyze()` stays (already gated on text output), and the channel ID3v2 MINMAX scan stays (the apply stats only cover one channel's gains).

## Verification

- `cargo fmt` / `cargo build` / `cargo test` (125 tests) / `cargo clippy -- -D warnings` green for both crates; mp3rgui builds and links.
- Byte-level parity against a master-built binary on fixture copies: `-g` (APE + ID3v2), `-r` (APE + ID3v2), `-a` with 2 files (APE incl. ALBUM_MINMAX + ID3v2), `-l` left/right (APE + ID3v2), `-w`, `-g -c`, and text/tsv output — all outputs byte-identical to master.
- Undo round-trips: APE and ID3v2 undo results are byte-identical to master's undo output; APE round-trips restore the original bytes (the known pre-existing exceptions — saturated applies and the id3 crate re-encoding a pre-existing ID3v2 tag — behave identically on master).

Note: `write_album_minmax` and `process_apply_replaygain_with_album` signatures changed (they now carry the gain ranges); both in-repo callers (CLI + GUI) are updated.

Fixes #232