### PR TITLE
refactor: unify stored-tag reading dispatch between CLI and GUI

### DIFF
--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -13,11 +13,7 @@ use mp3rgain::apply::{
     ApplyOptions,
 };
 use mp3rgain::replaygain::{self, ReplayGainResult};
-use mp3rgain::{
-    id3v2, mp4meta, read_ape_tag_from_file, AacAlbumInfo, Channel, TAG_MP3GAIN_MINMAX,
-    TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
-    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
-};
+use mp3rgain::{read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -834,7 +830,7 @@ pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>
 /// Spawn the stored-tag scanner. Iterates files serially (tag reads are
 /// I/O-light) and emits `StoredTagsRead` for each.
 ///
-/// Dispatch mirrors the CLI's `process_check_tags`:
+/// Dispatch is shared with the CLI via `mp3rgain::read_gain_tags_auto`:
 ///   - AAC: MP4 freeform RG + undo
 ///   - MP3 + `use_id3v2`: ID3v2 TXXX RG
 ///   - MP3: APE
@@ -876,46 +872,27 @@ pub fn spawn_check_stored_tags(
 }
 
 fn read_stored_tags(path: &Path, use_id3v2: bool) -> StoredTagsView {
-    if mp4meta::is_aac_file(path) {
-        let undo_tags = mp4meta::read_undo_tags(path).unwrap_or_default();
-        let rg_tags = mp4meta::read_replaygain_tags(path).unwrap_or_default();
-        return StoredTagsView {
-            format: Some("MP4"),
-            track_gain: rg_tags.track_gain().map(str::to_string),
-            track_peak: rg_tags.track_peak().map(str::to_string),
-            album_gain: rg_tags.album_gain().map(str::to_string),
-            album_peak: rg_tags.album_peak().map(str::to_string),
-            undo: undo_tags.undo().map(str::to_string),
-            minmax: undo_tags.minmax().map(str::to_string),
-        };
-    }
-    if use_id3v2 {
-        let rg = id3v2::read_id3v2_replaygain(path).unwrap_or_default();
-        return StoredTagsView {
-            format: Some("ID3v2"),
-            track_gain: rg.track_gain,
-            track_peak: rg.track_peak,
-            album_gain: rg.album_gain,
-            album_peak: rg.album_peak,
-            undo: rg.undo,
-            minmax: rg.minmax,
-        };
-    }
-    // APE
-    if let Ok(Some(tag)) = read_ape_tag_from_file(path) {
-        return StoredTagsView {
-            format: Some("APE"),
-            track_gain: tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string),
-            track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK).map(str::to_string),
-            album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN).map(str::to_string),
-            album_peak: tag.get(TAG_REPLAYGAIN_ALBUM_PEAK).map(str::to_string),
-            undo: tag.get(TAG_MP3GAIN_UNDO).map(str::to_string),
-            minmax: tag.get(TAG_MP3GAIN_MINMAX).map(str::to_string),
-        };
-    }
-    StoredTagsView {
-        format: Some("APE"),
-        ..Default::default()
+    match read_gain_tags_auto(path, use_id3v2) {
+        Ok(tags) => StoredTagsView {
+            format: Some(match tags.source {
+                GainTagSource::Aac => "MP4",
+                GainTagSource::Id3v2 => "ID3v2",
+                GainTagSource::Ape { .. } => "APE",
+            }),
+            track_gain: tags.track_gain,
+            track_peak: tags.track_peak,
+            album_gain: tags.album_gain,
+            album_peak: tags.album_peak,
+            undo: tags.undo,
+            minmax: tags.minmax,
+        },
+        // Read error: render as an empty tag set, like the pre-unification
+        // fail-soft branches did. The AAC branch never errors, so the label
+        // follows the MP3 tag mode.
+        Err(_) => StoredTagsView {
+            format: Some(if use_id3v2 { "ID3v2" } else { "APE" }),
+            ..Default::default()
+        },
     }
 }
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::{
-    id3v2, mp4meta, read_ape_tag_from_file, TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX,
-    TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
+    read_gain_tags_auto, GainTagSource, StoredGainTags, TAG_MP3GAIN_ALBUM_MINMAX,
+    TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
     TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use std::fmt::Write as _;
@@ -14,31 +14,15 @@ use crate::json_output::{FileStatus, JsonFileResult};
 use crate::processors::utils::{report_file_error, restore_timestamp, save_original_mtime};
 use crate::util::get_filename;
 
-/// Tag values and labels for display in cmd_check_tags
+/// Tags plus per-container labels for display in cmd_check_tags
 struct CheckTagInfo<'a> {
-    undo: Option<&'a str>,
-    minmax: Option<&'a str>,
-    album_minmax: Option<&'a str>,
-    track_gain: Option<&'a str>,
-    track_peak: Option<&'a str>,
-    album_gain: Option<&'a str>,
-    album_peak: Option<&'a str>,
+    tags: &'a StoredGainTags,
     undo_label: &'a str,
     minmax_label: &'a str,
     no_tag_msg: &'a str,
 }
 
 impl CheckTagInfo<'_> {
