### PR TITLE
Add ITU-R BS.1770-4 gated loudness engine (issue #270)

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -749,7 +749,14 @@ mod tests {
     use crate::replaygain::AudioFileType;
 
     fn track_with_peak(peak: f64) -> ReplayGainResult {
-        ReplayGainResult::new(0.0, 0.0, peak, 44_100, AudioFileType::Mp3)
+        ReplayGainResult::new(
+            0.0,
+            0.0,
+            peak,
+            44_100,
+            AudioFileType::Mp3,
+            Default::default(),
+        )
     }
 
     fn opts_with_track(steps: i32, peak: f64, prevent_clipping: bool) -> ApplyOptions {

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -1,0 +1,452 @@
+//! ITU-R BS.1770-4 integrated loudness measurement (K-weighting + gating).
+//!
+//! This is the measurement engine behind the opt-in ReplayGain 2.0 (`--rg2`)
+//! and EBU R128 (`--r128`) analysis modes (issues #269 / #270). It runs
+//! alongside — never instead of — the ReplayGain 1.0 analyzer in
+//! [`crate::replaygain`], which stays the default for mp3gain compatibility.
+//!
+//! The pipeline per BS.1770-4:
+//!
+//! 1. K-weighting: a high-shelf ("head") filter cascaded with an RLB
+//!    high-pass, per channel. The spec tabulates coefficients only for
+//!    48 kHz; they are derived analytically here for any sample rate.
+//! 2. Gating blocks: 400 ms windows with 75% overlap (100 ms step).
+//!    Block energy is the channel-weighted mean square of the filtered
+//!    signal (weights: 1.0 for L/R/C, 1.41 for surround, 0 for LFE).
+//! 3. Gating: blocks below -70 LUFS are dropped (absolute gate); the mean
+//!    of the survivors minus 10 LU forms the relative gate; integrated
+//!    loudness is the mean energy of blocks passing both gates.
+//!
+//! Input samples are normalized floats (digital full scale = 1.0) — unlike
+//! the RG1 analyzer, which expects 16-bit-scaled samples, because LUFS is
+//! defined relative to full scale.
+
+/// The K-weighting cascade has ~+0.691 dB of gain at 997 Hz; BS.1770 cancels
+/// it with this constant so a 997 Hz reference tone reads its dBFS level.
+const LOUDNESS_OFFSET: f64 = -0.691;
+
+/// Absolute gating threshold from BS.1770-4.
+const ABSOLUTE_GATE_LUFS: f64 = -70.0;
+
+/// Relative gate sits this many LU below the mean of the absolutely-gated
+/// blocks; in energy terms a factor of 10^(-10/10) = 0.1.
+const RELATIVE_GATE_FACTOR: f64 = 0.1;
+
+fn energy_to_loudness(energy: f64) -> f64 {
+    LOUDNESS_OFFSET + 10.0 * energy.log10()
+}
+
+fn loudness_to_energy(lufs: f64) -> f64 {
+    10f64.powf((lufs - LOUDNESS_OFFSET) / 10.0)
+}
+
+/// Second-order IIR section, direct form II transposed.
+#[derive(Clone)]
+struct Biquad {
+    b0: f64,
+    b1: f64,
+    b2: f64,
+    a1: f64,
+    a2: f64,
+    z1: f64,
+    z2: f64,
+}
+
+impl Biquad {
+    fn new(coeffs: (f64, f64, f64, f64, f64)) -> Self {
+        let (b0, b1, b2, a1, a2) = coeffs;
+        Self {
+            b0,
+            b1,
+            b2,
+            a1,
+            a2,
+            z1: 0.0,
+            z2: 0.0,
+        }
+    }
+
+    #[inline]
+    fn process(&mut self, x: f64) -> f64 {
+        let y = self.b0 * x + self.z1;
+        self.z1 = self.b1 * x - self.a1 * y + self.z2;
+        self.z2 = self.b2 * x - self.a2 * y;
+        y
+    }
+}
+
+/// Stage-1 shelving filter coefficients `(b0, b1, b2, a1, a2)`.
+///
+/// Analytic derivation of the BS.1770 pre-filter for an arbitrary sample
+/// rate (same parameterization as libebur128, after Brecht De Man,
+/// "Evaluation of Implementations of the EBU R128 Loudness Measurement").
+/// At 48 kHz this reproduces the coefficient table in BS.1770-4.
+fn shelf_coefficients(sample_rate: f64) -> (f64, f64, f64, f64, f64) {
+    let f0 = 1681.974450955533;
+    let gain_db = 3.999843853973347;
+    let q = 0.7071752369554196;
+
+    let k = (std::f64::consts::PI * f0 / sample_rate).tan();
+    let vh = 10f64.powf(gain_db / 20.0);
+    let vb = vh.powf(0.4996667741545416);
+    let a0 = 1.0 + k / q + k * k;
+
+    (
+        (vh + vb * k / q + k * k) / a0,
+        2.0 * (k * k - vh) / a0,
+        (vh - vb * k / q + k * k) / a0,
+        2.0 * (k * k - 1.0) / a0,
+        (1.0 - k / q + k * k) / a0,
+    )
+}
+
+/// Stage-2 RLB high-pass filter coefficients `(b0, b1, b2, a1, a2)`.
+fn highpass_coefficients(sample_rate: f64) -> (f64, f64, f64, f64, f64) {
+    let f0 = 38.13547087602444;
+    let q = 0.5003270373238773;
+
+    let k = (std::f64::consts::PI * f0 / sample_rate).tan();
+    let a0 = 1.0 + k / q + k * k;
+
+    (
+        1.0,
+        -2.0,
+        1.0,
+        2.0 * (k * k - 1.0) / a0,
+        (1.0 - k / q + k * k) / a0,
+    )
+}
+
+/// K-weighting filter for one channel: shelf then RLB high-pass.
+#[derive(Clone)]
+struct KWeightingFilter {
+    shelf: Biquad,
+    highpass: Biquad,
+}
+
+impl KWeightingFilter {
+    fn new(sample_rate: u32) -> Self {
+        let fs = sample_rate as f64;
+        Self {
+            shelf: Biquad::new(shelf_coefficients(fs)),
+            highpass: Biquad::new(highpass_coefficients(fs)),
+        }
+    }
+
+    #[inline]
+    fn process(&mut self, sample: f64) -> f64 {
+        self.highpass.process(self.shelf.process(sample))
+    }
+}
+
+/// BS.1770 channel weights by channel count, assuming the usual ordering
+/// (L R [C] [LFE] Ls Rs). Mono and stereo — the only layouts MP3 and almost
+/// all AAC files use — are weight 1.0; the LFE of a 5.1 layout is excluded.
+/// Unknown layouts fall back to 1.0 everywhere.
+fn channel_weights(channels: usize) -> Vec<f64> {
+    match channels {
+        4 => vec![1.0, 1.0, 1.41, 1.41],
+        5 => vec![1.0, 1.0, 1.0, 1.41, 1.41],
+        6 => vec![1.0, 1.0, 1.0, 0.0, 1.41, 1.41],
+        n => vec![1.0; n],
+    }
+}
+
+/// Channel-weighted mean-square energies of the 400 ms gating blocks of one
+/// or more tracks. Album loudness is measured over the concatenation of the
+/// album's tracks, so per-track block lists are kept and merged with
+/// [`BlockEnergies::accumulate`] before gating — mirroring how the RG1 path
+/// merges per-track histograms.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BlockEnergies {
+    energies: Vec<f64>,
+}
+
+impl BlockEnergies {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of gating blocks measured.
+    pub fn len(&self) -> usize {
+        self.energies.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.energies.is_empty()
+    }
+
+    /// Append another track's blocks (album accumulation).
+    pub fn accumulate(&mut self, other: &BlockEnergies) {
+        self.energies.extend_from_slice(&other.energies);
+    }
+
+    /// Integrated loudness in LUFS after absolute and relative gating.
+    ///
+    /// Returns `f64::NEG_INFINITY` when no block survives the gates
+    /// (silence or near-silence) — callers should treat that as "no
+    /// measurable loudness" rather than a huge gain.
+    pub fn integrated_lufs(&self) -> f64 {
+        let absolute_gate = loudness_to_energy(ABSOLUTE_GATE_LUFS);
+
+        let mut sum = 0.0;
+        let mut count = 0usize;
+        for &e in &self.energies {
+            if e > absolute_gate {
+                sum += e;
+                count += 1;
+            }
+        }
+        if count == 0 {
+            return f64::NEG_INFINITY;
+        }
+
+        let relative_gate = (sum / count as f64) * RELATIVE_GATE_FACTOR;
+        let gate = absolute_gate.max(relative_gate);
+
+        let mut sum = 0.0;
+        let mut count = 0usize;
+        for &e in &self.energies {
+            if e > gate {
+                sum += e;
+                count += 1;
+            }
+        }
+        if count == 0 {
+            return f64::NEG_INFINITY;
+        }
+
+        energy_to_loudness(sum / count as f64)
+    }
+}
+
+/// Streaming BS.1770 analyzer for one track.
+///
+/// Feed decoded frames with [`add_frame`](Self::add_frame), then take the
+/// gating blocks with [`into_blocks`](Self::into_blocks). A trailing partial
+/// block is discarded, as the spec measures only complete 400 ms blocks.
+pub struct Bs1770Analyzer {
+    filters: Vec<KWeightingFilter>,
+    weights: Vec<f64>,
+    /// Samples per 100 ms sub-block (rounded for rates not divisible by 10,
+    /// e.g. 11025 Hz).
+    subblock_len: usize,
+    /// Weighted sum of squares accumulating in the current sub-block.
+    subblock_sum: f64,
+    subblock_samples: usize,
+    /// Sums of the last up-to-3 completed sub-blocks, oldest first; a gating
+    /// block is these plus the sub-block that just completed (75% overlap).
+    recent: [f64; 3],
+    recent_len: usize,
+    blocks: BlockEnergies,
+}
+
+impl Bs1770Analyzer {
+    /// `channels` beyond the first are analyzed with BS.1770 channel weights;
+    /// see [`channel_weights`] for the layout assumption.
+    pub fn new(sample_rate: u32, channels: usize) -> Self {
+        let channels = channels.max(1);
+        Self {
+            filters: vec![KWeightingFilter::new(sample_rate); channels],
+            weights: channel_weights(channels),
+            subblock_len: (sample_rate as usize + 5) / 10,
+            subblock_sum: 0.0,
+            subblock_samples: 0,
+            recent: [0.0; 3],
+            recent_len: 0,
+            blocks: BlockEnergies::new(),
+        }
+    }
+
+    /// Add one frame of normalized samples (full scale = 1.0), one per
+    /// channel. Extra samples beyond the configured channel count are
+    /// ignored; missing ones count as silence.
+    #[inline]
+    pub fn add_frame(&mut self, frame: &[f64]) {
+        let mut acc = 0.0;
+        for ((filter, &weight), &sample) in self.filters.iter_mut().zip(&self.weights).zip(frame) {
+            let y = filter.process(sample);
+            acc += weight * y * y;
+        }
+        self.subblock_sum += acc;
+        self.subblock_samples += 1;
+        if self.subblock_samples >= self.subblock_len {
+            self.finish_subblock();
+        }
+    }
+
+    fn finish_subblock(&mut self) {
+        let sum = self.subblock_sum;
+        if self.recent_len == 3 {
+            let block_sum = self.recent.iter().sum::<f64>() + sum;
+            self.blocks
+                .energies
+                .push(block_sum / (4 * self.subblock_len) as f64);
+            self.recent.rotate_left(1);
+            self.recent[2] = sum;
+        } else {
+            self.recent[self.recent_len] = sum;
+            self.recent_len += 1;
+        }
+        self.subblock_sum = 0.0;
+        self.subblock_samples = 0;
+    }
+
+    /// Finish analysis, returning the gating blocks for this track.
+    pub fn into_blocks(self) -> BlockEnergies {
+        self.blocks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// EBU Tech 3341 allows a +/-0.1 LU deviation on the compliance cases.
+    const TOLERANCE: f64 = 0.1;
+
+    #[test]
+    fn coefficients_match_bs1770_reference_at_48khz() {
+        // Coefficient tables from ITU-R BS.1770-4, Tables 1 and 2.
+        let (b0, b1, b2, a1, a2) = shelf_coefficients(48000.0);
+        assert!((b0 - 1.53512485958697).abs() < 1e-6);
+        assert!((b1 - -2.69169618940638).abs() < 1e-6);
+        assert!((b2 - 1.19839281085285).abs() < 1e-6);
+        assert!((a1 - -1.69065929318241).abs() < 1e-6);
+        assert!((a2 - 0.73248077421585).abs() < 1e-6);
+
+        let (b0, b1, b2, a1, a2) = highpass_coefficients(48000.0);
+        assert_eq!(b0, 1.0);
+        assert_eq!(b1, -2.0);
+        assert_eq!(b2, 1.0);
+        assert!((a1 - -1.99004745483398).abs() < 1e-5);
+        assert!((a2 - 0.99007225036621).abs() < 1e-5);
+    }
+
+    fn append_sine(samples: &mut Vec<f64>, level_dbfs: f64, seconds: f64, sample_rate: u32) {
+        let amplitude = 10f64.powf(level_dbfs / 20.0);
+        let count = (seconds * sample_rate as f64) as usize;
+        let step = 2.0 * std::f64::consts::PI * 997.0 / sample_rate as f64;
+        for n in 0..count {
+            samples.push(amplitude * (step * n as f64).sin());
+        }
+    }
+
+    fn integrated_stereo(samples: &[f64], sample_rate: u32) -> f64 {
+        let mut analyzer = Bs1770Analyzer::new(sample_rate, 2);
+        for &s in samples {
+            analyzer.add_frame(&[s, s]);
+        }
+        analyzer.into_blocks().integrated_lufs()
+    }
+
+    /// EBU Tech 3341 case 1: 997 Hz stereo sine at -23 dBFS reads -23 LUFS.
+    #[test]
+    fn tech3341_case1_minus23_sine() {
+        for &rate in &[48000u32, 44100] {
+            let mut samples = Vec::new();
+            append_sine(&mut samples, -23.0, 20.0, rate);
+            let lufs = integrated_stereo(&samples, rate);
+            assert!(
+                (lufs - -23.0).abs() < TOLERANCE,
+                "expected -23 LUFS at {} Hz, got {:.3}",
+                rate,
+                lufs
+            );
+        }
+    }
+
+    /// EBU Tech 3341 case 2: same tone at -33 dBFS reads -33 LUFS.
+    #[test]
+    fn tech3341_case2_minus33_sine() {
+        let mut samples = Vec::new();
+        append_sine(&mut samples, -33.0, 20.0, 48000);
+        let lufs = integrated_stereo(&samples, 48000);
+        assert!((lufs - -33.0).abs() < TOLERANCE, "got {:.3}", lufs);
+    }
+
+    /// Relative gate (Tech 3341 case 3 shape): quiet -36 dBFS lead-in/out
+    /// around a -23 dBFS body must be gated out, reading -23 LUFS overall.
+    #[test]
+    fn relative_gate_excludes_quiet_passages() {
+        let mut samples = Vec::new();
+        append_sine(&mut samples, -36.0, 2.5, 48000);
+        append_sine(&mut samples, -23.0, 15.0, 48000);
+        append_sine(&mut samples, -36.0, 2.5, 48000);
+        let lufs = integrated_stereo(&samples, 48000);
+        assert!((lufs - -23.0).abs() < TOLERANCE, "got {:.3}", lufs);
+    }
+
+    /// Absolute gate: silence around the tone must not drag loudness down.
+    #[test]
+    fn absolute_gate_excludes_silence() {
+        let mut samples = vec![0.0; 5 * 48000];
+        append_sine(&mut samples, -23.0, 20.0, 48000);
+        samples.extend(std::iter::repeat(0.0).take(5 * 48000));
+        let lufs = integrated_stereo(&samples, 48000);
+        assert!((lufs - -23.0).abs() < TOLERANCE, "got {:.3}", lufs);
+    }
+
+    /// A tone in only one channel carries half the energy: -3.01 LU lower.
+    #[test]
+    fn single_channel_reads_3db_below_stereo() {
+        let mut samples = Vec::new();
+        append_sine(&mut samples, -23.0, 20.0, 48000);
+        let mut analyzer = Bs1770Analyzer::new(48000, 2);
+        for &s in &samples {
+            analyzer.add_frame(&[s, 0.0]);
+        }
+        let lufs = analyzer.into_blocks().integrated_lufs();
+        assert!((lufs - -26.01).abs() < TOLERANCE, "got {:.3}", lufs);
+    }
+
+    #[test]
+    fn silence_has_no_measurable_loudness() {
+        let samples = vec![0.0; 10 * 48000];
+        let lufs = integrated_stereo(&samples, 48000);
+        assert!(lufs.is_infinite() && lufs < 0.0);
+    }
+
+    /// Album accumulation equals measuring the concatenated tracks: two
+    /// equal-length tracks at -23 and -33 dBFS average (in energy) to
+    /// -23 + 10*log10((1 + 0.1) / 2) ~= -25.6 LUFS, with both tracks
+    /// above the relative gate.
+    #[test]
+    fn accumulate_merges_tracks_like_concatenation() {
+        let mut a = Vec::new();
+        append_sine(&mut a, -23.0, 20.0, 48000);
+        let mut b = Vec::new();
+        append_sine(&mut b, -33.0, 20.0, 48000);
+
+        let mut analyzer_a = Bs1770Analyzer::new(48000, 2);
+        for &s in &a {
+            analyzer_a.add_frame(&[s, s]);
+        }
+        let mut analyzer_b = Bs1770Analyzer::new(48000, 2);
+        for &s in &b {
+            analyzer_b.add_frame(&[s, s]);
+        }
+
+        let mut album = analyzer_a.into_blocks();
+        album.accumulate(&analyzer_b.into_blocks());
+
+        let expected = -23.0 + 10.0 * (1.1f64 / 2.0).log10();
+        let lufs = album.integrated_lufs();
+        assert!(
+            (lufs - expected).abs() < TOLERANCE,
+            "expected {:.3}, got {:.3}",
+            expected,
+            lufs
+        );
+    }
+
+    /// 11025 Hz is not divisible by 10; the rounded 100 ms sub-block must
+    /// still produce a sane measurement (997 Hz is well below Nyquist).
+    #[test]
+    fn odd_sample_rate_11025() {
+        let mut samples = Vec::new();
+        append_sine(&mut samples, -23.0, 20.0, 11025);
+        let lufs = integrated_stereo(&samples, 11025);
+        assert!((lufs - -23.0).abs() < 0.2, "got {:.3}", lufs);
+    }
+}

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -45,6 +45,7 @@ pub fn run_album_analysis(
             on_progress: (!parallel).then_some(&on_progress as _),
             on_complete: parallel.then_some(&on_complete as _),
             cancel: None,
+            mode: Default::default(),
         },
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //! - [`gain`] - Gain adjustment operations and the [`GainOptions`] builder
 //! - [`ape`] - APEv2 tag reading, writing, and management
 //! - [`replaygain`] - ReplayGain loudness analysis
+//! - [`bs1770`] - ITU-R BS.1770 loudness engine for the RG2/R128 modes (feature-gated)
 //! - [`mp4meta`] - MP4/M4A metadata handling
 //! - [`aac`] - AAC bitstream parsing (feature-gated)
 //!
@@ -66,6 +67,8 @@ mod aac_codebooks;
 pub mod analysis;
 pub mod ape;
 pub mod apply;
+#[cfg(feature = "replaygain")]
+pub mod bs1770;
 pub mod error;
 mod frame;
 pub mod gain;

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -46,6 +46,52 @@ pub const REPLAYGAIN_REFERENCE_DB: f64 = 89.0;
 /// Source: https://replaygain.hydrogenaud.io/calibration.html
 const PINK_REF: f64 = 64.82;
 
+/// ReplayGain 2.0 reference level in LUFS. This is the same perceived level
+/// as the 89 dB SPL reference of ReplayGain 1.0, expressed on the BS.1770
+/// scale — only the measurement algorithm differs between the two modes.
+pub const RG2_REFERENCE_LUFS: f64 = -18.0;
+
+/// EBU R128 broadcast target level in LUFS.
+pub const R128_REFERENCE_LUFS: f64 = -23.0;
+
+/// Loudness measurement algorithm used for gain calculation (issue #269).
+///
+/// [`Rg1`](AnalysisMode::Rg1) is the default and reproduces mp3gain's values
+/// exactly; the BS.1770-based modes are strictly opt-in.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AnalysisMode {
+    /// ReplayGain 1.0 (mp3gain-compatible, 89 dB SPL reference).
+    #[default]
+    Rg1,
+    /// ReplayGain 2.0: BS.1770 integrated loudness, -18 LUFS reference.
+    Rg2,
+    /// EBU R128: BS.1770 integrated loudness, -23 LUFS target.
+    R128,
+}
+
+impl AnalysisMode {
+    /// Target level in LUFS for the BS.1770-based modes; `None` for RG1.
+    pub fn target_lufs(&self) -> Option<f64> {
+        match self {
+            AnalysisMode::Rg1 => None,
+            AnalysisMode::Rg2 => Some(RG2_REFERENCE_LUFS),
+            AnalysisMode::R128 => Some(R128_REFERENCE_LUFS),
+        }
+    }
+}
+
+impl std::fmt::Display for AnalysisMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AnalysisMode::Rg1 => f.write_str("ReplayGain 1.0"),
+            AnalysisMode::Rg2 => f.write_str("ReplayGain 2.0"),
+            AnalysisMode::R128 => f.write_str("EBU R128"),
+        }
+    }
+}
+
 /// Audio file type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -76,6 +122,8 @@ pub struct ReplayGainResult {
     peak: f64,
     sample_rate: u32,
     file_type: AudioFileType,
