### PR TITLE
ci: fetch Windows ffmpeg from GitHub and stop matrix fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -59,8 +60,14 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $url = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
-          Invoke-WebRequest -Uri $url -OutFile ffmpeg.zip
+          # GitHub-hosted build: gyan.dev is a single shared-hosting site and
+          # has returned 503 mid-run, taking the whole matrix down with it.
+          $ProgressPreference = "SilentlyContinue"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest -Uri $url -OutFile ffmpeg.zip; break }
+            catch { if ($i -eq 3) { throw }; Start-Sleep -Seconds (10 * $i) }
+          }
           Expand-Archive -Path ffmpeg.zip -DestinationPath C:\ffmpeg
           $ffmpegBin = Get-ChildItem -Path C:\ffmpeg -Recurse -Directory -Filter "bin" | Select-Object -First 1
           echo "$($ffmpegBin.FullName)" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -90,6 +97,7 @@ jobs:
     name: GUI on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 


### PR DESCRIPTION
## Problem

[Run 31163231296](https://github.com/M-Igashi/mp3rgain/actions/runs/31163231296) failed on `master` — not because of a code change, but because the ffmpeg download host went down mid-run:

```
Invoke-WebRequest -Uri https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip
  | 503 Service Unavailable   www.gyan.dev
  | ...NFSN:e13  NearlyFreeSpeech Error 503
```

`gyan.dev` is a single-maintainer site on shared hosting with no SLA, so this will recur. Because the matrix had no `fail-fast: false`, the Windows failure also cancelled the Ubuntu and macOS jobs, so that commit was never actually verified on any platform.

## Changes

- **Windows ffmpeg now comes from [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) GitHub Releases** — GitHub-hosted, so runners fetch it over the same network. Verified the archive ships `bin/ffmpeg.exe` (the existing recursive `bin` lookup finds it unchanged) and that the build has `--enable-libmp3lame`, which the `-f mp3` fixtures require.
- **Retry up to 3 times with backoff** (10s, 20s) for any remaining transient failure.
- **`$ProgressPreference = "SilentlyContinue"`** — the GPL build is 162 MB and `Invoke-WebRequest`'s progress bar slows large downloads considerably.
- **`fail-fast: false` on both matrix jobs** (`test` and `gui`) so one platform's environment failure no longer cancels the others.

## Verification

This PR's own CI run exercises the new Windows ffmpeg path end-to-end.