### PR TITLE
Read each file once in the default -g apply path

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -108,8 +108,9 @@ pub struct ApplyOptions {
 
     /// Skip the pre-apply clipping check entirely. For callers that will
     /// never surface [`ApplyReport::clipping_detected`] (`-c` / `-q`, or the
-    /// channel path), the headroom check's full-file `analyze()` is pure
-    /// waste (issue #232). Ignored when [`Self::prevent_clipping`] is on —
+    /// channel path), the headroom check's full-file frame walk is pure
+    /// waste (issue #232; the read itself is shared with the apply step
+    /// since issue #251). Ignored when [`Self::prevent_clipping`] is on —
     /// `-k` needs the check to cap the gain.
     pub skip_clipping_check: bool,
 }
@@ -211,9 +212,13 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     // it instead of a second scan (issue #188). MINMAX / ReplayGain are now
     // recorded from a *post-apply* scan (issue #210), so no pre-apply MP3
     // analysis needs to be threaded through here.
+    // The MP3 headroom check likewise keeps the bytes it read so the apply
+    // step below reuses them instead of a second full read + frame walk of
+    // the unchanged file (issue #251).
     let mut aac_analysis: AacAnalysisCache = None;
+    let mut mp3_data: Option<Vec<u8>> = None;
     let (actual_steps, clipping_prevented, clipping_detected) =
-        check_clipping(file_path, opts, is_aac, &mut aac_analysis)?;
+        check_clipping(file_path, opts, is_aac, &mut aac_analysis, &mut mp3_data)?;
 
     // 2) Apply gain to bytes. MP3 reports global_gain saturation (issue
     // #207); AAC clamps in its own path and isn't tallied here.
@@ -229,7 +234,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     let modified = if is_aac {
         apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
     } else if opts.use_id3v2 {
-        saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts)?;
+        saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts, mp3_data.take())?;
         saturation.frames
     } else {
         let folded_rg = if opts.write_replaygain_tags && opts.channel.is_none() && !opts.wrap {
@@ -238,7 +243,8 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
             None
         };
         ape_rg_folded = folded_rg.is_some();
-        saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts, folded_rg)?;
+        saturation =
+            apply_mp3_ape_bytes(file_path, actual_steps, opts, folded_rg, mp3_data.take())?;
         saturation.frames
     };
 
@@ -300,7 +306,7 @@ pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyRepor
     let is_aac = mp4meta::is_aac_file(file_path);
     let mut aac_analysis: AacAnalysisCache = None;
     let (actual_steps, clipping_prevented, clipping_detected) =
