### PR TITLE
gui: explain OpenGL startup failures and document the RDP limitation

### DIFF
--- a/mp3rgui/src/main.rs
+++ b/mp3rgui/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod startup;
 mod ui;
 mod worker;
 
@@ -20,7 +21,7 @@ fn main() {
         options,
         Box::new(|cc| Ok(Box::new(Mp3rgainApp::new(cc)))),
     ) {
-        let msg = format!("Failed to start mp3rgain GUI:\n\n{e}");
+        let msg = startup::startup_error_message(startup::classify(&e), &e.to_string());
         eprintln!("{msg}");
         rfd::MessageDialog::new()
             .set_title("mp3rgain Error")

--- a/mp3rgui/src/startup.rs
+++ b/mp3rgui/src/startup.rs
@@ -1,0 +1,126 @@
+//! Diagnosis of `eframe::run_native` startup failures (issue #282).
+//!
+//! The raw eframe error is accurate but unhelpful — a user who sees
+//! "egui_glow requires opengl 2.0+" has no way to know that installing a
+//! graphics driver, or just using the CLI, would solve their problem.
+
+use eframe::Error;
+
+const CLI_HINT: &str =
+    "  - Use the mp3rgain command-line tool instead. It does everything the GUI\n\
+     \x20   does and needs no graphics driver:\n\
+     \x20   https://github.com/M-Igashi/mp3rgain";
+
+/// Why the GUI could not start, as far as eframe's error tells us.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupFailure {
+    /// No usable OpenGL 2.0+ context.
+    NoOpenGl,
+    /// No window system to open a window on.
+    NoDisplay,
+    /// Anything else — no specific advice to give.
+    Unknown,
+}
+
+/// Map an eframe error onto the failure we can advise on.
+///
+/// All three glow-related variants mean the same thing to a user: this
+/// machine cannot give us an OpenGL 2.0+ context. `NoGlutinConfigs` fires
+/// when no GL config matches at all, `Glutin` when context creation fails,
+/// and `OpenGL` when the context exists but is too old — the observed case
+/// in the winget validation VM.
+pub fn classify(err: &Error) -> StartupFailure {
+    match err {
+        Error::OpenGL(_) | Error::Glutin(_) | Error::NoGlutinConfigs(..) => {
+            StartupFailure::NoOpenGl
+        }
+        Error::Winit(_) | Error::WinitEventLoop(_) => StartupFailure::NoDisplay,
+        _ => StartupFailure::Unknown,
+    }
+}
+
+/// Build the message shown on stderr and in the error dialog.
+///
+/// `details` is the raw eframe error, kept at the end so bug reports still
+/// carry the exact failure.
+pub fn startup_error_message(failure: StartupFailure, details: &str) -> String {
+    let body = match failure {
+        StartupFailure::NoOpenGl => format!(
+            "This computer has no usable OpenGL 2.0+ driver, which the GUI requires.\n\
+             Common causes are a missing or outdated graphics driver, a virtual\n\
+             machine without 3D acceleration, or a remote desktop session that does\n\
+             not forward OpenGL.\n\
+             \n\
+             What you can try:\n\
+             \x20 - Install or update your graphics driver.\n\
+             \x20 - On a virtual machine, enable 3D acceleration for the guest.\n\
+             {CLI_HINT}"
+        ),
+        StartupFailure::NoDisplay => format!(
+            "No display or window system is available, so the GUI cannot open a\n\
+             window. This is expected over a plain SSH session, in a container, or\n\
+             on a Windows Server Core install.\n\
+             \n\
+             What you can try:\n\
+             {CLI_HINT}"
+        ),
+        StartupFailure::Unknown => format!(
+            "The GUI failed to start for an unexpected reason.\n\
+             \n\
+             What you can try:\n\
+             {CLI_HINT}\n\
+             \x20 - Report this at https://github.com/M-Igashi/mp3rgain/issues"
+        ),
+    };
+
+    format!("mp3rgain GUI could not start.\n\n{body}\n\nDetails: {details}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eframe::egui_glow::PainterError;
+
+    /// The exact error seen in the winget validation VM (issue #282).
+    #[test]
+    fn old_opengl_is_classified_and_explained() {
+        let err = Error::OpenGL(PainterError::from(
+            "egui_glow requires opengl 2.0+. ".to_owned(),
+        ));
+        assert_eq!(classify(&err), StartupFailure::NoOpenGl);
+
+        let msg = startup_error_message(classify(&err), &err.to_string());
+        assert!(msg.contains("OpenGL 2.0+ driver"));
+        assert!(msg.contains("graphics driver"));
+        // The CLI is the actionable escape hatch on a GPU-less box.
+        assert!(msg.contains("mp3rgain command-line tool"));
+        // The raw error must survive for bug reports.
+        assert!(msg.contains("egui_glow requires opengl 2.0+"));
+    }
+
+    #[test]
+    fn unknown_failure_still_points_at_the_cli_and_issue_tracker() {
+        let err = Error::AppCreation("something else broke".into());
+        assert_eq!(classify(&err), StartupFailure::Unknown);
+
+        let msg = startup_error_message(classify(&err), &err.to_string());
+        assert!(msg.contains("mp3rgain command-line tool"));
+        assert!(msg.contains("issues"));
+        assert!(msg.contains("something else broke"));
+    }
+
+    /// Every message must open with the same headline and end with the raw
+    /// error, whichever branch produced it.
+    #[test]
+    fn all_variants_share_headline_and_keep_details() {
+        for failure in [
+            StartupFailure::NoOpenGl,
+            StartupFailure::NoDisplay,
+            StartupFailure::Unknown,
+        ] {
+            let msg = startup_error_message(failure, "raw-error-text");
+            assert!(msg.starts_with("mp3rgain GUI could not start."));
+            assert!(msg.ends_with("Details: raw-error-text"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #282.

Implements **option 1** from the issue (better error message), plus documentation of the constraint. Option 2 (wgpu fallback) is explicitly declined — see below.

## Problem

On a machine without OpenGL 2.0+, `mp3rgui` shows only the raw egui string and exits:

```
Failed to start mp3rgain GUI:
egui_glow: OpenGL: egui_glow requires opengl 2.0+.
```

Accurate, but the user has no way to know that updating a graphics driver — or just using the CLI — would solve it.

## Scoping: who this actually affects

Worth recording, because the issue title ("GPU-less") reads narrower than reality. The constraint is never the hardware — OpenGL 2.0 is from 2004 — it is whether a driver exposes GL to the process:

- **macOS** — every Mac has GL 4.1. Not affected.
- **Linux** — Mesa's `llvmpipe` software rasteriser is well above GL 2.0 even with no GPU. Effectively not affected.
- **Windows** — the inbox Basic Display driver is GL 1.1 only. This is the whole problem, and Windows is 90% of mp3rgui downloads.

The one case that reaches ordinary users is **Remote Desktop**: Windows' RDP display driver typically exposes only OpenGL 1.1, so a desktop where `mp3rgui` runs fine fails to start over RDP. The rest (VMs without 3D accel, Windows Sandbox, freshly installed Windows, Server Core) are mostly developer/CI territory — the winget validation failure that surfaced this is the last of those.

## Changes

**1. `mp3rgui/src/startup.rs`** — classify `eframe::Error` and say what happened and what to try:

| eframe variant | Diagnosis | Advice |
|---|---|---|
| `OpenGL` / `Glutin` / `NoGlutinConfigs` | No usable GL context | Update GPU driver, enable VM 3D acceleration, use the CLI |
| `Winit` / `WinitEventLoop` | No window system | Headless wording, use the CLI |
| everything else | Unknown | Use the CLI, report an issue |

Every branch points at the `mp3rgain` CLI and keeps the raw error under `Details:` so bug reports stay useful.

```
mp3rgain GUI could not start.

This computer has no usable OpenGL 2.0+ driver, which the GUI requires.
Common causes are a missing or outdated graphics driver, a virtual
machine without 3D acceleration, or a remote desktop session that does
not forward OpenGL.

What you can try:
  - Install or update your graphics driver.
  - On a virtual machine, enable 3D acceleration for the guest.
  - Use the mp3rgain command-line tool instead. It does everything the GUI
    does and needs no graphics driver:
    https://github.com/M-Igashi/mp3rgain

Details: egui_glow: OpenGL: egui_glow requires opengl 2.0+.
```

**2. `docs/gui-requirements.md`** (new) — the per-platform picture, the five environments where it bites, workarounds for each, and the rationale for shipping no fallback renderer.

**3. `README.md`** — a short NOTE next to the GUI install instructions, plus a Documentation entry. "Works locally, fails over RDP" is otherwise a baffling symptom.

## Why option 2 (wgpu) is declined

`wgpu` would plausibly start over RDP, since Windows forwards D3D where it does not forward GL. It is still not worth it:

- It adds substantial code to a binary that already trips Defender's ML heuristics as an unsigned static Rust binary (#281), where size is a contributing factor.
- Every affected scenario already has a working answer — the CLI — with no graphics stack at all.

The doc invites anyone with a case where the CLI genuinely is not a substitute to reopen the discussion.

## Testing

The real GL failure cannot be reproduced on normal desktop hardware, so the tests drive classification and message assembly directly. `eframe::egui_glow::PainterError` is constructible from a `String`, which reproduces the winget-observed error exactly.

- `cargo test -p mp3rgui` — 3 passed
- `cargo fmt --manifest-path mp3rgui/Cargo.toml -- --check` — clean
- `cargo clippy --manifest-path mp3rgui/Cargo.toml --all-targets` — no warnings
- CLI test suite unaffected (144 passed)
- No dependency change; binary size untouched