-    fn has_any(&self) -> bool {
-        self.undo.is_some()
-            || self.minmax.is_some()
-            || self.album_minmax.is_some()
-            || self.track_gain.is_some()
-            || self.track_peak.is_some()
-            || self.album_gain.is_some()
-            || self.album_peak.is_some()
-    }
-
     fn render(
         &self,
         filename: &str,
@@ -46,28 +30,29 @@ impl CheckTagInfo<'_> {
         format: OutputFormat,
         out: &mut String,
     ) -> Option<JsonFileResult> {
+        let tags = self.tags;
         match format {
             OutputFormat::Text => {
                 writeln!(out, "{}", filename.cyan().bold()).ok();
-                if let Some(v) = self.undo {
+                if let Some(v) = &tags.undo {
                     writeln!(out, "  {:<25}{}", format!("{}:", self.undo_label), v).ok();
                 }
-                if let Some(v) = self.minmax {
+                if let Some(v) = &tags.minmax {
                     writeln!(out, "  {:<25}{}", format!("{}:", self.minmax_label), v).ok();
                 }
                 let rg_fields = [
-                    (TAG_MP3GAIN_ALBUM_MINMAX, self.album_minmax),
-                    (TAG_REPLAYGAIN_TRACK_GAIN, self.track_gain),
-                    (TAG_REPLAYGAIN_TRACK_PEAK, self.track_peak),
-                    (TAG_REPLAYGAIN_ALBUM_GAIN, self.album_gain),
-                    (TAG_REPLAYGAIN_ALBUM_PEAK, self.album_peak),
+                    (TAG_MP3GAIN_ALBUM_MINMAX, &tags.album_minmax),
+                    (TAG_REPLAYGAIN_TRACK_GAIN, &tags.track_gain),
+                    (TAG_REPLAYGAIN_TRACK_PEAK, &tags.track_peak),
+                    (TAG_REPLAYGAIN_ALBUM_GAIN, &tags.album_gain),
+                    (TAG_REPLAYGAIN_ALBUM_PEAK, &tags.album_peak),
                 ];
                 for (label, value) in rg_fields {
                     if let Some(v) = value {
                         writeln!(out, "  {:<25}{}", format!("{}:", label), v).ok();
                     }
                 }
-                if !self.has_any() {
+                if !tags.has_any() {
                     writeln!(out, "  ({})", self.no_tag_msg).ok();
                 }
                 writeln!(out).ok();
@@ -78,20 +63,20 @@ impl CheckTagInfo<'_> {
                     out,
                     "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     filename,
-                    self.undo.unwrap_or("-"),
-                    self.minmax.unwrap_or("-"),
-                    self.track_gain.unwrap_or("-"),
-                    self.track_peak.unwrap_or("-"),
-                    self.album_gain.unwrap_or("-"),
-                    self.album_peak.unwrap_or("-"),
-                    self.album_minmax.unwrap_or("-")
+                    tags.undo.as_deref().unwrap_or("-"),
+                    tags.minmax.as_deref().unwrap_or("-"),
+                    tags.track_gain.as_deref().unwrap_or("-"),
+                    tags.track_peak.as_deref().unwrap_or("-"),
+                    tags.album_gain.as_deref().unwrap_or("-"),
+                    tags.album_peak.as_deref().unwrap_or("-"),
+                    tags.album_minmax.as_deref().unwrap_or("-")
                 )
                 .ok();
                 None
             }
             OutputFormat::Json => Some(JsonFileResult {
                 file: file_path.display().to_string(),
-                status: Some(if self.has_any() {
+                status: Some(if tags.has_any() {
                     FileStatus::Success
                 } else {
                     FileStatus::NoTag
@@ -214,81 +199,34 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
     let filename = get_filename(file);
     let mut out = String::new();
 
-    let is_aac = mp4meta::is_aac_file(file);
+    let tags = match read_gain_tags_auto(file, opts.use_id3v2) {
+        Ok(tags) => tags,
+        Err(e) => return (tag_read_error(file, filename, e, opts), out),
+    };
 
-    if is_aac {
-        let undo_tags = mp4meta::read_undo_tags(file).unwrap_or_default();
-        let rg_tags = mp4meta::read_replaygain_tags(file).unwrap_or_default();
+    let (undo_label, minmax_label, no_tag_msg) = match tags.source {
+        GainTagSource::Aac => ("MP3RGAIN_UNDO", "MP3RGAIN_MINMAX", "no tags found"),
+        GainTagSource::Id3v2 => (
+            TAG_MP3GAIN_UNDO,
+            TAG_MP3GAIN_MINMAX,
+            "no ID3v2 ReplayGain tags found",
+        ),
+        GainTagSource::Ape { tag_present: true } => (
+            TAG_MP3GAIN_UNDO,
+            TAG_MP3GAIN_MINMAX,
+            "no mp3gain tags found",
+        ),
+        GainTagSource::Ape { tag_present: false } => {
+            (TAG_MP3GAIN_UNDO, TAG_MP3GAIN_MINMAX, "no APE tag found")
+        }
+    };
 
-        let info = CheckTagInfo {
-            undo: undo_tags.undo(),
-            minmax: undo_tags.minmax(),
-            album_minmax: None,
-            track_gain: rg_tags.track_gain(),
-            track_peak: rg_tags.track_peak(),
-            album_gain: rg_tags.album_gain(),
-            album_peak: rg_tags.album_peak(),
-            undo_label: "MP3RGAIN_UNDO",
-            minmax_label: "MP3RGAIN_MINMAX",
-            no_tag_msg: "no tags found",
-        };
-        let json = info.render(filename, file, opts.output_format, &mut out);
-        (json, out)
-    } else if opts.use_id3v2 {
-        match id3v2::read_id3v2_replaygain(file) {
-            Ok(rg) => {
-                let info = CheckTagInfo {
-                    undo: rg.undo.as_deref(),
-                    minmax: rg.minmax.as_deref(),
-                    album_minmax: None,
-                    track_gain: rg.track_gain.as_deref(),
-                    track_peak: rg.track_peak.as_deref(),
-                    album_gain: rg.album_gain.as_deref(),
-                    album_peak: rg.album_peak.as_deref(),
-                    undo_label: TAG_MP3GAIN_UNDO,
-                    minmax_label: TAG_MP3GAIN_MINMAX,
-                    no_tag_msg: "no ID3v2 ReplayGain tags found",
-                };
-                let json = info.render(filename, file, opts.output_format, &mut out);
-                (json, out)
-            }
-            Err(e) => (tag_read_error(file, filename, e, opts), out),
-        }
-    } else {
-        match read_ape_tag_from_file(file) {
-            Ok(Some(tag)) => {
-                let info = CheckTagInfo {
-                    undo: tag.get(TAG_MP3GAIN_UNDO),
-                    minmax: tag.get(TAG_MP3GAIN_MINMAX),
-                    album_minmax: tag.get(TAG_MP3GAIN_ALBUM_MINMAX),
-                    track_gain: tag.get(TAG_REPLAYGAIN_TRACK_GAIN),
-                    track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK),
-                    album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN),
-                    album_peak: tag.get(TAG_REPLAYGAIN_ALBUM_PEAK),
-                    undo_label: TAG_MP3GAIN_UNDO,
-                    minmax_label: TAG_MP3GAIN_MINMAX,
-                    no_tag_msg: "no mp3gain tags found",
-                };
-                let json = info.render(filename, file, opts.output_format, &mut out);
-                (json, out)
-            }
-            Ok(None) => {
-                let info = CheckTagInfo {
-                    undo: None,
-                    minmax: None,
-                    album_minmax: None,
-                    track_gain: None,
-                    track_peak: None,
-                    album_gain: None,
-                    album_peak: None,
-                    undo_label: TAG_MP3GAIN_UNDO,
-                    minmax_label: TAG_MP3GAIN_MINMAX,
-                    no_tag_msg: "no APE tag found",
-                };
-                let json = info.render(filename, file, opts.output_format, &mut out);
-                (json, out)
-            }
-            Err(e) => (tag_read_error(file, filename, e, opts), out),
-        }
-    }
+    let info = CheckTagInfo {
+        tags: &tags,
+        undo_label,
+        minmax_label,
+        no_tag_msg,
+    };
+    let json = info.render(filename, file, opts.output_format, &mut out);
+    (json, out)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,114 @@ pub fn delete_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<()> {
     }
 }
 
+/// Tag store a [`StoredGainTags`] snapshot was read from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GainTagSource {
+    /// MP4/AAC iTunes freeform tags.
+    Aac,
+    /// ID3v2 TXXX frames.
+    Id3v2,
+    /// APEv2 tag. `tag_present` distinguishes a file with no APE tag at all
+    /// from one whose APE tag simply carries no mp3gain items.
+    Ape { tag_present: bool },
+}
+
+/// Owned snapshot of the gain tags stored in one file, as returned by
+/// [`read_gain_tags_auto`]. `None` means the tag is absent (not an error).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredGainTags {
+    pub source: GainTagSource,
+    pub track_gain: Option<String>,
+    pub track_peak: Option<String>,
+    pub album_gain: Option<String>,
+    pub album_peak: Option<String>,
+    pub undo: Option<String>,
+    pub minmax: Option<String>,
+    /// APE-only `MP3GAIN_ALBUM_MINMAX`; always `None` for AAC and ID3v2.
+    pub album_minmax: Option<String>,
+}
+
+impl StoredGainTags {
+    fn empty(source: GainTagSource) -> Self {
+        Self {
+            source,
+            track_gain: None,
+            track_peak: None,
+            album_gain: None,
+            album_peak: None,
+            undo: None,
+            minmax: None,
+            album_minmax: None,
+        }
+    }
+
+    /// True if at least one gain tag is present.
+    pub fn has_any(&self) -> bool {
+        self.track_gain.is_some()
+            || self.track_peak.is_some()
+            || self.album_gain.is_some()
+            || self.album_peak.is_some()
+            || self.undo.is_some()
+            || self.minmax.is_some()
+            || self.album_minmax.is_some()
+    }
+}
+
+/// Read stored gain tags (ReplayGain plus mp3gain undo/minmax) without
+/// modifying the file, auto-dispatching by file format and tag mode.
+///
+/// Mirrors [`delete_gain_tags_auto`]'s dispatch: AAC files read the MP4
+/// freeform tags, MP3 files read ID3v2 when `use_id3v2` is set and APE
+/// otherwise. The AAC branch is fail-soft (unreadable tags come back
+/// empty); ID3v2/APE read errors are propagated.
+pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGainTags> {
+    #[cfg(feature = "aac")]
+    {
+        if mp4meta::is_aac_file(file_path) {
+            let undo_tags = mp4meta::read_undo_tags(file_path).unwrap_or_default();
+            let rg_tags = mp4meta::read_replaygain_tags(file_path).unwrap_or_default();
+            return Ok(StoredGainTags {
+                source: GainTagSource::Aac,
+                track_gain: rg_tags.track_gain().map(str::to_string),
+                track_peak: rg_tags.track_peak().map(str::to_string),
+                album_gain: rg_tags.album_gain().map(str::to_string),
+                album_peak: rg_tags.album_peak().map(str::to_string),
+                undo: undo_tags.undo().map(str::to_string),
+                minmax: undo_tags.minmax().map(str::to_string),
+                album_minmax: None,
+            });
+        }
+    }
+    if use_id3v2 {
+        let rg = id3v2::read_id3v2_replaygain(file_path)?;
+        return Ok(StoredGainTags {
+            source: GainTagSource::Id3v2,
+            track_gain: rg.track_gain,
+            track_peak: rg.track_peak,
+            album_gain: rg.album_gain,
+            album_peak: rg.album_peak,
+            undo: rg.undo,
+            minmax: rg.minmax,
+            album_minmax: None,
+        });
+    }
+    match ape::read_ape_tag_from_file(file_path)? {
+        Some(tag) => Ok(StoredGainTags {
+            source: GainTagSource::Ape { tag_present: true },
+            track_gain: tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string),
+            track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK).map(str::to_string),
+            album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN).map(str::to_string),
+            album_peak: tag.get(TAG_REPLAYGAIN_ALBUM_PEAK).map(str::to_string),
+            undo: tag.get(TAG_MP3GAIN_UNDO).map(str::to_string),
+            minmax: tag.get(TAG_MP3GAIN_MINMAX).map(str::to_string),
+            album_minmax: tag.get(TAG_MP3GAIN_ALBUM_MINMAX).map(str::to_string),
+        }),
+        None => Ok(StoredGainTags::empty(GainTagSource::Ape {
+            tag_present: false,
+        })),
+    }
+}
+
 /// Read the left-channel undo step count without modifying the file.
 ///
 /// Mirrors [`undo_gain_auto`]'s dispatch so the returned value matches what


### PR DESCRIPTION
Closes #265

## What

Adds `read_gain_tags_auto(path, use_id3v2) -> Result<StoredGainTags>` to the library's existing `*_auto` family in `src/lib.rs`, and rewrites both frontends to render from it:

- CLI: `process_check_tags` in `src/commands/tags.rs`
- GUI: `read_stored_tags` in `mp3rgui/src/worker.rs`

`StoredGainTags` is an owned snapshot (track/album gain+peak, undo, minmax, album_minmax) plus a `GainTagSource` enum (`Aac` / `Id3v2` / `Ape { tag_present }`). `CheckTagInfo` in the CLI now borrows the snapshot and only adds the per-container display labels.

## Semantics preserved

Per the design notes in the issue:

- AAC branch stays fail-soft (`unwrap_or_default`); ID3v2/APE read errors still propagate to stderr/JSON.
- `Ape { tag_present }` keeps the distinction between "no APE tag found" and "no mp3gain tags found".
- Per-container labels (`MP3RGAIN_*` for AAC vs `MP3GAIN_*` for MP3) are derived from the source enum.
- GUI error handling unchanged: a read error renders as an empty tag set with the format label following the tag mode.

## Verification

- `cargo test` passes; `cargo clippy` clean for the changed code (the one remaining warning is pre-existing in `src/replaygain.rs`).
- CLI output verified **byte-identical** against a master build: ran `-s c` with both binaries over APE-tagged, ID3v2-tagged, AAC-tagged (real `.m4a`), and untagged files, in each of text / tsv / json and in both APE and `-s i` modes, and diffed the outputs — no differences.

## Out of scope (follow-ups from the issue)

- Folding in `read_undo_steps`: its AAC branch currently returns `None` on a read error, while the unified reader is fail-soft there; folding it in would silently turn that `None` into `Some(0)`, so it was left as-is.
- Single-`moov`-read efficiency improvement for the AAC branch.