### PR TITLE
docs: position foobar2000 as the right tool for the Windows GUI case

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,14 @@ real-corpus benchmark numbers.
 
 The original [mp3gain](http://mp3gain.sourceforge.net/) has been unmaintained upstream since ~2015 (though distribution maintainers continue to apply security patches). [aacgain](http://aacgain.altosdesign.com/), its AAC counterpart, has been unmaintained since ~2009 and is effectively unbuildable on modern 64-bit systems. mp3rgain is a modern, memory-safe replacement written in Rust that covers both.
 
-**AAC/M4A on the CLI is the differentiator.** Among CLIs, rsgain / loudgain / FFmpeg either only write ReplayGain tags (which non-compliant players ignore) or re-encode the audio. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only, has no undo, and is unsuited for batch, headless, or container workflows. mp3rgain fills the cross-platform, scriptable, reversible niche.
+**AAC/M4A on the CLI is the differentiator.** Among CLIs, rsgain / loudgain / FFmpeg either only write ReplayGain tags (which non-compliant players ignore) or re-encode the audio. [foobar2000](https://www.foobar2000.org/) has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only, has no undo, and is not built for batch, headless, or container workflows. mp3rgain fills the cross-platform, scriptable, reversible niche.
+
+> [!TIP]
+> **On Windows with a GUI, and want current ReplayGain? Use [foobar2000](https://www.foobar2000.org/).**
+> Its ReplayGain scanner is BS.1770-based, it covers more formats than mp3rgain does, and it can
+> bake gain into MP3 and AAC bitstreams too. mp3rgain is the better fit when you need a command
+> line, a non-Windows host, mp3gain-identical ReplayGain 1.0 values, or an undo path — and the two
+> coexist fine, since mp3rgain writes the same standard `REPLAYGAIN_*` tags foobar2000 reads.
 
 mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 This document provides a detailed comparison between mp3rgain and the original aacgain/mp3gain tools.
 
-> **Headline:** mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. aacgain has been effectively abandoned since ~2009 and is unbuildable on most modern 64-bit systems; among other CLIs, rsgain / loudgain / FFmpeg either tags-only or re-encodes. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only with no undo and is unsuited for batch / headless / CI use. If you need re-encode-free AAC volume adjustment from a script, container, or non-Windows host in 2026, mp3rgain is the only practical choice.
+> **Headline:** mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. aacgain has been effectively abandoned since ~2009 and is unbuildable on most modern 64-bit systems; among other CLIs, rsgain / loudgain / FFmpeg either tags-only or re-encodes. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only with no undo and is not built for batch / headless / CI use. If you need re-encode-free AAC volume adjustment from a script, container, or non-Windows host in 2026, mp3rgain is the only practical choice — **on a Windows desktop with a GUI, foobar2000 is the one to reach for.**
 
 ## Overview
 
@@ -265,7 +265,9 @@ For AAC/M4A files specifically, the choice of tool matters more than for MP3, be
 | FFmpeg `loudnorm` | Re-encode | No (lossy) | Yes | Yes | Yes |
 | beets ReplayGain plugin | Tags via backend | Yes (file untouched) | No (player must read tags) | Yes | Yes |
 
-**The "lossless + player-agnostic + maintained + CLI/scriptable + reversible" intersection contains exactly one tool: mp3rgain.** foobar2000 covers the lossless / player-agnostic / maintained cells but is GUI-only on Windows and irreversible. This matters for DJ equipment, car audio, smart speakers, batch / Docker / CI pipelines, and any environment where the playback device ignores ReplayGain tags or where a desktop GUI is not an option.
+**The "lossless + player-agnostic + maintained + CLI/scriptable + reversible" intersection contains exactly one tool: mp3rgain.** This matters for DJ equipment, car audio, smart speakers, batch / Docker / CI pipelines, and any environment where the playback device ignores ReplayGain tags or where a desktop GUI is not an option.
+
+That is a statement about the intersection, not a ranking. [foobar2000](https://www.foobar2000.org/) covers the lossless / player-agnostic / maintained cells and does so well; what it does not offer is a command line, a non-Windows host, or an undo path. **If you are on Windows, working in a GUI, and want current BS.1770 ReplayGain, foobar2000 is the tool to recommend** — it also covers more formats than mp3rgain and its scanner is the reference many people compare against. The two interoperate: mp3rgain writes the standard `REPLAYGAIN_*` tags foobar2000 reads, and `--rg2` matches its measurement.
 
 ### When to Use global_gain vs ReplayGain Tags
 
@@ -274,7 +276,7 @@ For AAC/M4A files specifically, the choice of tool matters more than for MP3, be
 | DJ equipment (CDJs, controllers) | `global_gain` (mp3rgain) |
 | Car stereos, portable players | `global_gain` (mp3rgain) |
 | Smart speakers, Chromecast | `global_gain` (mp3rgain) |
-| Desktop players (foobar2000, etc.) | ReplayGain tags (rsgain) |
+| Desktop players (foobar2000, etc.) | ReplayGain tags (rsgain, or foobar2000's own scanner) |
 | Streaming to phone apps | ReplayGain tags (rsgain) |
 | Maximum flexibility | ReplayGain tags (rsgain) |
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -4,13 +4,13 @@ This document describes real-world use cases for mp3rgain.
 
 ## Standout Capability: Lossless AAC Volume Adjustment on the CLI
 
-mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. (foobar2000's "Apply ReplayGain to file content" can do a comparable scalefactor-based AAC adjustment in MP4/MKA, but it is Windows GUI only with no undo path.) Use cases that specifically benefit from a scriptable, cross-platform option:
+mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. ([foobar2000](https://www.foobar2000.org/)'s "Apply ReplayGain to file content" does a comparable scalefactor-based AAC adjustment in MP4/MKA — if you are on a Windows desktop and happy in a GUI, use it. It has no undo path and no command line.) Use cases that specifically benefit from a scriptable, cross-platform option:
 
 - **iTunes / Apple Music libraries on macOS / Linux**: Most personal music libraries on Apple platforms are AAC/M4A. Normalizing them without re-encoding from a non-Windows host previously had no maintained option.
 - **DJ workflows with AAC**: DJ hardware (CDJs, XDJs, controllers) ignores ReplayGain tags. AAC tracks bought from iTunes Store or other M4A sources previously had to be re-encoded to lose loudness, sacrificing quality.
 - **Smart speaker / car audio playback**: Same issue — these devices don't read ReplayGain tags, so the only way to adjust AAC volume in a way they respect is via bitstream rewrite.
 - **Audio archival**: For users who curate AAC libraries and want non-destructive, reversible (`-u`) volume normalization.
-- **Headless / batch / CI / Docker pipelines**: foobar2000 is not a fit; mp3rgain is the only practical option.
+- **Headless / batch / CI / Docker pipelines**: a desktop GUI is not a fit here; mp3rgain is the only practical option.
 
 For MP3, mp3rgain is one of several drop-in mp3gain replacements; for AAC on the command line, it currently has no equivalent.
 


### PR DESCRIPTION
## Problem

Every mention of foobar2000 across the README and docs was framed as a limitation — "Windows GUI only", "no undo", "unsuited for batch/headless" — and the landing page listed it alongside mp3gain and aacgain under a heading about tools that are *gone*.

foobar2000 is actively developed, its BS.1770 ReplayGain scanner is the reference many people compare against, and it covers more formats than mp3rgain does. Framing it purely as a set of shortcomings was both unfair and unhelpful to a reader trying to decide what to use.

## Change

Recommend foobar2000 directly where it genuinely is the better answer: **on Windows, in a GUI, wanting current ReplayGain.**

| File | Change |
|---|---|
| `README.md` | New TIP block under "Why mp3rgain?" recommending foobar2000 for that case; softened "unsuited for" → "not built for"; linked foobar2000.org |
| `docs/COMPARISON.md` | The "intersection contains exactly one tool" claim now says explicitly that it is a statement about the intersection, not a ranking, followed by a direct recommendation |
| `docs/use-cases.md` | Recommends foobar2000 for the Windows desktop case; dropped "foobar2000 is not a fit" in favour of "a desktop GUI is not a fit" |

Also notes that the two **interoperate rather than compete**: mp3rgain writes the standard `REPLAYGAIN_*` tags foobar2000 reads, and `--rg2` matches its measurement.

mp3rgain's actual niche — command line, non-Windows hosts, mp3gain-identical RG1 values, reversibility — is unchanged, and reads more precisely for being stated as a scope rather than a comparison.

## Not changed

Every factual claim about foobar2000 is kept: no undo path, no command line, Windows only. Only the framing moves.

## Note

The matching edits to the website source (`web/src/index.js`, `web/src/pages.js`) are **not in this PR** — `web/` is not yet tracked in git. They are applied locally and ready; see the PR discussion.