### PR TITLE
cli: --rg2 / --r128 opt-in BS.1770 loudness modes (issue #271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ A native GUI application (`mp3rgui`) is available for users who prefer a graphic
 |--------|-------------|
 | `-r` | Apply Track gain (ReplayGain) |
 | `-a` | Apply Album gain (ReplayGain) |
+| `--rg2` | Use ReplayGain 2.0 analysis (BS.1770, −18 LUFS reference) |
+| `--r128` | Use EBU R128 analysis (BS.1770, −23 LUFS target) |
 | `-g <i>` | Apply gain of i steps (1 step = 1.5 dB) |
 | `-d <n>` | Modify suggested dB gain by n (mp3gain-compatible; applied with `-r` / `-a`) |
 | `-u` | Undo gain changes |
@@ -157,7 +159,7 @@ The original [mp3gain](http://mp3gain.sourceforge.net/) has been unmaintained up
 
 **AAC/M4A on the CLI is the differentiator.** Among CLIs, rsgain / loudgain / FFmpeg either only write ReplayGain tags (which non-compliant players ignore) or re-encode the audio. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only, has no undo, and is unsuited for batch, headless, or container workflows. mp3rgain fills the cross-platform, scriptable, reversible niche.
 
-mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) for full compatibility with the original mp3gain / aacgain. Loudness values will differ from EBU R128/LUFS-based tools (foobar2000, loudgain, ffmpeg loudnorm).
+mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 
 ## Use mp3rgain in Docker / CI
 

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -64,6 +64,28 @@ Each file is normalized individually to the 89 dB reference level.
 Analyze and apply Album gain using the ReplayGain 1.0 algorithm.
 All files are treated as an album and normalized together.
 .TP
+.B \-\-rg2
+Measure loudness with the ReplayGain 2.0 algorithm (ITU-R BS.1770
+integrated loudness, gated) against the \-18 LUFS reference instead of
+the default ReplayGain 1.0 algorithm. The reference corresponds to the
+same perceived level as the classic 89 dB SPL reference; only the
+measurement is different. Combines with
+.BR \-r ,
+.BR \-a ,
+.BR \-d ,
+.B \-m
+and
+.BR \-k .
+Mutually exclusive with
+.BR \-\-r128 .
+.TP
+.B \-\-r128
+Like
+.BR \-\-rg2 ,
+but normalizes to the EBU R128 broadcast target of \-23 LUFS.
+Mutually exclusive with
+.BR \-\-rg2 .
+.TP
 .B \-e
 Skip album analysis even when processing multiple files.
 Apply track gain only.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,8 +202,8 @@ All core functionality complete:
 
 ### Future Enhancements
 
-- [ ] EBU R128 loudness analysis (`--r128` option, ITU-R BS.1770 / LUFS-based)
-- [ ] ReplayGain 2.0 support (`--rg2` option, R128-based with -18 LUFS reference)
+- [x] EBU R128 loudness analysis (`--r128` option, ITU-R BS.1770 / LUFS-based) (#269, #270, #271)
+- [x] ReplayGain 2.0 support (`--rg2` option, R128-based with -18 LUFS reference) (#269, #270, #271)
 - [ ] Official Debian repository (ITP submission)
 - [ ] Homebrew core inclusion (currently in tap)
 - [ ] Fedora/RPM package

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -1,3 +1,4 @@
+use mp3rgain::replaygain::AnalysisMode;
 use mp3rgain::Channel;
 use std::path::PathBuf;
 
@@ -36,7 +37,10 @@ pub struct Options {
     pub force_recalc: bool, // -s r: accepted for compatibility (always recalculates)
     pub track_gain: bool,   // -r (apply track gain)
     pub album_gain: bool,   // -a (apply album gain)
-    pub skip_album: bool,   // -e: skip album analysis
+    // --rg2 / --r128: opt-in BS.1770 loudness modes (issue #269).
+    // Default Rg1 keeps mp3gain-identical values.
+    pub analysis_mode: AnalysisMode,
+    pub skip_album: bool,         // -e: skip album analysis
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files
 

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use colored::*;
+use mp3rgain::replaygain::AnalysisMode;
 use mp3rgain::Channel;
 use std::path::PathBuf;
 
@@ -27,6 +28,24 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
 
         if arg == "--skip-errors" {
             opts.skip_errors = true;
+            i += 1;
+            continue;
+        }
+
+        if arg == "--rg2" {
+            if opts.analysis_mode == AnalysisMode::R128 {
+                anyhow::bail!("--rg2 and --r128 are mutually exclusive");
+            }
+            opts.analysis_mode = AnalysisMode::Rg2;
+            i += 1;
+            continue;
+        }
+
+        if arg == "--r128" {
+            if opts.analysis_mode == AnalysisMode::Rg2 {
+                anyhow::bail!("--rg2 and --r128 are mutually exclusive");
+            }
+            opts.analysis_mode = AnalysisMode::R128;
             i += 1;
             continue;
         }
@@ -640,6 +659,31 @@ mod tests {
     fn invalid_attached_gain_returns_error() {
         let result = parse_args(&args(&["-gabc"]));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn analysis_mode_flags() {
+        // Default stays RG1 (mp3gain compatible)
+        let opts = parse_args(&args(&["-r", "song.mp3"])).unwrap();
+        assert_eq!(opts.analysis_mode, AnalysisMode::Rg1);
+
+        let opts = parse_args(&args(&["--rg2", "-r", "song.mp3"])).unwrap();
+        assert_eq!(opts.analysis_mode, AnalysisMode::Rg2);
+        assert!(opts.track_gain);
+
+        let opts = parse_args(&args(&["-a", "--r128", "song.mp3"])).unwrap();
+        assert_eq!(opts.analysis_mode, AnalysisMode::R128);
+        assert!(opts.album_gain);
+
+        // Repeating the same flag is fine
+        let opts = parse_args(&args(&["--rg2", "--rg2", "song.mp3"])).unwrap();
+        assert_eq!(opts.analysis_mode, AnalysisMode::Rg2);
+    }
+
+    #[test]
+    fn rg2_and_r128_are_mutually_exclusive() {
+        assert!(parse_args(&args(&["--rg2", "--r128", "song.mp3"])).is_err());
+        assert!(parse_args(&args(&["--r128", "--rg2", "song.mp3"])).is_err());
     }
 
     #[test]

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -28,6 +28,8 @@ pub fn print_usage() {
     println!("    -m <i>      Modify suggested gain by integer i");
     println!("    -r          Apply Track gain (ReplayGain analysis)");
     println!("    -a          Apply Album gain (ReplayGain analysis)");
+    println!("    --rg2       ReplayGain 2.0 analysis (BS.1770, -18 LUFS reference)");
+    println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
     println!("    -e          Skip album analysis (even with multiple files)");
     println!("    -i <n>      Specify which audio track to process (default: 0)");
     println!("    -u          Undo gain changes (restore from APEv2 tag)");
@@ -64,6 +66,8 @@ pub fn print_usage() {
     println!("    mp3rgain -r -d 4.5 song.mp3    Apply track gain, target +4.5 dB louder");
     println!("    mp3rgain -r song.mp3           Analyze and apply track gain");
     println!("    mp3rgain -a *.mp3              Analyze and apply album gain");
+    println!("    mp3rgain -r --rg2 song.mp3     Track gain via ReplayGain 2.0 (BS.1770)");
+    println!("    mp3rgain -a --r128 *.mp3       Album gain to the EBU R128 target");
     println!("    mp3rgain -r -m 2 *.mp3         Apply track gain + 2 steps");
     println!("    mp3rgain -e *.mp3              Track gain only (skip album calc)");
     println!("    mp3rgain -u song.mp3           Undo previous gain changes");
@@ -100,6 +104,8 @@ pub fn print_usage() {
             "enabled".green(),
             REPLAYGAIN_REFERENCE_DB
         );
+        println!("    - Default analysis is ReplayGain 1.0 (mp3gain-identical values);");
+        println!("      --rg2 / --r128 opt into BS.1770 loudness measurement");
     } else {
         println!();
         println!("{}", "REPLAYGAIN:".yellow().bold());

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::replaygain::{self, AlbumAnalysisReport, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{self, AlbumAnalysisReport, AnalysisMode, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{steps_to_db, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
@@ -12,23 +12,42 @@ use crate::commands::utils::{
     create_json_summary, exit_if_failed, finish_with_summary, for_each_file_with_analysis_bar,
     print_dry_run_notice, run_album_analysis, update_counters,
 };
-use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
+use crate::json_output::{
+    analysis_mode_str, FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput,
+};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
 fn print_target_with_modifier(opts: &Options) {
     let modifier_steps = opts.gain_modifier_steps();
-    if modifier_steps != 0 {
-        let modifier_db = steps_to_db(modifier_steps);
-        println!(
-            "  Target: {:.1} dB (ReplayGain {} dB {:+.1} dB modifier)",
-            REPLAYGAIN_REFERENCE_DB + modifier_db,
-            REPLAYGAIN_REFERENCE_DB,
-            modifier_db,
-        );
-    } else {
-        println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
+    let modifier_db = steps_to_db(modifier_steps);
+    match opts.analysis_mode.target_lufs() {
+        Some(target) => {
+            if modifier_steps != 0 {
+                println!(
+                    "  Target: {:.1} LUFS ({} {} LUFS {:+.1} dB modifier)",
+                    target + modifier_db,
+                    opts.analysis_mode,
+                    target,
+                    modifier_db,
+                );
+            } else {
+                println!("  Target: {} LUFS ({})", target, opts.analysis_mode);
+            }
+        }
+        None => {
+            if modifier_steps != 0 {
+                println!(
+                    "  Target: {:.1} dB (ReplayGain {} dB {:+.1} dB modifier)",
+                    REPLAYGAIN_REFERENCE_DB + modifier_db,
+                    REPLAYGAIN_REFERENCE_DB,
+                    modifier_db,
+                );
+            } else {
+                println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
+            }
+        }
     }
 }
 
@@ -133,8 +152,11 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let modifier_steps = opts.gain_modifier_steps();
             let modified_gain_steps = album_result.album_gain_steps() + modifier_steps;
 
+            let is_lufs = opts.analysis_mode != AnalysisMode::Rg1;
             let json_album = JsonAlbumResult {
                 loudness_db: album_result.album_loudness_db(),
+                loudness_lufs: is_lufs.then(|| album_result.album_loudness_db()),
+                analysis_mode: Some(analysis_mode_str(opts.analysis_mode)),
                 gain_db: album_result.album_gain_db(),
                 gain_steps: modified_gain_steps,
                 peak: album_result.album_peak(),
@@ -148,8 +170,9 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 println!();
                 println!(
-                    "  Album loudness: {:.1} dB",
-                    album_result.album_loudness_db()
+                    "  Album loudness: {:.1} {}",
+                    album_result.album_loudness_db(),
+                    if is_lufs { "LUFS" } else { "dB" }
                 );
                 println!(
                     "  Album gain:     {:+.1} dB ({} steps{})",
@@ -180,6 +203,8 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                                     file: file.display().to_string(),
                                     status: Some(FileStatus::Skipped),
                                     loudness_db: Some(track.loudness_db()),
+                                    loudness_lufs: track.loudness_lufs(),
+                                    analysis_mode: Some(analysis_mode_str(track.analysis_mode())),
                                     peak: Some(track.peak()),
                                     gain_applied_steps: Some(0),
                                     gain_applied_db: Some(0.0),

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -45,7 +45,7 @@ pub fn run_album_analysis(
             on_progress: (!parallel).then_some(&on_progress as _),
             on_complete: parallel.then_some(&on_complete as _),
             cancel: None,
-            mode: Default::default(),
+            mode: opts.analysis_mode,
         },
     );
 

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -1,5 +1,16 @@
+use mp3rgain::replaygain::AnalysisMode;
 use serde::Serialize;
 use std::path::Path;
+
+/// JSON identifier for an [`AnalysisMode`] (issue #269).
+pub fn analysis_mode_str(mode: AnalysisMode) -> &'static str {
+    match mode {
+        AnalysisMode::Rg1 => "rg1",
+        AnalysisMode::Rg2 => "rg2",
+        AnalysisMode::R128 => "r128",
+        _ => "unknown",
+    }
+}
 
 #[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -50,6 +61,10 @@ pub struct JsonFileResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub loudness_db: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub loudness_lufs: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analysis_mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub peak: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_amplitude: Option<f64>,
@@ -77,6 +92,10 @@ impl JsonFileResult {
 #[derive(Serialize, Clone, Copy)]
 pub struct JsonAlbumResult {
     pub loudness_db: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loudness_lufs: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analysis_mode: Option<&'static str>,
     pub gain_db: f64,
     pub gain_steps: i32,
     pub peak: f64,

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -7,7 +7,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::json_output::{FileStatus, JsonFileResult};
+use crate::json_output::{analysis_mode_str, FileStatus, JsonFileResult};
 use crate::processors::utils::analyze_track;
 use crate::util::get_filename;
 
@@ -81,6 +81,8 @@ pub fn format_rg_row(
         JsonFileResult {
             file: file.display().to_string(),
             loudness_db: Some(rg_result.loudness_db()),
+            loudness_lufs: rg_result.loudness_lufs(),
+            analysis_mode: Some(analysis_mode_str(rg_result.analysis_mode())),
             gain_applied_db: Some(gain_db),
             gain_applied_steps: Some(gain_steps),
             peak: Some(rg_result.peak()),

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -8,8 +8,18 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
-use crate::json_output::{FileStatus, JsonFileResult};
+use crate::json_output::{analysis_mode_str, FileStatus, JsonFileResult};
 use crate::util::get_filename;
+
+/// Unit label for a result's loudness value: LUFS for the BS.1770 modes,
+/// dB for RG1.
+fn loudness_unit(result: &ReplayGainResult) -> &'static str {
+    if result.loudness_lufs().is_some() {
+        "LUFS"
+    } else {
+        "dB"
+    }
+}
 
 use super::utils::{
     analyze_track, emit_clipping_warning, report_file_error, restore_timestamp,
@@ -55,8 +65,9 @@ fn process_track_gain_into(
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 writeln!(
                     out,
-                    "      Loudness: {:.1} dB, Gain: {:+.1} dB ({} steps{}), Peak: {:.4}",
+                    "      Loudness: {:.1} {}, Gain: {:+.1} dB ({} steps{}), Peak: {:.4}",
                     result.loudness_db(),
+                    loudness_unit(&result),
                     result.gain_db(),
                     base_steps,
                     if modifier_steps != 0 {
@@ -90,6 +101,8 @@ fn process_track_gain_into(
                     file: file.display().to_string(),
                     status: Some(FileStatus::Skipped),
                     loudness_db: Some(result.loudness_db()),
+                    loudness_lufs: result.loudness_lufs(),
+                    analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
                     peak: Some(result.peak()),
                     gain_applied_steps: Some(0),
                     gain_applied_db: Some(0.0),
@@ -161,6 +174,8 @@ fn apply_replaygain_with_album_into(
                 file: file.display().to_string(),
                 status: Some(FileStatus::DryRun),
                 loudness_db: Some(result.loudness_db()),
+                loudness_lufs: result.loudness_lufs(),
+                analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
                 peak: Some(result.peak()),
                 gain_applied_steps: Some(actual_steps),
                 gain_applied_db: Some(steps_to_db(actual_steps)),
@@ -217,6 +232,8 @@ fn apply_replaygain_with_album_into(
                     status: Some(FileStatus::Success),
                     frames: Some(report.modified),
                     loudness_db: Some(result.loudness_db()),
+                    loudness_lufs: result.loudness_lufs(),
+                    analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
                     peak: Some(result.peak()),
                     gain_applied_steps: Some(report.actual_steps),
                     gain_applied_db: Some(steps_to_db(report.actual_steps)),
@@ -357,6 +374,8 @@ fn apply_replaygain_aac_with_album_into(
                 file: file.display().to_string(),
                 status: Some(FileStatus::Success),
                 loudness_db: Some(result.loudness_db()),
+                loudness_lufs: result.loudness_lufs(),
+                analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
                 peak: Some(result.peak()),
                 gain_applied_steps: Some(actual_steps),
                 gain_applied_db: Some(steps_to_db(actual_steps)),

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -25,21 +25,25 @@ pub fn report_file_error(
     JsonFileResult::error(file, e)
 }
 
-/// Analyze one track, driving the byte-level analysis bar when present.
+/// Analyze one track with the selected analysis mode, driving the byte-level
+/// analysis bar when present.
 pub fn analyze_track(
     file: &Path,
     opts: &Options,
     analysis_pb: Option<&ProgressBar>,
 ) -> mp3rgain::Result<ReplayGainResult> {
-    match analysis_pb {
-        Some(pb) => {
-            replaygain::analyze_track_with_progress(file, opts.track_index, &|bytes, total| {
-                pb.set_length(total);
-                pb.set_position(bytes);
-            })
+    let on_progress = analysis_pb.map(|pb| {
+        move |bytes, total| {
+            pb.set_length(total);
+            pb.set_position(bytes);
         }
-        None => replaygain::analyze_track_with_index(file, opts.track_index),
-    }
+    });
+    replaygain::analyze_track_with_mode(
+        file,
+        opts.track_index,
+        opts.analysis_mode,
+        on_progress.as_ref().map(|cb| cb as &dyn Fn(u64, u64)),
+    )
 }
 
 pub fn save_original_mtime(file: &Path, opts: &Options) -> Option<SystemTime> {

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -167,6 +167,12 @@ impl ReplayGainResult {
         self.analysis_mode
     }
 
+    /// Integrated loudness in LUFS when measured with a BS.1770-based mode;
+    /// `None` for [`AnalysisMode::Rg1`].
+    pub fn loudness_lufs(&self) -> Option<f64> {
+        self.analysis_mode.target_lufs().map(|_| self.loudness_db)
+    }
+
     /// Convert gain in dB to MP3 gain steps (1.5 dB per step)
     pub fn gain_steps(&self) -> i32 {
         crate::gain::db_to_steps(self.gain_db)
@@ -1293,14 +1299,16 @@ pub fn analyze_track_with_index(
 ///
 /// [`AnalysisMode::Rg1`] is identical to [`analyze_track_with_index`]; the
 /// other modes measure BS.1770 integrated loudness and compute the gain
-/// against the mode's target level.
+/// against the mode's target level. `on_progress` behaves like
+/// [`analyze_track_with_progress`].
 #[cfg(feature = "replaygain")]
 pub fn analyze_track_with_mode(
     file_path: &Path,
     track_index: Option<u32>,
     mode: AnalysisMode,
+    on_progress: Option<&dyn Fn(u64, u64)>,
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(file_path, track_index, None, mode)?;
+    let internal = analyze_track_internal(file_path, track_index, on_progress, mode)?;
     Ok(internal.result)
 }
 
@@ -1751,6 +1759,7 @@ pub fn analyze_track_with_mode(
     _file_path: &Path,
     _track_index: Option<u32>,
     _mode: AnalysisMode,
+    _on_progress: Option<&dyn Fn(u64, u64)>,
 ) -> Result<ReplayGainResult> {
     Err(Error::FeatureNotAvailable {
         feature: "ReplayGain analysis",

--- a/tests/bs1770_integration.rs
+++ b/tests/bs1770_integration.rs
@@ -15,6 +15,7 @@ fn lufs(file: &str) -> f64 {
         Path::new(&format!("tests/fixtures/{}", file)),
         None,
         AnalysisMode::Rg2,
+        None,
     )
     .unwrap()
     .loudness_db()
@@ -30,8 +31,8 @@ fn fixture_lufs_matches_ffmpeg_ebur128() {
 #[test]
 fn rg2_and_r128_share_measurement_and_differ_by_target() {
     let path = Path::new("tests/fixtures/test_mono.mp3");
-    let rg2 = analyze_track_with_mode(path, None, AnalysisMode::Rg2).unwrap();
-    let r128 = analyze_track_with_mode(path, None, AnalysisMode::R128).unwrap();
+    let rg2 = analyze_track_with_mode(path, None, AnalysisMode::Rg2, None).unwrap();
+    let r128 = analyze_track_with_mode(path, None, AnalysisMode::R128, None).unwrap();
 
     assert_eq!(rg2.loudness_db(), r128.loudness_db());
     assert!((rg2.gain_db() - (RG2_REFERENCE_LUFS - rg2.loudness_db())).abs() < 1e-12);
@@ -44,7 +45,7 @@ fn rg2_and_r128_share_measurement_and_differ_by_target() {
 fn default_mode_is_unchanged_rg1() {
     let path = Path::new("tests/fixtures/test_mono.mp3");
     let default = analyze_track(path).unwrap();
-    let rg1 = analyze_track_with_mode(path, None, AnalysisMode::Rg1).unwrap();
+    let rg1 = analyze_track_with_mode(path, None, AnalysisMode::Rg1, None).unwrap();
     assert_eq!(default, rg1);
     assert_eq!(default.analysis_mode(), AnalysisMode::Rg1);
 }


### PR DESCRIPTION
Adds the opt-in CLI surface for the BS.1770 loudness engine from #273.

Closes #271. Part of #269.

## Flags

| Flag | Measurement | Target |
|------|-------------|--------|
| *(none)* | ReplayGain 1.0 — unchanged, mp3gain-identical | 89 dB SPL |
| `--rg2` | BS.1770 integrated LUFS | −18 LUFS (RG2 reference) |
| `--r128` | BS.1770 integrated LUFS | −23 LUFS (EBU R128) |

`--rg2` and `--r128` are mutually exclusive (usage error). Both compose with `-r`, `-a`, `-d`/`-m`, `-k`, `-n`, `-j`, `--skip-errors`, and the default info command; gain application still quantizes to 1.5 dB `global_gain` steps through the existing lossless pipeline.

## Tag semantics

Standard `REPLAYGAIN_*` tags (APEv2 default / `-s i` ID3v2 / iTunes freeform for M4A) via the unchanged plumbing — same names as loudgain/foobar2000, only the values differ. No Opus-style `R128_*` Q7.8 tags (Ogg/Opus-specific, out of scope). `-u` undo and `-s c/d/s` are mode-agnostic.

## Output

- **Text**: target line shows the mode (`Target: -18 LUFS (ReplayGain 2.0)`), loudness labeled in LUFS.
- **JSON**: new `analysis_mode` (`"rg1"`/`"rg2"`/`"r128"`) and `loudness_lufs` fields on file and album records; additive only, RG1 output shape unchanged apart from `analysis_mode`.
- **TSV**: untouched — it is the mp3gain-compatible format consumed by beets etc.; values simply reflect the selected mode.

## Library

`analyze_track_with_mode()` gains an `on_progress` parameter (function was introduced in #273 and is not yet in any release, so no compatibility impact) — this lets the CLI byte-progress bar work in all modes through one entry point.

## Verified

- `cargo test` (all suites incl. new parse tests), clippy, `--no-default-features`, mp3rgui build
- Manual end-to-end: `--rg2` dry-run/apply/`-s c`/undo on fixtures; JSON output; mutual-exclusion error
- Default (no flag) output remains byte-identical (golden RG1 reference test unchanged)

Docs updated: README, man page, `--help`, roadmap checkboxes.

Remaining in the v3.0 series: #272 (GUI mode selector).
