### PR TITLE
Remove unused public API items for v3.0 (issue #266)

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1285,22 +1285,17 @@ fn apply_aac_gain_to_data(data: &mut [u8], analysis: &AacAnalysis, gain_steps: i
 // Public API
 // =============================================================================
 
-/// Apply gain adjustment to AAC/M4A file (lossless, in-place modification).
+/// Apply gain adjustment to an AAC/M4A file (lossless), reading from
+/// `read_from` and writing to `write_to`.
 ///
-/// Modifies `global_gain` values directly in the file without container rewriting.
-/// Each gain step is approximately 1.5 dB. Values are clamped to 0-255 range.
-///
-/// Returns the number of modified gain locations.
-pub fn apply_aac_gain(file_path: &Path, gain_steps: i32) -> Result<usize> {
-    apply_aac_gain_to_path(file_path, file_path, gain_steps)
-}
-
-/// Apply gain reading from `read_from` and writing to `write_to`.
-///
-/// When `read_from == write_to`, behaves identically to [`apply_aac_gain`].
-/// When the paths differ, reads `read_from` once and writes the modified bytes
+/// Modifies `global_gain` values directly without container rewriting.
+/// Each gain step is approximately 1.5 dB; values are clamped to 0-255.
+/// When `read_from == write_to`, the file is modified in place. When the
+/// paths differ, reads `read_from` once and writes the modified bytes
 /// directly to `write_to` — the caller (e.g. `apply_with_temp_file`) is
 /// responsible for the rename to atomically swap the file (issue #135).
+///
+/// Returns the number of modified gain locations.
 pub fn apply_aac_gain_to_path(read_from: &Path, write_to: &Path, gain_steps: i32) -> Result<usize> {
     apply_aac_gain_to_path_with_analysis(read_from, write_to, gain_steps, None)
 }
@@ -1337,36 +1332,20 @@ pub(crate) fn apply_aac_gain_to_path_with_analysis(
     Ok(modified)
 }
 
-/// Apply gain adjustment and store undo information in iTunes freeform tags.
+/// Apply gain and store undo information in iTunes freeform tags, reading
+/// from `read_from` and writing to `write_to`.
 ///
 /// Undo tags are stored cumulatively: each application adds to the existing
-/// undo value, so multiple gain changes can be fully reversed with a single undo.
-///
-/// Returns the number of modified gain locations.
+/// undo value, so multiple gain changes can be fully reversed with a single
+/// undo. The atomic-write step targets `write_to`, so when this is called
+/// from `apply_with_temp_file` with `write_to == temp_path`, the temp file
+/// ends up containing the fully-rewritten MP4 ready to be renamed over the
+/// original (issue #135). Takes an optional pre-computed analysis of
+/// `read_from` — see [`apply_aac_gain_to_path_with_analysis`] (issue #188).
 //
 // Performs exactly one read and one atomic write: analysis, undo-tag parsing,
 // gain application, and metadata rewrite all run against an in-memory buffer
 // (issue #135).
-pub fn apply_aac_gain_with_undo(file_path: &Path, gain_steps: i32) -> Result<usize> {
-    apply_aac_gain_with_undo_to_path(file_path, file_path, gain_steps)
-}
-
-/// Read-from-A / write-to-B variant of [`apply_aac_gain_with_undo`].
-///
-/// The atomic-write step targets `write_to`, so when this is called from
-/// `apply_with_temp_file` with `write_to == temp_path`, the temp file ends up
-/// containing the fully-rewritten MP4 ready to be renamed over the original
-/// (issue #135).
-pub fn apply_aac_gain_with_undo_to_path(
-    read_from: &Path,
-    write_to: &Path,
-    gain_steps: i32,
-) -> Result<usize> {
-    apply_aac_gain_with_undo_to_path_with_analysis(read_from, write_to, gain_steps, None)
-}
-
-/// [`apply_aac_gain_with_undo_to_path`] with an optional pre-computed analysis
-/// of `read_from` — see [`apply_aac_gain_to_path_with_analysis`] (issue #188).
 pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
     read_from: &Path,
     write_to: &Path,

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -15,9 +15,6 @@ pub const GAIN_STEP_DB: f64 = 1.5;
 /// Maximum global_gain value
 pub const MAX_GAIN: u8 = 255;
 
-/// Minimum global_gain value
-pub const MIN_GAIN: u8 = 0;
-
 /// Channel selection for independent gain adjustment
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -44,14 +41,6 @@ impl Channel {
             0 => Some(Channel::Left),
             1 => Some(Channel::Right),
             _ => None,
-        }
-    }
-
-    /// Get the opposite channel
-    pub fn other(&self) -> Self {
-        match self {
-            Channel::Left => Channel::Right,
-            Channel::Right => Channel::Left,
         }
     }
 
@@ -162,7 +151,7 @@ impl GainOptions {
 
     /// Apply the configured gain adjustment, reading from `read_from` and writing
     /// to `write_to`. When the two paths are the same, this is equivalent to
-    /// [`apply`].
+    /// [`Self::apply`].
     ///
     /// Used by the `--temp-file` (`-t`) path so that the modified audio is written
     /// directly to the temp file without an intermediate full-file copy of the

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -187,25 +187,6 @@ pub fn delete_id3v2_replaygain(path: &Path) -> Result<()> {
     write_tag(path, &tag)
 }
 
-/// Write undo information to ID3v2 TXXX frames
-pub fn write_id3v2_undo(
-    path: &Path,
-    left_gain: i32,
-    right_gain: i32,
-    wrap: bool,
-    min: u8,
-    max: u8,
-) -> Result<()> {
-    write_id3v2_replaygain(
-        path,
-        &Id3v2ReplayGain {
-            undo: Some(crate::ape::format_undo_value(left_gain, right_gain, wrap)),
-            minmax: Some(crate::ape::format_minmax(min, max)),
-            ..Default::default()
-        },
-    )
-}
-
 /// Undo gain changes based on ID3v2 undo tag information
 pub fn undo_gain_id3v2(path: &Path) -> Result<usize> {
     let rg = read_id3v2_replaygain(path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,11 @@ pub use error::{Error, Result};
 pub use gain::{
     apply_gain, apply_gain_db, apply_gain_to_peak, db_to_linear, db_to_steps, peak_to_headroom_db,
     peak_to_pcm_sample, steps_to_db, undo_gain, would_clip, Channel, GainOptions, GAIN_STEP_DB,
-    MAX_GAIN, MIN_GAIN,
+    MAX_GAIN,
 };
 pub use id3v2::{
     delete_id3v2_replaygain, read_id3v2_replaygain, undo_gain_id3v2, write_id3v2_replaygain,
-    write_id3v2_undo, Id3v2ReplayGain,
+    Id3v2ReplayGain,
 };
 
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Removes the unused public API items flagged by the 2026-07 full-codebase review, per the plan in #266. **Semver-breaking — must ship in v3.0.0** (which is imminent, hence the timing).

Closes #266.

## Removed

| Item | Location | Re-verified |
|------|----------|-------------|
| `write_id3v2_undo` | `src/id3v2.rs` + `lib.rs` re-export | zero callers |
| `Channel::other()` | `src/gain.rs` | zero callers |
| `MIN_GAIN` | `src/gain.rs` + `lib.rs` re-export | never read |
| `apply_aac_gain` | `src/aac.rs` | all callers use the `_to_path` variant |
| `apply_aac_gain_with_undo` | `src/aac.rs` | same |
| `apply_aac_gain_with_undo_to_path` | `src/aac.rs` | **added during re-verification** — its only caller was the `apply_aac_gain_with_undo` wrapper removed above, so it fails the same zero-usage test |

Every removal was re-verified with a grep across `src/`, `mp3rgui/`, and `tests/` at cleanup time, as the issue's plan required.

## Kept

- `apply_aac_gain_to_path` — used by `apply_gain_db_auto` (lib.rs); its doc absorbed the in-place semantics from the removed wrapper.
- `apply_aac_gain_with_undo_to_path_with_analysis` (pub(crate)) — the apply pipeline's actual entry point; its doc now carries the cumulative-undo semantics.

## Drive-by

- Fixed the pre-existing unresolved `[apply]` intra-doc link in `gain.rs` (→ `[Self::apply]`).

## Verified

`cargo test` (all suites), clippy `--all-features` clean, GUI and `--no-default-features` builds, and `cargo doc` warning count unchanged vs master (8 pre-existing).

Reminder for the v3.0.0 release notes: mention these API removals.