-        check_clipping(file_path, opts, is_aac, &mut aac_analysis)?;
+        check_clipping(file_path, opts, is_aac, &mut aac_analysis, &mut None)?;
     Ok(ApplyReport {
         modified: 0,
         actual_steps,
@@ -317,6 +323,7 @@ fn check_clipping(
     opts: &ApplyOptions,
     is_aac: bool,
     aac_analysis: &mut AacAnalysisCache,
+    mp3_data: &mut Option<Vec<u8>>,
 ) -> Result<(i32, bool, Option<ClippingDetection>)> {
     let steps = opts.steps;
     if opts.wrap || (opts.skip_clipping_check && !opts.prevent_clipping) {
@@ -381,7 +388,17 @@ fn check_clipping(
             None
         }
     } else {
-        crate::analyze(file_path).ok().map(|i| i.headroom_steps())
+        // Read once and keep the bytes in `mp3_data` so the apply step can
+        // reuse them instead of a second full read + frame walk (issue #251).
+        // A failed read leaves `None`; the apply step re-reads and surfaces
+        // the proper I/O error.
+        let data = std::fs::read(file_path).ok();
+        let headroom = data
+            .as_deref()
+            .and_then(|d| crate::analyze_data(d).ok())
+            .map(|i| i.headroom_steps());
+        *mp3_data = data;
+        headroom
     };
 
     if let Some(h) = headroom {
@@ -513,6 +530,7 @@ fn apply_mp3_ape_bytes(
     steps: i32,
     opts: &ApplyOptions,
     replaygain: Option<ape::ApeReplayGain>,
+    preread: Option<Vec<u8>>,
 ) -> Result<SaturationStats> {
     with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps)
@@ -524,7 +542,7 @@ fn apply_mp3_ape_bytes(
         if let Some(rg) = replaygain {
             gain = gain.replaygain(rg);
         }
-        gain.apply_to_path_with_stats(r, w)
+        gain.apply_to_path_with_stats_preread(r, w, preread)
     })
 }
 
@@ -532,6 +550,7 @@ fn apply_mp3_id3v2_bytes(
     file_path: &Path,
     steps: i32,
     opts: &ApplyOptions,
+    preread: Option<Vec<u8>>,
 ) -> Result<SaturationStats> {
     // APE undo is never written in `-s i` mode; undo/minmax and the
     // REPLAYGAIN_* values go into TXXX frames instead. All frames are written
@@ -543,7 +562,7 @@ fn apply_mp3_id3v2_bytes(
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
         }
-        let stats = gain.apply_to_path_with_stats(r, w)?;
+        let stats = gain.apply_to_path_with_stats_preread(r, w, preread)?;
 
         let mut rg = id3v2::Id3v2ReplayGain::default();
 
@@ -747,7 +766,7 @@ mod tests {
     fn prevent_clipping_caps_at_floor_not_round() {
         let opts = opts_with_track(5, 0.9, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(prevented);
         assert_eq!(steps, 0);
         let new_peak = 0.9 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -761,7 +780,7 @@ mod tests {
         for &peak in &[0.55_f64, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 0.99] {
             let opts = opts_with_track(20, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(
@@ -777,7 +796,7 @@ mod tests {
     fn prevent_clipping_passthrough_when_safe() {
         let opts = opts_with_track(3, 0.5, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(!prevented);
         assert_eq!(steps, 3);
     }
@@ -793,7 +812,7 @@ mod tests {
         // = -2 steps (= -3 dB). Resulting peak = 1.2 * 10^(-3/20) = 0.85.
         let opts = opts_with_track(1, 1.2, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(prevented);
         assert!(steps < 0, "expected negative steps, got {steps}");
         let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -810,7 +829,7 @@ mod tests {
     fn prevent_clipping_caps_zero_step_clipping_track() {
         let opts = opts_with_track(0, 1.2, true);
         let (steps, prevented, _) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert!(prevented);
         assert!(steps < 0, "expected attenuation, got {steps}");
         let new_peak = 1.2 * 10.0_f64.powf(steps_to_db(steps) / 20.0);
@@ -823,7 +842,7 @@ mod tests {
     fn zero_step_non_clipping_track_is_noop() {
         let opts = opts_with_track(0, 0.8, true);
         let (steps, prevented, detected) =
-            check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+            check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
         assert_eq!(steps, 0);
         assert!(!prevented);
         assert!(detected.is_none());
@@ -837,7 +856,7 @@ mod tests {
         for &peak in &[1.001_f64, 1.05, 1.1, 1.2, 1.5, 2.0] {
             let opts = opts_with_track(5, peak, true);
             let (steps, prevented, _) =
-                check_clipping(Path::new("unused"), &opts, false, &mut None).unwrap();
+                check_clipping(Path::new("unused"), &opts, false, &mut None, &mut None).unwrap();
             assert!(prevented, "peak {peak} should trigger prevention");
             let new_peak = peak * 10.0_f64.powf(steps_to_db(steps) / 20.0);
             assert!(

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -180,28 +180,54 @@ impl GainOptions {
         read_from: &Path,
         write_to: &Path,
     ) -> Result<SaturationStats> {
+        self.apply_to_path_with_stats_preread(read_from, write_to, None)
+    }
+
+    /// [`apply_to_path_with_stats`] variant that accepts the file's bytes if
+    /// a caller already read them. The apply pipeline's clipping check reads
+    /// the file for its headroom scan; handing that buffer through here saves
+    /// a second full read of the unchanged file (issue #251). `read_from` is
+    /// still used for error reporting and when `preread` is `None`.
+    pub(crate) fn apply_to_path_with_stats_preread(
+        &self,
+        read_from: &Path,
+        write_to: &Path,
+        preread: Option<Vec<u8>>,
+    ) -> Result<SaturationStats> {
         let same_path = read_from == write_to;
+        let read = |preread: Option<Vec<u8>>| match preread {
+            Some(data) => Ok(data),
+            None => fs::read(read_from).map_err(|e| Error::io_read(read_from, e)),
+        };
 
         if self.steps == 0 {
             // No undo/minmax on a zero-step apply (nothing to undo), but the
             // ReplayGain items still need to be recorded when requested.
             if let Some(rg) = &self.replaygain {
-                let data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
+                let data = read(preread)?;
                 let mut tag = read_ape_tag(&data).unwrap_or_default();
                 tag.set_replaygain(rg);
                 let new_data = replace_ape_tag(&data, &tag);
                 fs::write(write_to, &new_data).map_err(|e| Error::io_write(write_to, e))?;
             } else if !same_path {
-                fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
+                match preread {
+                    Some(data) => {
+                        fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
+                    }
+                    None => {
+                        fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
+                    }
+                }
             }
             return Ok(SaturationStats::default());
         }
 
+        let data = read(preread)?;
         if let Some(channel) = self.channel {
             if self.undo {
-                apply_gain_channel_with_undo(read_from, write_to, channel, self.steps)
+                apply_gain_channel_with_undo(data, write_to, channel, self.steps)
             } else {
-                apply_gain_channel_impl(read_from, write_to, channel, self.steps)
+                apply_gain_channel_impl(data, write_to, channel, self.steps)
             }
         } else {
             let mode = if self.wrap {
@@ -211,7 +237,7 @@ impl GainOptions {
             };
             if self.undo {
                 apply_gain_with_undo_impl_to_path(
-                    read_from,
+                    data,
                     write_to,
                     self.steps,
                     mode,
@@ -219,7 +245,7 @@ impl GainOptions {
                 )
             } else {
                 apply_gain_simple_to_path(
-                    read_from,
+                    data,
                     write_to,
                     self.steps,
                     mode,
@@ -345,16 +371,14 @@ pub fn would_clip(peak: f64, gain_db: f64) -> bool {
 // =============================================================================
 
 /// Simple gain application (no undo tag).
-/// Reads from `read_from` and writes the modified bytes to `write_to`.
+/// Modifies the file's bytes in `data` and writes them to `write_to`.
 fn apply_gain_simple_to_path(
-    read_from: &Path,
+    mut data: Vec<u8>,
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
     replaygain: Option<&ApeReplayGain>,
 ) -> Result<SaturationStats> {
-    let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
-
     let stats = apply_gain_to_data(&mut data, gain_steps, mode, None);
 
     if let Some(rg) = replaygain {
@@ -375,14 +399,12 @@ fn apply_gain_simple_to_path(
 /// one write. The previous version re-read the file for each step (4 reads +
 /// 2 writes per apply), which dominated batch throughput.
 fn apply_gain_with_undo_impl_to_path(
-    read_from: &Path,
+    mut data: Vec<u8>,
     write_to: &Path,
     gain_steps: i32,
     mode: GainMode,
     replaygain: Option<&ApeReplayGain>,
 ) -> Result<SaturationStats> {
-    let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
-
     let mut tag = read_ape_tag(&data).unwrap_or_default();
 
     // Accumulate into BOTH channel slots independently: a prior `-l`
@@ -425,12 +447,11 @@ fn apply_gain_with_undo_impl_to_path(
 
 /// Apply gain to a specific channel (no undo)
 fn apply_gain_channel_impl(
-    read_from: &Path,
+    mut data: Vec<u8>,
     write_to: &Path,
     channel: Channel,
     gain_steps: i32,
 ) -> Result<SaturationStats> {
-    let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
     let analysis = analyze_data(&data)?;
     if analysis.channel_mode() == ChannelMode::Mono {
         return Err(Error::ChannelGainOnMono);
@@ -450,12 +471,11 @@ fn apply_gain_channel_impl(
 
 /// Apply channel-specific gain and store undo information in APEv2 tag
 fn apply_gain_channel_with_undo(
-    read_from: &Path,
+    mut data: Vec<u8>,
     write_to: &Path,
     channel: Channel,
     gain_steps: i32,
 ) -> Result<SaturationStats> {
-    let mut data = fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
     let analysis = analyze_data(&data)?;
     if analysis.channel_mode() == ChannelMode::Mono {
         return Err(Error::ChannelGainOnMono);


### PR DESCRIPTION
## Summary

The default text-mode apply (`mp3rgain -g N *.mp3` without `-c`/`-k`/`-q`) read and frame-walked each file twice: `check_clipping` called `analyze()` (full `fs::read` + frame scan) solely for the headroom clipping warning, then the apply step re-read the unchanged file for the actual gain apply. #232 removed the check for `-c`/`-q`/channel callers; this covers the plain default invocation.

## Changes
- `check_clipping` reads the bytes itself, runs `analyze_data` on the buffer, and hands it back via a new `&mut Option<Vec<u8>>` cache param (mirroring the existing AAC analysis cache from #188).
- `apply_mp3_ape_bytes` / `apply_mp3_id3v2_bytes` pass the cached buffer through to `GainOptions::apply_to_path_with_stats_preread`, which uses it instead of a second `fs::read`.
- The internal gain impl functions now take the file bytes (`Vec<u8>`) directly; the public `apply` / `apply_to_path` API is unchanged.
- A failed read at check time leaves the cache `None`; the apply step re-reads and surfaces the proper I/O error, preserving existing error behavior.

Roughly halves I/O and parse time for the most common apply invocation on large batches.

## Test plan
- `cargo test --all-features` — 59+39+29 tests pass; `cargo check --no-default-features` and mp3rgui check clean
- End-to-end: release binaries from master and this branch produce **byte-identical** files for `-g 2` across all fixtures and for a `-k -g 20` clipping-capped apply

Fixes #251