### PR TITLE
gui: analysis mode selector for RG1 / RG2 / R128 (issue #272)

### DIFF
--- a/mp3rgui/Cargo.toml
+++ b/mp3rgui/Cargo.toml
@@ -12,7 +12,7 @@ eframe = { version = "0.31", features = ["persistence"] }
 egui = "0.31"
 egui_extras = { version = "0.31", features = ["all_loaders"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
-mp3rgain = { path = ".." }
+mp3rgain = { path = "..", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 
 # Linux: use GTK3 backend to avoid ashpd/xdg-portal compilation issues

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -3,7 +3,7 @@ use crate::worker::{
     WorkerEvent, WorkerHandle,
 };
 use mp3rgain::ape::{parse_rg_gain, parse_rg_peak};
-use mp3rgain::replaygain::{self, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{self, AnalysisMode, ReplayGainResult, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{apply_gain_to_peak, db_to_steps, would_clip, AacAlbumInfo, Channel};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -167,6 +167,8 @@ struct PersistedSettings {
     show_filename_only: bool,
     #[serde(default)]
     single_album: bool,
+    #[serde(default)]
+    analysis_mode: AnalysisMode,
 }
 
 impl Default for PersistedSettings {
@@ -176,6 +178,7 @@ impl Default for PersistedSettings {
             target_volume: 89.0,
             show_filename_only: false,
             single_album: false,
+            analysis_mode: AnalysisMode::default(),
         }
     }
 }
@@ -260,6 +263,11 @@ pub struct Mp3rgainApp {
     /// as a single album regardless of directory (issue #224). Off = each
     /// folder is its own album, the default (issue #159).
     pub single_album: bool,
+
+    /// Loudness measurement mode for Track / Album Analysis (issue #272).
+    /// RG 1.0 (mp3gain-compatible) by default; the BS.1770 modes normalize
+    /// to their fixed LUFS targets and show loudness in LUFS.
+    pub analysis_mode: AnalysisMode,
 }
 
 impl Mp3rgainApp {
@@ -294,7 +302,28 @@ impl Mp3rgainApp {
             pending_drops: Vec::new(),
             show_filename_only: settings.show_filename_only,
             single_album: settings.single_album,
+            analysis_mode: settings.analysis_mode,
         }
+    }
+
+    /// Drop all analysis-derived row values. Called when the analysis mode
+    /// changes: RG1 and BS.1770 numbers live on different scales, so cached
+    /// results must not be reused across modes (issue #272). The stored-tag
+    /// snapshot is kept — it reflects the file, not the analysis.
+    pub fn invalidate_analysis_results(&mut self) {
+        for file in &mut self.files {
+            file.volume = None;
+            file.clipping = false;
+            file.track_gain = None;
+            file.track_clip = false;
+            file.album_volume = None;
+            file.album_gain = None;
+            file.album_clip = false;
+            file.track_result = None;
+            file.album_info = None;
+            file.status = FileStatus::Pending;
+        }
+        self.display_order_dirty = true;
     }
 
     /// Toggle the sort state when the given header is clicked. First click on
@@ -630,7 +659,7 @@ impl Mp3rgainApp {
         self.begin_worker(
             WorkerKind::TrackAnalysis,
             jobs.len(),
-            worker::spawn_track_analysis(ctx.clone(), jobs),
+            worker::spawn_track_analysis(ctx.clone(), jobs, self.analysis_mode),
         );
     }
 
@@ -691,7 +720,7 @@ impl Mp3rgainApp {
         self.begin_worker(
             WorkerKind::AlbumAnalysis,
             total,
-            worker::spawn_album_analysis(ctx.clone(), group_jobs),
+            worker::spawn_album_analysis(ctx.clone(), group_jobs, self.analysis_mode),
         );
     }
 
@@ -1136,7 +1165,8 @@ impl Mp3rgainApp {
                 album_info,
             } => {
                 let target = self.target_volume;
-                let (album_volume, album_gain) = volume_and_gain(album_info.album_gain_db, target);
+                let (album_volume, album_gain) =
+                    volume_and_gain(album_info.album_gain_db, target, self.analysis_mode);
                 let album_clip = would_clip(album_info.album_peak, album_gain);
 
                 for (idx, track_result) in successful {
@@ -1211,10 +1241,11 @@ impl Mp3rgainApp {
             }
             WorkerEvent::StoredTagsRead { idx, view } => {
                 let target = self.target_volume;
+                let mode = self.analysis_mode;
                 let is_import = self.worker_kind() == Some(WorkerKind::ImportScan);
                 if let Some(file) = self.files.get_mut(idx) {
                     if is_import {
-                        Self::populate_from_stored_tags(file, &view, target);
+                        Self::populate_from_stored_tags(file, &view, target, mode);
                     }
                     file.stored_tags = Some(view);
                 }
@@ -1266,13 +1297,15 @@ impl Mp3rgainApp {
     }
 
     /// Populate a file entry with track-level analysis results.
-    /// Volume is displayed relative to ReplayGain reference (89 dB) for MP3Gain compatibility.
+    /// In RG1 mode volume is displayed relative to the 89 dB reference for
+    /// mp3gain compatibility; in the BS.1770 modes it is the LUFS loudness.
     fn populate_track_analysis(
         file: &mut FileEntry,
         result: &ReplayGainResult,
         target_volume: f64,
     ) {
-        let (volume, gain) = volume_and_gain(result.gain_db(), target_volume);
+        let (volume, gain) =
+            volume_and_gain(result.gain_db(), target_volume, result.analysis_mode());
         file.volume = Some(volume);
         file.clipping = result.peak() >= 1.0;
         file.track_gain = Some(gain);
@@ -1287,14 +1320,25 @@ impl Mp3rgainApp {
     /// real analysis is never overwritten. Leaves `track_result` None — the
     /// tags carry no full analysis — so applying gain afterwards falls back to
     /// the headroom-based clipping check, exactly like manual gain.
-    fn populate_from_stored_tags(file: &mut FileEntry, view: &StoredTagsView, target_volume: f64) {
+    ///
+    /// In the BS.1770 modes the tag carries no loudness on the LUFS scale
+    /// (and no record of which algorithm wrote it), so the gain is shown
+    /// as-is and the Volume column is left empty (issue #272).
+    fn populate_from_stored_tags(
+        file: &mut FileEntry,
+        view: &StoredTagsView,
+        target_volume: f64,
+        mode: AnalysisMode,
+    ) {
         if file.status != FileStatus::Pending {
             return;
         }
+        let is_rg1 = mode == AnalysisMode::Rg1;
         let mut found = false;
         if let Some(track_gain_db) = view.track_gain.as_deref().and_then(parse_rg_gain) {
-            let (volume, gain) = volume_and_gain(track_gain_db, target_volume);
-            file.volume = Some(volume);
+            let (volume, gain) = volume_and_gain(track_gain_db, target_volume, AnalysisMode::Rg1);
+            let gain = if is_rg1 { gain } else { track_gain_db };
+            file.volume = is_rg1.then_some(volume);
             file.track_gain = Some(gain);
             if let Some(peak) = view.track_peak.as_deref().and_then(parse_rg_peak) {
                 file.clipping = peak >= 1.0;
@@ -1304,8 +1348,10 @@ impl Mp3rgainApp {
             found = true;
         }
         if let Some(album_gain_db) = view.album_gain.as_deref().and_then(parse_rg_gain) {
-            let (album_volume, album_gain) = volume_and_gain(album_gain_db, target_volume);
-            file.album_volume = Some(album_volume);
+            let (album_volume, album_gain) =
+                volume_and_gain(album_gain_db, target_volume, AnalysisMode::Rg1);
+            let album_gain = if is_rg1 { album_gain } else { album_gain_db };
+            file.album_volume = is_rg1.then_some(album_volume);
             file.album_gain = Some(album_gain);
             if let Some(peak) = view.album_peak.as_deref().and_then(parse_rg_peak) {
                 file.album_clip = would_clip(peak, album_gain);
@@ -1377,13 +1423,20 @@ impl Mp3rgainApp {
     }
 }
 
-/// Display pair for a ReplayGain value: volume relative to the 89 dB
-/// reference, and the gain re-targeted to `target`.
-fn volume_and_gain(gain_db: f64, target: f64) -> (f64, f64) {
-    (
-        REPLAYGAIN_REFERENCE_DB - gain_db,
-        target - REPLAYGAIN_REFERENCE_DB + gain_db,
-    )
+/// Display pair for a ReplayGain value, mode-aware (issue #272).
+///
+/// RG1: volume relative to the 89 dB reference, and the gain re-targeted to
+/// the user-adjustable `target`. BS.1770 modes: measured loudness in LUFS,
+/// and the gain to the mode's fixed LUFS target (the Target control is
+/// disabled in those modes).
+fn volume_and_gain(gain_db: f64, target: f64, mode: AnalysisMode) -> (f64, f64) {
+    match mode.target_lufs() {
+        Some(target_lufs) => (target_lufs - gain_db, gain_db),
+        None => (
+            REPLAYGAIN_REFERENCE_DB - gain_db,
+            target - REPLAYGAIN_REFERENCE_DB + gain_db,
+        ),
+    }
 }
 
 /// Compare two `Option<f64>` values, putting `None` always at the bottom
@@ -1481,6 +1534,7 @@ impl eframe::App for Mp3rgainApp {
             target_volume: self.target_volume,
             show_filename_only: self.show_filename_only,
             single_album: self.single_album,
+            analysis_mode: self.analysis_mode,
         };
         eframe::set_value(storage, SETTINGS_KEY, &settings);
     }

--- a/mp3rgui/src/ui/options.rs
+++ b/mp3rgui/src/ui/options.rs
@@ -1,4 +1,5 @@
 use crate::app::Mp3rgainApp;
+use mp3rgain::replaygain::AnalysisMode;
 
 /// Apply-options checkbox row, shown right below the toolbar.
 ///
@@ -59,6 +60,34 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                         "Show only the file name in the Path/File column instead of \
                          the full path. The full path is still shown on hover.",
                     );
+
+                ui.separator();
+
+                // Loudness measurement mode (issue #272). Switching modes
+                // invalidates cached analysis results — RG1 and BS.1770
+                // numbers live on different scales.
+                ui.label("Analysis:");
+                let before = app.analysis_mode;
+                ui.radio_value(&mut app.analysis_mode, AnalysisMode::Rg1, "RG 1.0")
+                    .on_hover_text(
+                        "ReplayGain 1.0 (default): mp3gain-compatible values, \
+                         89 dB reference. Keeps re-scans consistent with \
+                         libraries normalized by mp3gain.",
+                    );
+                ui.radio_value(&mut app.analysis_mode, AnalysisMode::Rg2, "RG 2.0")
+                    .on_hover_text(
+                        "ReplayGain 2.0: BS.1770 integrated loudness, -18 LUFS \
+                         reference (same perceived level as 89 dB). \
+                         CLI --rg2.",
+                    );
+                ui.radio_value(&mut app.analysis_mode, AnalysisMode::R128, "R128")
+                    .on_hover_text(
+                        "EBU R128: BS.1770 integrated loudness, -23 LUFS \
+                         broadcast target. CLI --r128.",
+                    );
+                if app.analysis_mode != before {
+                    app.invalidate_analysis_results();
+                }
             });
         });
     });

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -68,6 +68,24 @@ fn sort_header(
 }
 
 pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
+    // BS.1770 modes show loudness in LUFS instead of the 89 dB-relative
+    // volume (issue #272); the headers carry the unit so mixed-up scales
+    // are visible at a glance.
+    let lufs = app.analysis_mode.target_lufs().is_some();
+    let (volume_header, album_volume_header) = if lufs {
+        ("Volume (LUFS)", "Album (LUFS)")
+    } else {
+        ("Volume", "Album Vol")
+    };
+    let volume_hover = if lufs {
+        "Track Analysis: BS.1770 integrated loudness in LUFS. \
+         Find Max Amplitude: available headroom in dB before clipping. \
+         Click to sort."
+    } else {
+        "Track Analysis: current loudness relative to ReplayGain reference (89 dB). \
+         Find Max Amplitude: available headroom in dB before clipping. \
+         Click to sort."
+    };
     app.ensure_display_order();
     // Set lookup instead of `Vec::contains` per row, which made selection
     // O(rows × selected) per frame; the set allocation is reused across
@@ -102,15 +120,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                     sort_header(ui, app, "Path/File", SortColumn::Filename, "");
                 });
                 header.col(|ui| {
-                    sort_header(
-                        ui,
-                        app,
-                        "Volume",
-                        SortColumn::Volume,
-                        "Track Analysis: current loudness relative to ReplayGain reference (89 dB). \
-                         Find Max Amplitude: available headroom in dB before clipping. \
-                         Click to sort.",
-                    );
+                    sort_header(ui, app, volume_header, SortColumn::Volume, volume_hover);
                 });
                 header.col(|ui| {
                     ui.strong("Clip");
@@ -122,7 +132,7 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
                     ui.strong("Clip(T)");
                 });
                 header.col(|ui| {
-                    sort_header(ui, app, "Album Vol", SortColumn::AlbumVolume, "");
+                    sort_header(ui, app, album_volume_header, SortColumn::AlbumVolume, "");
                 });
                 header.col(|ui| {
                     sort_header(ui, app, "Album Gain", SortColumn::AlbumGain, "");
@@ -150,100 +160,100 @@ pub fn render(app: &mut Mp3rgainApp, ui: &mut egui::Ui) {
             // `rows` (vs per-row `body.row`) lays out only the rows
             // inside the viewport; fixed 18.0 height makes it a drop-in.
             body.rows(18.0, display_order.len(), |mut row| {
-                    let Some(&idx) = display_order.get(row.index()) else {
-                        return;
-                    };
-                    let Some(file) = app.files.get(idx) else {
-                        return;
-                    };
-                    let is_selected = selected.contains(&idx);
-                    row.set_selected(is_selected);
+                let Some(&idx) = display_order.get(row.index()) else {
+                    return;
+                };
+                let Some(file) = app.files.get(idx) else {
+                    return;
+                };
+                let is_selected = selected.contains(&idx);
+                row.set_selected(is_selected);
 
-                        row.col(|ui| {
-                            let path_text = file.path.to_string_lossy();
-                            // Issue #223: optionally show just the file name;
-                            // the full path stays on hover either way.
-                            let label_text: &str = if app.show_filename_only {
-                                file.filename.as_str()
-                            } else {
-                                path_text.as_ref()
-                            };
-                            let resp = ui
-                                .selectable_label(is_selected, label_text)
-                                .on_hover_text(path_text.as_ref());
-                            if resp.clicked() {
-                                let mode = ui.input(|i| {
-                                    let toggle = i.modifiers.ctrl || i.modifiers.command;
-                                    let shift = i.modifiers.shift;
-                                    match (shift, toggle) {
-                                        (true, true) => ClickMode::RangeAdd,
-                                        (true, false) => ClickMode::Range,
-                                        (false, true) => ClickMode::Toggle,
-                                        (false, false) => ClickMode::Replace,
-                                    }
-                                });
-                                pending_click = Some((idx, mode));
-                            }
-                            // Issue #161 item 4: right-click → reveal in
-                            // file manager. Captured for after-loop apply.
-                            resp.context_menu(|ui| {
-                                if ui.button("Open file location").clicked() {
-                                    pending_reveal = Some(file.path.clone());
-                                    ui.close_menu();
-                                }
-                            });
-                        });
-                        row.col(|ui| {
-                            if let Some(v) = file.volume {
-                                ui.label(format!("{:.1}", v));
+                row.col(|ui| {
+                    let path_text = file.path.to_string_lossy();
+                    // Issue #223: optionally show just the file name;
+                    // the full path stays on hover either way.
+                    let label_text: &str = if app.show_filename_only {
+                        file.filename.as_str()
+                    } else {
+                        path_text.as_ref()
+                    };
+                    let resp = ui
+                        .selectable_label(is_selected, label_text)
+                        .on_hover_text(path_text.as_ref());
+                    if resp.clicked() {
+                        let mode = ui.input(|i| {
+                            let toggle = i.modifiers.ctrl || i.modifiers.command;
+                            let shift = i.modifiers.shift;
+                            match (shift, toggle) {
+                                (true, true) => ClickMode::RangeAdd,
+                                (true, false) => ClickMode::Range,
+                                (false, true) => ClickMode::Toggle,
+                                (false, false) => ClickMode::Replace,
                             }
                         });
-                        row.col(|ui| {
-                            if file.clipping {
-                                ui.colored_label(egui::Color32::RED, "Y");
-                            }
-                        });
-                        row.col(|ui| {
-                            if let Some(g) = file.track_gain {
-                                let color = if file.track_clip {
-                                    egui::Color32::RED
-                                } else {
-                                    ui.style().visuals.text_color()
-                                };
-                                ui.colored_label(color, format!("{:+.1} dB", g));
-                            }
-                        });
-                        row.col(|ui| {
-                            if file.track_clip {
-                                ui.colored_label(egui::Color32::RED, "Y");
-                            }
-                        });
-                        row.col(|ui| {
-                            if let Some(v) = file.album_volume {
-                                ui.label(format!("{:.1}", v));
-                            }
-                        });
-                        row.col(|ui| {
-                            if let Some(g) = file.album_gain {
-                                let color = if file.album_clip {
-                                    egui::Color32::RED
-                                } else {
-                                    ui.style().visuals.text_color()
-                                };
-                                ui.colored_label(color, format!("{:+.1} dB", g));
-                            }
-                        });
-                        row.col(|ui| {
-                            if file.album_clip {
-                                ui.colored_label(egui::Color32::RED, "Y");
-                            }
-                        });
-                        row.col(|ui| {
-                            render_stored_tags_cell(ui, file.stored_tags.as_ref());
-                        });
-                        row.col(|ui| {
-                            ui.label(file.status.label());
-                        });
+                        pending_click = Some((idx, mode));
+                    }
+                    // Issue #161 item 4: right-click → reveal in
+                    // file manager. Captured for after-loop apply.
+                    resp.context_menu(|ui| {
+                        if ui.button("Open file location").clicked() {
+                            pending_reveal = Some(file.path.clone());
+                            ui.close_menu();
+                        }
+                    });
+                });
+                row.col(|ui| {
+                    if let Some(v) = file.volume {
+                        ui.label(format!("{:.1}", v));
+                    }
+                });
+                row.col(|ui| {
+                    if file.clipping {
+                        ui.colored_label(egui::Color32::RED, "Y");
+                    }
+                });
+                row.col(|ui| {
+                    if let Some(g) = file.track_gain {
+                        let color = if file.track_clip {
+                            egui::Color32::RED
+                        } else {
+                            ui.style().visuals.text_color()
+                        };
+                        ui.colored_label(color, format!("{:+.1} dB", g));
+                    }
+                });
+                row.col(|ui| {
+                    if file.track_clip {
+                        ui.colored_label(egui::Color32::RED, "Y");
+                    }
+                });
+                row.col(|ui| {
+                    if let Some(v) = file.album_volume {
+                        ui.label(format!("{:.1}", v));
+                    }
+                });
+                row.col(|ui| {
+                    if let Some(g) = file.album_gain {
+                        let color = if file.album_clip {
+                            egui::Color32::RED
+                        } else {
+                            ui.style().visuals.text_color()
+                        };
+                        ui.colored_label(color, format!("{:+.1} dB", g));
+                    }
+                });
+                row.col(|ui| {
+                    if file.album_clip {
+                        ui.colored_label(egui::Color32::RED, "Y");
+                    }
+                });
+                row.col(|ui| {
+                    render_stored_tags_cell(ui, file.stored_tags.as_ref());
+                });
+                row.col(|ui| {
+                    ui.label(file.status.label());
+                });
             });
         });
     });

--- a/mp3rgui/src/ui/toolbar.rs
+++ b/mp3rgui/src/ui/toolbar.rs
@@ -76,15 +76,28 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
 
             ui.separator();
 
-            // Target volume
+            // Target volume. Adjustable on the 89 dB scale in RG1 mode;
+            // the BS.1770 modes normalize to their fixed LUFS target
+            // (issue #272).
             ui.label("Target:");
-            ui.add_enabled(
-                !app.is_processing(),
-                egui::DragValue::new(&mut app.target_volume)
-                    .speed(0.1)
-                    .range(75.0..=100.0)
-                    .suffix(" dB"),
-            );
+            match app.analysis_mode.target_lufs() {
+                Some(target_lufs) => {
+                    ui.label(format!("{} LUFS", target_lufs)).on_hover_text(
+                        "Fixed target of the selected analysis mode. \
+                         Switch back to RG 1.0 in the Options row to adjust \
+                         the target.",
+                    );
+                }
+                None => {
+                    ui.add_enabled(
+                        !app.is_processing(),
+                        egui::DragValue::new(&mut app.target_volume)
+                            .speed(0.1)
+                            .range(75.0..=100.0)
+                            .suffix(" dB"),
+                    );
+                }
+            }
         });
     });
 }

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -12,7 +12,7 @@ use mp3rgain::apply::{
     apply_with_options, predict_apply, read_mtime, restore_timestamp, write_album_minmax,
     ApplyOptions,
 };
-use mp3rgain::replaygain::{self, ReplayGainResult};
+use mp3rgain::replaygain::{self, AnalysisMode, ReplayGainResult};
 use mp3rgain::{read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -217,7 +217,11 @@ impl Default for ApplyOptionsUi {
 /// file emits a `TrackAnalyzed` event immediately so the table updates as
 /// work happens instead of in a single batch at the end. Cancellation is
 /// checked between files.
-pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) -> WorkerHandle {
+pub fn spawn_track_analysis(
+    ctx: egui::Context,
+    files: Vec<(usize, PathBuf)>,
+    mode: AnalysisMode,
+) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_w = Arc::clone(&cancel);
@@ -232,7 +236,7 @@ pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) ->
             let (analyzed, errors) = (&analyzed, &errors);
             run_job_pool(files, &cancel_w, move |(idx, path)| {
                 send(&tx, &ctx, WorkerEvent::FileStart { idx });
-                match replaygain::analyze_track(&path) {
+                match replaygain::analyze_track_with_mode(&path, None, mode, None) {
                     Ok(result) => {
                         analyzed.fetch_add(1, Ordering::Relaxed);
                         send(&tx, &ctx, WorkerEvent::TrackAnalyzed { idx, result });
@@ -287,6 +291,7 @@ pub fn spawn_track_analysis(ctx: egui::Context, files: Vec<(usize, PathBuf)>) ->
 pub fn spawn_album_analysis(
     ctx: egui::Context,
     groups: Vec<Vec<(usize, PathBuf)>>,
+    mode: AnalysisMode,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
@@ -334,6 +339,7 @@ pub fn spawn_album_analysis(
                     skip_errors: true,
                     on_complete: Some(&on_complete),
                     cancel: Some(&cancel_w),
+                    mode,
                     ..Default::default()
                 },
             );


### PR DESCRIPTION
Adds the analysis-mode selector to mp3rgui, completing the v3.0 series (#269).

Closes #272.

## What changed

- **Options row**: new `Analysis:` radio group — **RG 1.0** (default) / **RG 2.0** / **R128** — with hover text mapping each to its CLI flag. Persisted with the other settings. Disabled while a worker runs, like every other toggle.
- **Mode invalidation**: switching modes clears all analysis-derived row values (volume, gains, clip flags, cached `track_result` / `album_info`) and resets rows to Pending — RG1 and BS.1770 numbers live on different scales, so cached results are never reused across modes. The stored-tag snapshot is kept (it reflects the file, not the analysis).
- **Analysis**: Track / Album Analysis pass the mode to `analyze_track_with_mode` / `AlbumAnalysisOptions.mode`; Apply Track/Album Gain then applies the mode's target gain via the unchanged lossless pipeline (undo, clipping prevention, tags all as before).
- **Display**: in the BS.1770 modes the Volume / Album Vol columns show integrated loudness in LUFS and the headers read `Volume (LUFS)` / `Album (LUFS)`; the toolbar's adjustable 89 dB Target is replaced by the mode's fixed LUFS label (`-18 LUFS` / `-23 LUFS`).
- **Import scan** (#203 path): stored-tag gains stay visible in every mode, but the Volume column is left empty outside RG1 — a `REPLAYGAIN_TRACK_GAIN` tag carries no LUFS loudness and no record of which algorithm wrote it.
- `mp3rgui` now enables the library's `serde` feature so `AnalysisMode` persists in the settings blob (`serde(default)` keeps old blobs loading as RG 1.0).

## Verified

- `cargo build` / `cargo clippy` clean for mp3rgui; full root test suite still green.
- Note: I could not exercise the UI interactively in this environment (no screen access) — the mode plumbing reuses the CLI-verified library path end to end, but a quick manual click-through (switch mode → analyze → apply → undo) is worth doing before merge.
