### PR TITLE
docs: note the Windows Defender false positive on mp3rgui

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ mp3rgain adjusts MP3 and AAC volume without re-encoding by modifying the `global
 
 Binaries for all platforms are also available from [GitHub Releases](https://github.com/M-Igashi/mp3rgain/releases).
 
+> [!NOTE]
+> **Windows: Defender may flag `mp3rgui.exe` as a false positive.**
+> The GUI is an unsigned, statically linked Rust binary, which occasionally trips
+> Microsoft Defender's cloud/ML heuristics (e.g. `Trojan:Win32/Sprisky.U!cl`).
+> It is a false positive — every release is built from public source by a
+> [public GitHub Actions workflow](.github/workflows/release.yml), and each release
+> ships `.sha256` files so you can verify what you downloaded. False positives are
+> reported to Microsoft as they appear, and usually clear within a few days once
+> the definitions update. If you hit this, please
+> [open an issue](https://github.com/M-Igashi/mp3rgain/issues) so it can be reported.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Adds a note under Installation so Windows users who hit a Defender block on `mp3rgui.exe` have an authoritative answer without needing to open an issue first (though it invites them to, so new detections get reported to Microsoft).

Context: v3.0.0 is detected as `Trojan:Win32/Sprisky.U!cl` (cloud/ML heuristic), currently blocking microsoft/winget-pkgs#412645. False-positive reports for both architectures are filed with Microsoft. Since code signing is out of scope, this can recur on future releases — hence a permanent note rather than a one-off reply.

Docs-only; `*.md` is in the CI `paths-ignore` list so no CI run is expected.