+    #[cfg_attr(feature = "serde", serde(default))]
+    analysis_mode: AnalysisMode,
 }
 
 impl ReplayGainResult {
@@ -86,6 +134,7 @@ impl ReplayGainResult {
         peak: f64,
         sample_rate: u32,
         file_type: AudioFileType,
+        analysis_mode: AnalysisMode,
     ) -> Self {
         Self {
             loudness_db,
@@ -93,9 +142,12 @@ impl ReplayGainResult {
             peak,
             sample_rate,
             file_type,
+            analysis_mode,
         }
     }
 
+    /// Measured loudness: the RG1 histogram value in [`AnalysisMode::Rg1`],
+    /// or the BS.1770 integrated loudness in LUFS in the other modes.
     pub fn loudness_db(&self) -> f64 {
         self.loudness_db
     }
@@ -110,6 +162,9 @@ impl ReplayGainResult {
     }
     pub fn file_type(&self) -> AudioFileType {
         self.file_type
+    }
+    pub fn analysis_mode(&self) -> AnalysisMode {
+        self.analysis_mode
     }
 
     /// Convert gain in dB to MP3 gain steps (1.5 dB per step)
@@ -962,19 +1017,86 @@ impl MediaSource for ProgressMediaSource {
     }
 }
 
-/// Internal result containing both ReplayGainResult and histogram for album calculation
+/// Per-track loudness state kept for album accumulation, one variant per
+/// measurement algorithm. Modes never mix within one album analysis.
+#[cfg(feature = "replaygain")]
+enum LoudnessState {
+    Rg1(LoudnessHistogram),
+    Bs1770(crate::bs1770::BlockEnergies),
+}
+
+#[cfg(feature = "replaygain")]
+impl LoudnessState {
+    fn new(mode: AnalysisMode) -> Self {
+        match mode {
+            AnalysisMode::Rg1 => LoudnessState::Rg1(LoudnessHistogram::new()),
+            _ => LoudnessState::Bs1770(crate::bs1770::BlockEnergies::new()),
+        }
+    }
+
+    fn accumulate(&mut self, other: &LoudnessState) {
+        match (self, other) {
+            (LoudnessState::Rg1(a), LoudnessState::Rg1(b)) => a.accumulate(b),
+            (LoudnessState::Bs1770(a), LoudnessState::Bs1770(b)) => a.accumulate(b),
+            _ => debug_assert!(false, "mixed analysis modes in album accumulation"),
+        }
+    }
+
+    /// `(loudness, gain_db)` of the accumulated state under `mode`.
+    fn loudness_and_gain(&self, mode: AnalysisMode) -> (f64, f64) {
+        match self {
+            LoudnessState::Rg1(histogram) => {
+                let loudness = histogram.get_loudness();
+                (loudness, PINK_REF - loudness)
+            }
+            LoudnessState::Bs1770(blocks) => lufs_loudness_and_gain(blocks.integrated_lufs(), mode),
+        }
+    }
+}
+
+/// Convert integrated LUFS to `(loudness, gain_db)` for the mode's target.
+/// Fully-gated input (silence) has no measurable loudness and is treated as
+/// already at target: gain 0.
+#[cfg(feature = "replaygain")]
+fn lufs_loudness_and_gain(lufs: f64, mode: AnalysisMode) -> (f64, f64) {
+    let target = mode.target_lufs().unwrap_or(RG2_REFERENCE_LUFS);
+    if lufs.is_finite() {
+        (lufs, target - lufs)
+    } else {
+        (target, 0.0)
+    }
+}
+
+/// Internal result containing both ReplayGainResult and the loudness state
+/// for album calculation
 #[cfg(feature = "replaygain")]
 struct TrackAnalysisInternal {
     result: ReplayGainResult,
-    histogram: LoudnessHistogram,
+    state: LoudnessState,
 }
 
-/// Internal function to analyze a track and return both result and histogram
+/// Per-track analyzer, selected by [`AnalysisMode`]. The RG1 variant is the
+/// original mp3gain algorithm and must stay bit-identical; the BS.1770
+/// variant feeds normalized samples of all channels to [`crate::bs1770`].
+#[cfg(feature = "replaygain")]
+enum TrackAnalyzer {
+    Rg1 {
+        filters: Vec<EqualLoudnessFilter>,
+        analyzer: ReplayGainAnalyzer,
+    },
+    Bs1770 {
+        analyzer: crate::bs1770::Bs1770Analyzer,
+        frame_buf: Vec<f64>,
+    },
+}
+
+/// Internal function to analyze a track and return both result and loudness state
 #[cfg(feature = "replaygain")]
 fn analyze_track_internal(
     file_path: &Path,
     track_index: Option<u32>,
     progress: Option<&dyn Fn(u64, u64)>,
+    mode: AnalysisMode,
 ) -> Result<TrackAnalysisInternal> {
     // Detect file type
     let file_type = detect_file_type(file_path);
@@ -1066,14 +1188,25 @@ fn analyze_track_internal(
         .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
         .map_err(|e| Error::Decode(Box::new(e)))?;
 
-    // Create filter for each channel
-    let mut filters: Vec<EqualLoudnessFilter> = (0..channels)
-        .map(|_| {
-            EqualLoudnessFilter::new(sample_rate).ok_or(Error::UnsupportedSampleRate(sample_rate))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let mut analyzer = ReplayGainAnalyzer::new(sample_rate);
+    let mut track_analyzer = match mode {
+        AnalysisMode::Rg1 => {
+            // Create filter for each channel
+            let filters: Vec<EqualLoudnessFilter> = (0..channels)
+                .map(|_| {
+                    EqualLoudnessFilter::new(sample_rate)
+                        .ok_or(Error::UnsupportedSampleRate(sample_rate))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            TrackAnalyzer::Rg1 {
+                filters,
+                analyzer: ReplayGainAnalyzer::new(sample_rate),
+            }
+        }
+        _ => TrackAnalyzer::Bs1770 {
+            analyzer: crate::bs1770::Bs1770Analyzer::new(sample_rate, channels),
+            frame_buf: Vec::with_capacity(channels),
+        },
+    };
     let mut peak: f64 = 0.0;
 
     // Process all packets
@@ -1095,7 +1228,15 @@ fn analyze_track_internal(
         };
 
         // Process audio buffer
-        process_audio_buffer(&decoded, &mut filters, &mut analyzer, &mut peak);
+        match &mut track_analyzer {
+            TrackAnalyzer::Rg1 { filters, analyzer } => {
+                process_audio_buffer(&decoded, filters, analyzer, &mut peak)
+            }
+            TrackAnalyzer::Bs1770 {
+                analyzer,
+                frame_buf,
+            } => process_audio_buffer_bs1770(&decoded, analyzer, frame_buf, &mut peak),
+        }
 
         // Report progress
         if let (Some(cb), Some(ref tracker)) = (progress, &position_tracker) {
@@ -1108,19 +1249,28 @@ fn analyze_track_internal(
         cb(file_size, file_size);
     }
 
-    // Finish any remaining samples in the last window
-    analyzer.finish_window();
+    // Finish analysis and calculate loudness and gain
+    let (loudness_db, gain_db, state) = match track_analyzer {
+        TrackAnalyzer::Rg1 { mut analyzer, .. } => {
+            // Finish any remaining samples in the last window
+            analyzer.finish_window();
+            let loudness_db = analyzer.get_loudness();
+            (
+                loudness_db,
+                PINK_REF - loudness_db,
+                LoudnessState::Rg1(analyzer.into_histogram()),
+            )
+        }
+        TrackAnalyzer::Bs1770 { analyzer, .. } => {
+            let blocks = analyzer.into_blocks();
+            let (loudness_db, gain_db) = lufs_loudness_and_gain(blocks.integrated_lufs(), mode);
+            (loudness_db, gain_db, LoudnessState::Bs1770(blocks))
+        }
+    };
 
-    // Calculate loudness and gain
-    let loudness_db = analyzer.get_loudness();
-    let gain_db = PINK_REF - loudness_db;
+    let result = ReplayGainResult::new(loudness_db, gain_db, peak, sample_rate, file_type, mode);
 
-    let result = ReplayGainResult::new(loudness_db, gain_db, peak, sample_rate, file_type);
-
-    Ok(TrackAnalysisInternal {
-        result,
-        histogram: analyzer.into_histogram(),
-    })
+    Ok(TrackAnalysisInternal { result, state })
 }
 
 /// Analyze a single track and calculate ReplayGain
@@ -1135,7 +1285,22 @@ pub fn analyze_track_with_index(
     file_path: &Path,
     track_index: Option<u32>,
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(file_path, track_index, None)?;
+    let internal = analyze_track_internal(file_path, track_index, None, AnalysisMode::default())?;
+    Ok(internal.result)
+}
+
+/// Analyze a single track using the given analysis mode (issue #269).
+///
+/// [`AnalysisMode::Rg1`] is identical to [`analyze_track_with_index`]; the
+/// other modes measure BS.1770 integrated loudness and compute the gain
+/// against the mode's target level.
+#[cfg(feature = "replaygain")]
+pub fn analyze_track_with_mode(
+    file_path: &Path,
+    track_index: Option<u32>,
+    mode: AnalysisMode,
+) -> Result<ReplayGainResult> {
+    let internal = analyze_track_internal(file_path, track_index, None, mode)?;
     Ok(internal.result)
 }
 
@@ -1151,7 +1316,12 @@ pub fn analyze_track_with_progress(
     track_index: Option<u32>,
     on_progress: &dyn Fn(u64, u64),
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(file_path, track_index, Some(on_progress))?;
+    let internal = analyze_track_internal(
+        file_path,
+        track_index,
+        Some(on_progress),
+        AnalysisMode::default(),
+    )?;
     Ok(internal.result)
 }
 
@@ -1247,6 +1417,82 @@ fn process_audio_buffer(
     }
 }
 
+/// Feed normalized (full scale = 1.0) samples from a decoded buffer to the
+/// BS.1770 analyzer. Unlike the RG1 path, all channels are analyzed (the
+/// analyzer applies BS.1770 channel weights) and no 16-bit scaling is
+/// applied — LUFS is defined relative to digital full scale.
+#[cfg(feature = "replaygain")]
+fn process_audio_buffer_bs1770(
+    buffer: &GenericAudioBufferRef,
+    analyzer: &mut crate::bs1770::Bs1770Analyzer,
+    frame_buf: &mut Vec<f64>,
+    peak: &mut f64,
+) {
+    fn feed<T: Copy>(
+        planes: &[&[T]],
+        frames: usize,
+        conv: impl Fn(T) -> f64,
+        analyzer: &mut crate::bs1770::Bs1770Analyzer,
+        frame_buf: &mut Vec<f64>,
+        peak: &mut f64,
+    ) {
+        for frame in 0..frames {
+            frame_buf.clear();
+            for plane in planes {
+                let v = conv(plane[frame]);
+                *peak = peak.max(v.abs());
+                frame_buf.push(v);
+            }
+            analyzer.add_frame(frame_buf);
+        }
+    }
+
+    match buffer {
+        GenericAudioBufferRef::F32(buf) => {
+            let planes: Vec<&[f32]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            feed(
+                &planes,
+                buf.frames(),
+                |s| s as f64,
+                analyzer,
+                frame_buf,
+                peak,
+            );
+        }
+        GenericAudioBufferRef::S16(buf) => {
+            let planes: Vec<&[i16]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            feed(
+                &planes,
+                buf.frames(),
+                |s| s as f64 / SAMPLE_SCALE_16BIT,
+                analyzer,
+                frame_buf,
+                peak,
+            );
+        }
+        GenericAudioBufferRef::S32(buf) => {
+            let planes: Vec<&[i32]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            feed(
+                &planes,
+                buf.frames(),
+                |s| s as f64 / 2147483648.0,
+                analyzer,
+                frame_buf,
+                peak,
+            );
+        }
+        _ => {
+            // Unsupported format, skip
+        }
+    }
+}
+
 /// Byte-level progress callback: `(file_index, bytes_read, total_bytes)`.
 pub type AlbumProgressFn<'a> = &'a dyn Fn(usize, u64, u64);
 
@@ -1283,6 +1529,9 @@ pub struct AlbumAnalysisOptions<'a> {
     /// remaining files are not analyzed and [`Error::Cancelled`] is
     /// returned. Files already being decoded run to completion.
     pub cancel: Option<&'a AtomicBool>,
+    /// Loudness measurement algorithm (issue #269). Defaults to
+    /// [`AnalysisMode::Rg1`], the mp3gain-compatible algorithm.
+    pub mode: AnalysisMode,
 }
 
 /// Analyze multiple tracks for album gain (strict, serial, no callbacks).
@@ -1325,12 +1574,13 @@ fn analyze_album_serial(
         on_complete,
         skip_errors,
         cancel,
+        mode,
         ..
     } = *opts;
     let mut track_results = Vec::with_capacity(files.len());
     let mut album_peak: f64 = 0.0;
-    // Album histogram accumulates all track histograms (like B[] in original mp3gain)
-    let mut album_histogram = LoudnessHistogram::new();
+    // Album state accumulates all track states (like B[] in original mp3gain)
+    let mut album_state = LoudnessState::new(mode);
     let mut failures: Vec<(usize, String)> = Vec::new();
     let mut successful_indices: Vec<usize> = Vec::with_capacity(files.len());
 
@@ -1342,15 +1592,15 @@ fn analyze_album_serial(
         let file_progress: Option<Box<dyn Fn(u64, u64) + '_>> =
             on_progress.map(|cb| Box::new(move |bytes, total| cb(i, bytes, total)) as _);
 
-        // Analyze each track and get histogram
-        let track = analyze_track_internal(file, track_index, file_progress.as_deref());
+        // Analyze each track and get its loudness state
+        let track = analyze_track_internal(file, track_index, file_progress.as_deref(), mode);
         if let Some(cb) = on_complete {
             cb(i, file);
         }
         match track {
             Ok(internal) => {
                 album_peak = album_peak.max(internal.result.peak);
-                album_histogram.accumulate(&internal.histogram);
+                album_state.accumulate(&internal.state);
                 track_results.push(internal.result);
                 successful_indices.push(i);
             }
@@ -1368,9 +1618,8 @@ fn analyze_album_serial(
         return Err(Error::AllFilesFailed { count: files.len() });
     }
 
-    // Calculate album loudness from combined histogram (95th percentile)
-    let album_loudness_db = album_histogram.get_loudness();
-    let album_gain_db = PINK_REF - album_loudness_db;
+    // Calculate album loudness from the combined state
+    let (album_loudness_db, album_gain_db) = album_state.loudness_and_gain(mode);
 
     let album = AlbumGainResult::new(track_results, album_loudness_db, album_gain_db, album_peak);
     Ok(AlbumAnalysisReport {
@@ -1392,17 +1641,18 @@ fn analyze_album_parallel_internal(
         on_complete,
         skip_errors,
         cancel,
+        mode,
         ..
     } = *opts;
 
     let mut track_results = Vec::with_capacity(files.len());
     let mut album_peak: f64 = 0.0;
-    let mut album_histogram = LoudnessHistogram::new();
+    let mut album_state = LoudnessState::new(mode);
     let mut failures: Vec<(usize, String)> = Vec::new();
     let mut successful_indices: Vec<usize> = Vec::with_capacity(files.len());
 
     // par_iter().collect() preserves input order, which keeps album_peak
-    // / album_histogram folding deterministic and matches the serial path
+    // / album_state folding deterministic and matches the serial path
     // bit-for-bit. Strict mode short-circuits at the first error; lenient
     // collects all outcomes so failures can be reported alongside successes.
     if skip_errors {
@@ -1413,7 +1663,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None);
+                let r = analyze_track_internal(file, track_index, None, mode);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -1427,7 +1677,7 @@ fn analyze_album_parallel_internal(
             match r {
                 Ok(internal) => {
                     album_peak = album_peak.max(internal.result.peak);
-                    album_histogram.accumulate(&internal.histogram);
+                    album_state.accumulate(&internal.state);
                     track_results.push(internal.result);
                     successful_indices.push(i);
                 }
@@ -1444,7 +1694,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None);
+                let r = analyze_track_internal(file, track_index, None, mode);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -1453,7 +1703,7 @@ fn analyze_album_parallel_internal(
             .collect::<Result<Vec<_>>>()?;
         for (i, internal) in internals.into_iter().enumerate() {
             album_peak = album_peak.max(internal.result.peak);
-            album_histogram.accumulate(&internal.histogram);
+            album_state.accumulate(&internal.state);
             track_results.push(internal.result);
             successful_indices.push(i);
         }
@@ -1463,8 +1713,7 @@ fn analyze_album_parallel_internal(
         return Err(Error::AllFilesFailed { count: files.len() });
     }
 
-    let album_loudness_db = album_histogram.get_loudness();
-    let album_gain_db = PINK_REF - album_loudness_db;
+    let (album_loudness_db, album_gain_db) = album_state.loudness_and_gain(mode);
 
     let album = AlbumGainResult::new(track_results, album_loudness_db, album_gain_db, album_peak);
     Ok(AlbumAnalysisReport {
@@ -1490,6 +1739,18 @@ pub fn analyze_track(_file_path: &Path) -> Result<ReplayGainResult> {
 pub fn analyze_track_with_index(
     _file_path: &Path,
     _track_index: Option<u32>,
+) -> Result<ReplayGainResult> {
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_track_with_mode(
+    _file_path: &Path,
+    _track_index: Option<u32>,
+    _mode: AnalysisMode,
 ) -> Result<ReplayGainResult> {
     Err(Error::FeatureNotAvailable {
         feature: "ReplayGain analysis",
@@ -1714,7 +1975,14 @@ mod tests {
 
     #[test]
     fn with_peak_replaces_peak_and_preserves_other_fields() {
-        let original = ReplayGainResult::new(-15.0, 6.0, 0.5, 44_100, AudioFileType::Mp3);
+        let original = ReplayGainResult::new(
+            -15.0,
+            6.0,
+            0.5,
+            44_100,
+            AudioFileType::Mp3,
+            AnalysisMode::Rg1,
+        );
         let updated = original.clone().with_peak(0.8);
         assert_eq!(updated.peak(), 0.8);
         assert_eq!(updated.gain_db(), original.gain_db());

--- a/tests/bs1770_integration.rs
+++ b/tests/bs1770_integration.rs
@@ -1,0 +1,83 @@
+//! End-to-end checks of the BS.1770 analysis path (issue #270): decode via
+//! symphonia -> K-weighting -> gating -> gain. The expected LUFS values were
+//! cross-checked against `ffmpeg -af ebur128` (agreement within 0.05 LU).
+
+#![cfg(feature = "replaygain")]
+
+use mp3rgain::replaygain::{
+    analyze_album_with_options, analyze_track, analyze_track_with_mode, AlbumAnalysisOptions,
+    AnalysisMode, R128_REFERENCE_LUFS, RG2_REFERENCE_LUFS,
+};
+use std::path::Path;
+
+fn lufs(file: &str) -> f64 {
+    analyze_track_with_mode(
+        Path::new(&format!("tests/fixtures/{}", file)),
+        None,
+        AnalysisMode::Rg2,
+    )
+    .unwrap()
+    .loudness_db()
+}
+
+#[test]
+fn fixture_lufs_matches_ffmpeg_ebur128() {
+    assert!((lufs("test_mono.mp3") - -22.2).abs() < 0.1);
+    assert!((lufs("test_joint_stereo.mp3") - -22.2).abs() < 0.1);
+    assert!((lufs("test_vbr.mp3") - -21.8).abs() < 0.1);
+}
+
+#[test]
+fn rg2_and_r128_share_measurement_and_differ_by_target() {
+    let path = Path::new("tests/fixtures/test_mono.mp3");
+    let rg2 = analyze_track_with_mode(path, None, AnalysisMode::Rg2).unwrap();
+    let r128 = analyze_track_with_mode(path, None, AnalysisMode::R128).unwrap();
+
+    assert_eq!(rg2.loudness_db(), r128.loudness_db());
+    assert!((rg2.gain_db() - (RG2_REFERENCE_LUFS - rg2.loudness_db())).abs() < 1e-12);
+    assert!((r128.gain_db() - (R128_REFERENCE_LUFS - r128.loudness_db())).abs() < 1e-12);
+    assert_eq!(rg2.analysis_mode(), AnalysisMode::Rg2);
+    assert_eq!(r128.analysis_mode(), AnalysisMode::R128);
+}
+
+#[test]
+fn default_mode_is_unchanged_rg1() {
+    let path = Path::new("tests/fixtures/test_mono.mp3");
+    let default = analyze_track(path).unwrap();
+    let rg1 = analyze_track_with_mode(path, None, AnalysisMode::Rg1).unwrap();
+    assert_eq!(default, rg1);
+    assert_eq!(default.analysis_mode(), AnalysisMode::Rg1);
+}
+
+#[test]
+fn album_analysis_in_rg2_mode() {
+    let mono = Path::new("tests/fixtures/test_mono.mp3");
+    let vbr = Path::new("tests/fixtures/test_vbr.mp3");
+    let report = analyze_album_with_options(
+        &[mono, vbr],
+        &AlbumAnalysisOptions {
+            mode: AnalysisMode::Rg2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let album = &report.album;
+    let (lo, hi) = (
+        album
+            .tracks()
+            .iter()
+            .map(|t| t.loudness_db())
+            .fold(f64::INFINITY, f64::min),
+        album
+            .tracks()
+            .iter()
+            .map(|t| t.loudness_db())
+            .fold(f64::NEG_INFINITY, f64::max),
+    );
+    // Album loudness over the concatenation lies between the track extremes.
+    assert!(album.album_loudness_db() >= lo && album.album_loudness_db() <= hi);
+    assert!(
+        (album.album_gain_db() - (RG2_REFERENCE_LUFS - album.album_loudness_db())).abs() < 1e-12
+    );
+}


### PR DESCRIPTION
Implements the core BS.1770-4 loudness engine for the v3.0 `--rg2` / `--r128` modes.

Closes #270. Part of #269.

## What's included

- **`src/bs1770.rs`** — self-contained ITU-R BS.1770-4 engine, no new dependencies:
  - K-weighting (shelf + RLB high-pass) with coefficients derived analytically for any sample rate; reproduces the BS.1770-4 coefficient tables at 48 kHz (unit-tested to 1e-6)
  - 400 ms gating blocks, 75% overlap; channel weights (1.0 L/R/C, 1.41 surround, LFE excluded)
  - Absolute (−70 LUFS) + relative (−10 LU) gating; `BlockEnergies` merges per-track blocks for album measurement (same shape as the RG1 histogram accumulation)
- **Library plumbing** — `AnalysisMode { Rg1 (default), Rg2, R128 }` threaded through track/album analysis, `analyze_track_with_mode()`, `AlbumAnalysisOptions.mode`, `ReplayGainResult::analysis_mode()`. The BS.1770 path feeds normalized samples of **all** channels (LUFS is full-scale-relative); the RG1 path is untouched.

## RG1 stays bit-identical

The default mode goes through the exact same `EqualLoudnessFilter` / `ReplayGainAnalyzer` code; the golden reference test against the C `gain_analysis.c` (`analysis_matches_reference_c_to_float_precision`) passes unchanged, and `default_mode_is_unchanged_rg1` pins `analyze_track()` == RG1 mode.

## Validation

- EBU Tech 3341-style compliance tests (synthesized in-test, no fixtures): −23/−33 dBFS reference tones at 48/44.1 kHz, relative-gate and absolute-gate sequences, mono −3.01 LU offset, album accumulation, 11025 Hz rounding
- Fixtures cross-checked against `ffmpeg -af ebur128`:

  | fixture | ffmpeg | mp3rgain |
  |---|---|---|
  | test_mono.mp3 | −22.2 | −22.20 |
  | test_joint_stereo.mp3 | −22.2 | −22.20 |
  | test_vbr.mp3 | −21.8 | −21.75 |

  (`test_stereo.mp3` is excluded — it decodes to a peak of ~5.9e8 by design, so both tools produce meaningless loudness for it.)
- `cargo test` (all suites), `cargo clippy --all-features`, `--no-default-features` build, and mp3rgui build all pass.

## Not in this PR

CLI flags, tag/output semantics (#271) and the GUI selector (#272) build on this.
