### PR TITLE
Make -s r a compatibility no-op with a notice

### DIFF
--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -13,11 +13,9 @@ pub enum OutputFormat {
 pub enum StoredTagMode {
     #[default]
     None, // Default behavior
-    Check,    // -s c: Check/show stored tag info
-    Delete,   // -s d: Delete stored tag info
-    Skip,     // -s s: Skip (ignore) stored tag info
-    Recalc,   // -s r: Force recalculation
-    UseApev2, // -s a: Use APEv2 tags (default)
+    Check,  // -s c: Check/show stored tag info
+    Delete, // -s d: Delete stored tag info
+    Skip,   // -s s: Skip (don't write) stored tag info
 }
 
 #[derive(Default)]
@@ -29,14 +27,18 @@ pub struct Options {
     pub gain_modifier: i32,    // -m <i>: modify suggested gain by integer steps
 
     // Mode options
-    pub undo: bool,                     // -u
-    pub stored_tag_mode: StoredTagMode, // -s <mode>
-    pub use_id3v2: bool,                // -s i: use ID3v2 tags instead of APEv2
-    pub track_gain: bool,               // -r (apply track gain)
-    pub album_gain: bool,               // -a (apply album gain)
-    pub skip_album: bool,               // -e: skip album analysis
-    pub max_amplitude_only: bool,       // -x: only find max amplitude
-    pub track_index: Option<u32>,       // -i <index>: track index for multi-track files
+    pub undo: bool, // -u
+    // -s <mode>. Orthogonal to `use_id3v2`: the mode says *what* to do with
+    // stored tags (check / delete / skip writing), while `use_id3v2` says
+    // *where* they live (-s i: ID3v2 frames, -s a: APEv2, the default).
+    pub stored_tag_mode: StoredTagMode,
+    pub use_id3v2: bool,    // -s i: use ID3v2 tags instead of APEv2 (-s a resets)
+    pub force_recalc: bool, // -s r: accepted for compatibility (always recalculates)
+    pub track_gain: bool,   // -r (apply track gain)
+    pub album_gain: bool,   // -a (apply album gain)
+    pub skip_album: bool,   // -e: skip album analysis
+    pub max_amplitude_only: bool, // -x: only find max amplitude
+    pub track_index: Option<u32>, // -i <index>: track index for multi-track files
 
     // Behavior options
     pub preserve_timestamp: bool,    // -p

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -106,11 +106,12 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                         "c" => opts.stored_tag_mode = StoredTagMode::Check,
                         "d" => opts.stored_tag_mode = StoredTagMode::Delete,
                         "s" => opts.stored_tag_mode = StoredTagMode::Skip,
-                        "r" => opts.stored_tag_mode = StoredTagMode::Recalc,
-                        "i" => {
-                            opts.use_id3v2 = true;
-                        }
-                        "a" => opts.stored_tag_mode = StoredTagMode::UseApev2,
+                        // mp3gain compatibility: mp3rgain never reads stored
+                        // tags as an analysis cache, so "force recalculation"
+                        // is always in effect. Accepted with a notice (#253).
+                        "r" => opts.force_recalc = true,
+                        "i" => opts.use_id3v2 = true,
+                        "a" => opts.use_id3v2 = false,
                         other => {
                             eprintln!(
                                 "{}: unknown -s mode '{}', use c/d/s/r/i/a",
@@ -491,17 +492,16 @@ mod tests {
             parse_args(&args(&["-s", "s"])).unwrap().stored_tag_mode,
             StoredTagMode::Skip
         );
-        assert_eq!(
-            parse_args(&args(&["-s", "r"])).unwrap().stored_tag_mode,
-            StoredTagMode::Recalc
-        );
-        assert_eq!(
-            parse_args(&args(&["-s", "a"])).unwrap().stored_tag_mode,
-            StoredTagMode::UseApev2
-        );
-        // -s i sets use_id3v2 instead of stored_tag_mode
+        // -s r is a compatibility no-op flag, not a mode (#253)
+        let opts = parse_args(&args(&["-s", "r"])).unwrap();
+        assert!(opts.force_recalc);
+        assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
+        // -s i / -s a toggle the tag format; last one wins
         let opts = parse_args(&args(&["-s", "i"])).unwrap();
         assert!(opts.use_id3v2);
+        let opts = parse_args(&args(&["-s", "i", "-s", "a"])).unwrap();
+        assert!(!opts.use_id3v2);
+        assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
     }
 
     #[test]

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -35,8 +35,8 @@ pub fn print_usage() {
     println!("    -s <mode>   Stored tag handling:");
     println!("                  c = check/show stored tag info");
     println!("                  d = delete stored tag info");
-    println!("                  s = skip (ignore) stored tag info");
-    println!("                  r = force recalculation");
+    println!("                  s = skip (don't write) stored tag info");
+    println!("                  r = force recalculation (always on; kept for compatibility)");
     println!("                  i = use ID3v2 tags (not fully supported)");
     println!("                  a = use APEv2 tags (default)");
     println!("    -p          Preserve original file timestamp");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,6 +49,15 @@ pub fn run(mut opts: Options) -> Result<()> {
         );
     }
 
+    // -s r warning: mp3rgain never reads stored tags as an analysis cache,
+    // so recalculation is always in effect (issue #253)
+    if opts.force_recalc && !opts.quiet && opts.output_format == OutputFormat::Text {
+        eprintln!(
+            "{}: -s r (force recalculation) is accepted for compatibility but has no effect (mp3rgain always recalculates)",
+            "note".cyan()
+        );
+    }
+
     // Determine action based on options
     if opts.max_amplitude_only {
         // -x: only find max amplitude


### PR DESCRIPTION
## Summary

`StoredTagMode::Recalc` (`-s r`) and `StoredTagMode::UseApev2` (`-s a`) were set by the parser but never read anywhere — `-s r` was silently a no-op that contradicted the help text.

Since mp3rgain never reads stored tags as an analysis cache, "force recalculation" is **always** in effect. Rather than pretending to implement it, this takes the issue's second option:

- `-s r` now sets a `force_recalc` flag and prints the same `note: ... accepted for compatibility but has no effect` notice used for `-f`
- `-s a` now resets `use_id3v2`, giving it real last-wins semantics against `-s i` instead of setting a dead enum variant
- The dead `Recalc` / `UseApev2` variants are removed and the `stored_tag_mode` / `use_id3v2` orthogonality is documented on `Options` (mode = *what* to do with stored tags, `use_id3v2` = *where* they live)
- Usage text updated to match

Fixes #253

## Test plan
- `cargo test` passes (parse_args tests updated, incl. new `-s i -s a` last-wins case)
- Smoke test: `mp3rgain -s r file.mp3` prints the notice and proceeds normally