### PR TITLE
Simplify v3.0 changes: consolidate mode helpers and JSON construction

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -1333,12 +1333,21 @@ impl Mp3rgainApp {
         if file.status != FileStatus::Pending {
             return;
         }
-        let is_rg1 = mode == AnalysisMode::Rg1;
+        // `(volume column, gain column)` for one stored gain value: the RG1
+        // display pair, or — outside RG1, where the tag carries no LUFS
+        // loudness — the tag gain as-is with an empty Volume column.
+        let display = |gain_db: f64| -> (Option<f64>, f64) {
+            if mode == AnalysisMode::Rg1 {
+                let (volume, gain) = volume_and_gain(gain_db, target_volume, AnalysisMode::Rg1);
+                (Some(volume), gain)
+            } else {
+                (None, gain_db)
+            }
+        };
         let mut found = false;
         if let Some(track_gain_db) = view.track_gain.as_deref().and_then(parse_rg_gain) {
-            let (volume, gain) = volume_and_gain(track_gain_db, target_volume, AnalysisMode::Rg1);
-            let gain = if is_rg1 { gain } else { track_gain_db };
-            file.volume = is_rg1.then_some(volume);
+            let (volume, gain) = display(track_gain_db);
+            file.volume = volume;
             file.track_gain = Some(gain);
             if let Some(peak) = view.track_peak.as_deref().and_then(parse_rg_peak) {
                 file.clipping = peak >= 1.0;
@@ -1348,10 +1357,8 @@ impl Mp3rgainApp {
             found = true;
         }
         if let Some(album_gain_db) = view.album_gain.as_deref().and_then(parse_rg_gain) {
-            let (album_volume, album_gain) =
-                volume_and_gain(album_gain_db, target_volume, AnalysisMode::Rg1);
-            let album_gain = if is_rg1 { album_gain } else { album_gain_db };
-            file.album_volume = is_rg1.then_some(album_volume);
+            let (album_volume, album_gain) = display(album_gain_db);
+            file.album_volume = album_volume;
             file.album_gain = Some(album_gain);
             if let Some(peak) = view.album_peak.as_deref().and_then(parse_rg_peak) {
                 file.album_clip = would_clip(peak, album_gain);

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -188,36 +188,29 @@ impl BlockEnergies {
     /// measurable loudness" rather than a huge gain.
     pub fn integrated_lufs(&self) -> f64 {
         let absolute_gate = loudness_to_energy(ABSOLUTE_GATE_LUFS);
-
-        let mut sum = 0.0;
-        let mut count = 0usize;
-        for &e in &self.energies {
-            if e > absolute_gate {
-                sum += e;
-                count += 1;
-            }
-        }
-        if count == 0 {
+        let Some(ungated_mean) = gated_mean(&self.energies, absolute_gate) else {
             return f64::NEG_INFINITY;
-        }
+        };
 
-        let relative_gate = (sum / count as f64) * RELATIVE_GATE_FACTOR;
-        let gate = absolute_gate.max(relative_gate);
-
-        let mut sum = 0.0;
-        let mut count = 0usize;
-        for &e in &self.energies {
-            if e > gate {
-                sum += e;
-                count += 1;
-            }
+        let gate = absolute_gate.max(ungated_mean * RELATIVE_GATE_FACTOR);
+        match gated_mean(&self.energies, gate) {
+            Some(mean) => energy_to_loudness(mean),
+            None => f64::NEG_INFINITY,
         }
-        if count == 0 {
-            return f64::NEG_INFINITY;
-        }
-
-        energy_to_loudness(sum / count as f64)
     }
+}
+
+/// Mean of the energies strictly above `gate`; `None` when none survive.
+fn gated_mean(energies: &[f64], gate: f64) -> Option<f64> {
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for &e in energies {
+        if e > gate {
+            sum += e;
+            count += 1;
+        }
+    }
+    (count > 0).then(|| sum / count as f64)
 }
 
 /// Streaming BS.1770 analyzer for one track.
@@ -324,7 +317,7 @@ mod tests {
     }
 
     fn append_sine(samples: &mut Vec<f64>, level_dbfs: f64, seconds: f64, sample_rate: u32) {
-        let amplitude = 10f64.powf(level_dbfs / 20.0);
+        let amplitude = crate::gain::db_to_linear(level_dbfs);
         let count = (seconds * sample_rate as f64) as usize;
         let step = 2.0 * std::f64::consts::PI * 997.0 / sample_rate as f64;
         for n in 0..count {

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::replaygain::{self, AlbumAnalysisReport, AnalysisMode, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{self, AlbumAnalysisReport, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{steps_to_db, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
@@ -12,42 +12,28 @@ use crate::commands::utils::{
     create_json_summary, exit_if_failed, finish_with_summary, for_each_file_with_analysis_bar,
     print_dry_run_notice, run_album_analysis, update_counters,
 };
-use crate::json_output::{
-    analysis_mode_str, FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput,
-};
+use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
 fn print_target_with_modifier(opts: &Options) {
+    let mode = opts.analysis_mode;
+    let target = mode.target_lufs().unwrap_or(REPLAYGAIN_REFERENCE_DB);
     let modifier_steps = opts.gain_modifier_steps();
-    let modifier_db = steps_to_db(modifier_steps);
-    match opts.analysis_mode.target_lufs() {
-        Some(target) => {
-            if modifier_steps != 0 {
-                println!(
-                    "  Target: {:.1} LUFS ({} {} LUFS {:+.1} dB modifier)",
-                    target + modifier_db,
-                    opts.analysis_mode,
-                    target,
-                    modifier_db,
-                );
-            } else {
-                println!("  Target: {} LUFS ({})", target, opts.analysis_mode);
-            }
-        }
-        None => {
-            if modifier_steps != 0 {
-                println!(
-                    "  Target: {:.1} dB (ReplayGain {} dB {:+.1} dB modifier)",
-                    REPLAYGAIN_REFERENCE_DB + modifier_db,
-                    REPLAYGAIN_REFERENCE_DB,
-                    modifier_db,
-                );
-            } else {
-                println!("  Target: {} dB (ReplayGain 1.0)", REPLAYGAIN_REFERENCE_DB);
-            }
-        }
+    if modifier_steps != 0 {
+        let modifier_db = steps_to_db(modifier_steps);
+        println!(
+            "  Target: {:.1} {} ({} {} {} {:+.1} dB modifier)",
+            target + modifier_db,
+            mode.unit(),
+            mode,
+            target,
+            mode.unit(),
+            modifier_db,
+        );
+    } else {
+        println!("  Target: {} {} ({})", target, mode.unit(), mode);
     }
 }
 
@@ -152,11 +138,11 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let modifier_steps = opts.gain_modifier_steps();
             let modified_gain_steps = album_result.album_gain_steps() + modifier_steps;
 
-            let is_lufs = opts.analysis_mode != AnalysisMode::Rg1;
+            let is_lufs = opts.analysis_mode.target_lufs().is_some();
             let json_album = JsonAlbumResult {
                 loudness_db: album_result.album_loudness_db(),
                 loudness_lufs: is_lufs.then(|| album_result.album_loudness_db()),
-                analysis_mode: Some(analysis_mode_str(opts.analysis_mode)),
+                analysis_mode: Some(opts.analysis_mode.name()),
                 gain_db: album_result.album_gain_db(),
                 gain_steps: modified_gain_steps,
                 peak: album_result.album_peak(),
@@ -172,7 +158,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 println!(
                     "  Album loudness: {:.1} {}",
                     album_result.album_loudness_db(),
-                    if is_lufs { "LUFS" } else { "dB" }
+                    opts.analysis_mode.unit()
                 );
                 println!(
                     "  Album gain:     {:+.1} dB ({} steps{})",
@@ -200,15 +186,10 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                             Some(track_idx) => {
                                 let track = &album_result.tracks()[track_idx];
                                 JsonFileResult {
-                                    file: file.display().to_string(),
                                     status: Some(FileStatus::Skipped),
-                                    loudness_db: Some(track.loudness_db()),
-                                    loudness_lufs: track.loudness_lufs(),
-                                    analysis_mode: Some(analysis_mode_str(track.analysis_mode())),
-                                    peak: Some(track.peak()),
                                     gain_applied_steps: Some(0),
                                     gain_applied_db: Some(0.0),
-                                    ..Default::default()
+                                    ..JsonFileResult::from_analysis(file, track)
                                 }
                             }
                             None => JsonFileResult::error(

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -1,16 +1,6 @@
-use mp3rgain::replaygain::AnalysisMode;
+use mp3rgain::replaygain::ReplayGainResult;
 use serde::Serialize;
 use std::path::Path;
-
-/// JSON identifier for an [`AnalysisMode`] (issue #269).
-pub fn analysis_mode_str(mode: AnalysisMode) -> &'static str {
-    match mode {
-        AnalysisMode::Rg1 => "rg1",
-        AnalysisMode::Rg2 => "rg2",
-        AnalysisMode::R128 => "r128",
-        _ => "unknown",
-    }
-}
 
 #[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -84,6 +74,20 @@ impl JsonFileResult {
             file: file.display().to_string(),
             status: Some(FileStatus::Error),
             error: Some(e.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Base record for `file` carrying a ReplayGain analysis (loudness, mode,
+    /// peak). Call sites layer their status / gain fields on top with struct
+    /// update syntax.
+    pub fn from_analysis(file: &Path, result: &ReplayGainResult) -> Self {
+        Self {
+            file: file.display().to_string(),
+            loudness_db: Some(result.loudness_db()),
+            loudness_lufs: result.loudness_lufs(),
+            analysis_mode: Some(result.analysis_mode().name()),
+            peak: Some(result.peak()),
             ..Default::default()
         }
     }

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -7,7 +7,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::json_output::{analysis_mode_str, FileStatus, JsonFileResult};
+use crate::json_output::{FileStatus, JsonFileResult};
 use crate::processors::utils::analyze_track;
 use crate::util::get_filename;
 
@@ -79,17 +79,12 @@ pub fn format_rg_row(
 
     Ok((
         JsonFileResult {
-            file: file.display().to_string(),
-            loudness_db: Some(rg_result.loudness_db()),
-            loudness_lufs: rg_result.loudness_lufs(),
-            analysis_mode: Some(analysis_mode_str(rg_result.analysis_mode())),
             gain_applied_db: Some(gain_db),
             gain_applied_steps: Some(gain_steps),
-            peak: Some(rg_result.peak()),
             max_amplitude: Some(max_amp),
             max_gain: Some(max_gain),
             min_gain: Some(min_gain),
-            ..Default::default()
+            ..JsonFileResult::from_analysis(file, rg_result)
         },
         out,
     ))

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -8,18 +8,8 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
-use crate::json_output::{analysis_mode_str, FileStatus, JsonFileResult};
+use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
-
-/// Unit label for a result's loudness value: LUFS for the BS.1770 modes,
-/// dB for RG1.
-fn loudness_unit(result: &ReplayGainResult) -> &'static str {
-    if result.loudness_lufs().is_some() {
-        "LUFS"
-    } else {
-        "dB"
-    }
-}
 
 use super::utils::{
     analyze_track, emit_clipping_warning, report_file_error, restore_timestamp,
@@ -67,7 +57,7 @@ fn process_track_gain_into(
                     out,
                     "      Loudness: {:.1} {}, Gain: {:+.1} dB ({} steps{}), Peak: {:.4}",
                     result.loudness_db(),
-                    loudness_unit(&result),
+                    result.analysis_mode().unit(),
                     result.gain_db(),
                     base_steps,
                     if modifier_steps != 0 {
@@ -98,15 +88,10 @@ fn process_track_gain_into(
                     writeln!(out, "  {} {} (no adjustment needed)", ".".cyan(), filename)?;
                 }
                 return Ok(JsonFileResult {
-                    file: file.display().to_string(),
                     status: Some(FileStatus::Skipped),
-                    loudness_db: Some(result.loudness_db()),
-                    loudness_lufs: result.loudness_lufs(),
-                    analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
-                    peak: Some(result.peak()),
                     gain_applied_steps: Some(0),
                     gain_applied_db: Some(0.0),
-                    ..Default::default()
+                    ..JsonFileResult::from_analysis(file, &result)
                 });
             }
 
@@ -171,17 +156,12 @@ fn apply_replaygain_with_album_into(
         }
         return Ok((
             JsonFileResult {
-                file: file.display().to_string(),
                 status: Some(FileStatus::DryRun),
-                loudness_db: Some(result.loudness_db()),
-                loudness_lufs: result.loudness_lufs(),
-                analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
-                peak: Some(result.peak()),
                 gain_applied_steps: Some(actual_steps),
                 gain_applied_db: Some(steps_to_db(actual_steps)),
                 warning: warning_msg,
                 dry_run: Some(true),
-                ..Default::default()
+                ..JsonFileResult::from_analysis(file, result)
             },
             None,
         ));
@@ -228,17 +208,12 @@ fn apply_replaygain_with_album_into(
 
             Ok((
                 JsonFileResult {
-                    file: file.display().to_string(),
                     status: Some(FileStatus::Success),
                     frames: Some(report.modified),
-                    loudness_db: Some(result.loudness_db()),
-                    loudness_lufs: result.loudness_lufs(),
-                    analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
-                    peak: Some(result.peak()),
                     gain_applied_steps: Some(report.actual_steps),
                     gain_applied_db: Some(steps_to_db(report.actual_steps)),
                     warning: warning_msg,
-                    ..Default::default()
+                    ..JsonFileResult::from_analysis(file, result)
                 },
                 report.gain_range,
             ))
@@ -371,16 +346,11 @@ fn apply_replaygain_aac_with_album_into(
             }
 
             Ok(JsonFileResult {
-                file: file.display().to_string(),
                 status: Some(FileStatus::Success),
-                loudness_db: Some(result.loudness_db()),
-                loudness_lufs: result.loudness_lufs(),
-                analysis_mode: Some(analysis_mode_str(result.analysis_mode())),
-                peak: Some(result.peak()),
                 gain_applied_steps: Some(actual_steps),
                 gain_applied_db: Some(steps_to_db(actual_steps)),
                 warning: warning_msg,
-                ..Default::default()
+                ..JsonFileResult::from_analysis(file, result)
             })
         }
         Err(e) => Ok(report_file_error(file, filename, e, opts)),

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -80,6 +80,25 @@ impl AnalysisMode {
             AnalysisMode::R128 => Some(R128_REFERENCE_LUFS),
         }
     }
+
+    /// Unit label for loudness values measured in this mode.
+    pub fn unit(&self) -> &'static str {
+        if self.target_lufs().is_some() {
+            "LUFS"
+        } else {
+            "dB"
+        }
+    }
+
+    /// Lowercase short name (`"rg1"` / `"rg2"` / `"r128"`) for machine-readable
+    /// output, following the [`Channel::name`](crate::Channel::name) convention.
+    pub fn name(&self) -> &'static str {
+        match self {
+            AnalysisMode::Rg1 => "rg1",
+            AnalysisMode::Rg2 => "rg2",
+            AnalysisMode::R128 => "r128",
+        }
+    }
 }
 
 impl std::fmt::Display for AnalysisMode {
@@ -1062,10 +1081,13 @@ impl LoudnessState {
 
 /// Convert integrated LUFS to `(loudness, gain_db)` for the mode's target.
 /// Fully-gated input (silence) has no measurable loudness and is treated as
-/// already at target: gain 0.
+/// already at target: gain 0. Only reachable from BS.1770 branches, so an
+/// RG1 mode here is a programming error.
 #[cfg(feature = "replaygain")]
 fn lufs_loudness_and_gain(lufs: f64, mode: AnalysisMode) -> (f64, f64) {
-    let target = mode.target_lufs().unwrap_or(RG2_REFERENCE_LUFS);
+    let target = mode
+        .target_lufs()
+        .expect("BS.1770 gain calculation requires an RG2/R128 mode");
     if lufs.is_finite() {
         (lufs, target - lufs)
     } else {
@@ -1092,7 +1114,6 @@ enum TrackAnalyzer {
     },
     Bs1770 {
         analyzer: crate::bs1770::Bs1770Analyzer,
-        frame_buf: Vec<f64>,
     },
 }
 
@@ -1210,7 +1231,6 @@ fn analyze_track_internal(
         }
         _ => TrackAnalyzer::Bs1770 {
             analyzer: crate::bs1770::Bs1770Analyzer::new(sample_rate, channels),
-            frame_buf: Vec::with_capacity(channels),
         },
     };
     let mut peak: f64 = 0.0;
@@ -1238,10 +1258,9 @@ fn analyze_track_internal(
             TrackAnalyzer::Rg1 { filters, analyzer } => {
                 process_audio_buffer(&decoded, filters, analyzer, &mut peak)
             }
-            TrackAnalyzer::Bs1770 {
-                analyzer,
-                frame_buf,
-            } => process_audio_buffer_bs1770(&decoded, analyzer, frame_buf, &mut peak),
+            TrackAnalyzer::Bs1770 { analyzer } => {
+                process_audio_buffer_bs1770(&decoded, analyzer, &mut peak)
+            }
         }
 
         // Report progress
@@ -1291,8 +1310,7 @@ pub fn analyze_track_with_index(
     file_path: &Path,
     track_index: Option<u32>,
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(file_path, track_index, None, AnalysisMode::default())?;
-    Ok(internal.result)
+    analyze_track_with_mode(file_path, track_index, AnalysisMode::default(), None)
 }
 
 /// Analyze a single track using the given analysis mode (issue #269).
@@ -1324,13 +1342,12 @@ pub fn analyze_track_with_progress(
     track_index: Option<u32>,
     on_progress: &dyn Fn(u64, u64),
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(
+    analyze_track_with_mode(
         file_path,
         track_index,
-        Some(on_progress),
         AnalysisMode::default(),
-    )?;
-    Ok(internal.result)
+        Some(on_progress),
+    )
 }
 
 /// Scale factor to convert normalized float samples to 16-bit integer range.
@@ -1340,6 +1357,9 @@ pub fn analyze_track_with_progress(
 /// scale them to match the original algorithm's expected input range.
 /// Without this scaling, gain values are off by 20 * log10(32768) ≈ 90.31 dB.
 const SAMPLE_SCALE_16BIT: f64 = 32768.0;
+
+/// Scale factor for 32-bit integer samples (2^31).
+const SAMPLE_SCALE_32BIT: f64 = 2147483648.0;
 
 /// Process an audio buffer and feed filtered samples to the analyzer
 #[cfg(feature = "replaygain")]
@@ -1400,7 +1420,7 @@ fn process_audio_buffer(
             let channels = buf.num_planes();
             let frames = buf.frames();
             // Scale S32 to 16-bit range: divide by 2^16 to go from 32-bit to 16-bit range
-            let scale = SAMPLE_SCALE_16BIT / 2147483648.0;
+            let scale = SAMPLE_SCALE_16BIT / SAMPLE_SCALE_32BIT;
             let left_plane = buf.plane(0).unwrap();
             let right_plane = (channels >= 2).then(|| buf.plane(1).unwrap());
 
@@ -1433,7 +1453,6 @@ fn process_audio_buffer(
 fn process_audio_buffer_bs1770(
     buffer: &GenericAudioBufferRef,
     analyzer: &mut crate::bs1770::Bs1770Analyzer,
-    frame_buf: &mut Vec<f64>,
     peak: &mut f64,
 ) {
     fn feed<T: Copy>(
@@ -1441,17 +1460,38 @@ fn process_audio_buffer_bs1770(
         frames: usize,
         conv: impl Fn(T) -> f64,
         analyzer: &mut crate::bs1770::Bs1770Analyzer,
-        frame_buf: &mut Vec<f64>,
         peak: &mut f64,
     ) {
-        for frame in 0..frames {
-            frame_buf.clear();
-            for plane in planes {
-                let v = conv(plane[frame]);
-                *peak = peak.max(v.abs());
-                frame_buf.push(v);
+        // Mono and stereo (all MP3, nearly all AAC) go through fixed-size
+        // frames, mirroring the RG1 path's hoisted-plane specialization;
+        // rarer multichannel layouts fall back to a per-packet buffer.
+        match planes {
+            [mono] => {
+                for &s in &mono[..frames] {
+                    let v = conv(s);
+                    *peak = peak.max(v.abs());
+                    analyzer.add_frame(&[v]);
+                }
             }
-            analyzer.add_frame(frame_buf);
+            [left, right] => {
+                for (&l, &r) in left[..frames].iter().zip(&right[..frames]) {
+                    let l = conv(l);
+                    let r = conv(r);
+                    *peak = peak.max(l.abs()).max(r.abs());
+                    analyzer.add_frame(&[l, r]);
+                }
+            }
+            _ => {
+                let mut frame_buf = vec![0.0; planes.len()];
+                for frame in 0..frames {
+                    for (dst, plane) in frame_buf.iter_mut().zip(planes) {
+                        let v = conv(plane[frame]);
+                        *peak = peak.max(v.abs());
+                        *dst = v;
+                    }
+                    analyzer.add_frame(&frame_buf);
+                }
+            }
         }
     }
 
@@ -1460,14 +1500,7 @@ fn process_audio_buffer_bs1770(
             let planes: Vec<&[f32]> = (0..buf.num_planes())
                 .map(|i| buf.plane(i).unwrap())
                 .collect();
-            feed(
-                &planes,
-                buf.frames(),
-                |s| s as f64,
-                analyzer,
-                frame_buf,
-                peak,
-            );
+            feed(&planes, buf.frames(), |s| s as f64, analyzer, peak);
         }
         GenericAudioBufferRef::S16(buf) => {
             let planes: Vec<&[i16]> = (0..buf.num_planes())
@@ -1478,7 +1511,6 @@ fn process_audio_buffer_bs1770(
                 buf.frames(),
                 |s| s as f64 / SAMPLE_SCALE_16BIT,
                 analyzer,
-                frame_buf,
                 peak,
             );
         }
@@ -1489,9 +1521,8 @@ fn process_audio_buffer_bs1770(
             feed(
                 &planes,
                 buf.frames(),
-                |s| s as f64 / 2147483648.0,
+                |s| s as f64 / SAMPLE_SCALE_32BIT,
                 analyzer,
-                frame_buf,
                 peak,
             );
         }
@@ -1944,7 +1975,7 @@ pub fn find_peak_amplitude(file_path: &Path) -> Result<PeakAmplitudeResult> {
             GenericAudioBufferRef::S32(buf) => {
                 for ch in 0..buf.num_planes() {
                     for &sample in buf.plane(ch).unwrap() {
-                        let s = (sample as f64).abs() / 2147483648.0;
+                        let s = (sample as f64).abs() / SAMPLE_SCALE_32BIT;
                         max_peak = max_peak.max(s);
                     }
                 }


### PR DESCRIPTION
Pre-release cleanup of everything added since v2.11.0 (PRs #273–#276), from a three-agent review pass (code reuse / quality / efficiency). Net −19 lines, no behavior change.

## Fixed

**Consistency — one canonical definition per concept**
- `AnalysisMode::unit()` ("LUFS"/"dB") and `AnalysisMode::name()` ("rg1"/"rg2"/"r128", following the `Channel::name()` convention) now live on the enum. The same logic was previously spelled four different ways across `commands/replaygain.rs`, `processors/replaygain.rs`, `json_output.rs`, and the GUI. Deletes `analysis_mode_str` (with its unreachable `"unknown"` arm) and the local `loudness_unit` helper.
- `JsonFileResult::from_analysis(file, result)` replaces the loudness/mode/peak field trio copy-pasted across six JSON construction sites; call sites layer status/gain fields via struct-update syntax.
- `print_target_with_modifier`: single code path instead of the 2×2 LUFS/dB × modifier branch. (Minor output change: the RG1 modifier line now reads `ReplayGain 1.0 89 dB +3.0 dB modifier` instead of `ReplayGain 89 dB +3.0 dB modifier`.)

**Hack removal**
- GUI `populate_from_stored_tags`: the compute-then-discard `volume_and_gain` dance (duplicated for track and album) is now a single `display` helper that states the intent directly.
- `lufs_loudness_and_gain`: `expect()` instead of `unwrap_or(RG2_REFERENCE_LUFS)` — an RG1 mode reaching this function is a programming error and now fails loudly instead of silently computing against the RG2 target.
- `analyze_track_with_index` / `analyze_track_with_progress` delegate to `analyze_track_with_mode`, giving `analyze_track_internal` a single entry point.

**Efficiency / hot path**
- `process_audio_buffer_bs1770` gets mono/stereo specialization mirroring the RG1 path's structure: fixed-size frames instead of per-frame `Vec` bookkeeping, and the `frame_buf` plumbing disappears from `TrackAnalyzer`. Multichannel (>2ch AAC) keeps a per-packet buffer fallback. Worth a few percent of BS.1770 analysis time; mainly a consistency win.

**Small reuse**
- `bs1770::integrated_lufs`: the duplicated gate-sum loop is now `gated_mean()` called twice; the test helper reuses `gain::db_to_linear`.
- `SAMPLE_SCALE_32BIT` names the 2^31 literal that appeared three times.

## Reviewed and deliberately skipped

- Dropping the JSON `loudness_lufs` field (duplicates `loudness_db` in BS.1770 modes) — it is the documented schema from #271; keeping the explicit field is the design.
- Unifying the `--rg2`/`--r128` mutual-exclusion blocks in `parse_args` — with exactly two flags, the current one-block-per-flag style matches the rest of the parser.
- Storing the mode on `AlbumGainResult` — an API addition, not a simplification.

## Verified

- Full test suite green, including the RG1 bit-identity golden test (`analysis_matches_reference_c_to_float_precision`) — the RG1 hot path is untouched.
- CLI output byte-identical for RG1 and RG2 dry-runs on fixtures; JSON fields (`analysis_mode`, `loudness_lufs`) unchanged.
- clippy `--all-features` clean; GUI and `--no-default-features` builds pass.
