### PR TITLE
Write REPLAYGAIN_ALGORITHM in the BS.1770 modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The original [mp3gain](http://mp3gain.sourceforge.net/) has been unmaintained up
 
 mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 
+Files scanned with `--rg2` / `--r128` also carry a `REPLAYGAIN_ALGORITHM` tag set to `ITU-R BS.1770`, so a player (or you, years later) can tell which measurement produced the stored values. The default RG1 mode writes no such tag — an absent one means the classic mp3gain measurement, which is what every pre-existing tagged file already implies.
+
 ## Use mp3rgain in Docker / CI
 
 Official multi-arch images (`linux/amd64`, `linux/arm64`) are published to GHCR:

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -21,6 +21,11 @@ pub const TAG_REPLAYGAIN_TRACK_GAIN: &str = "REPLAYGAIN_TRACK_GAIN";
 pub const TAG_REPLAYGAIN_TRACK_PEAK: &str = "REPLAYGAIN_TRACK_PEAK";
 pub const TAG_REPLAYGAIN_ALBUM_GAIN: &str = "REPLAYGAIN_ALBUM_GAIN";
 pub const TAG_REPLAYGAIN_ALBUM_PEAK: &str = "REPLAYGAIN_ALBUM_PEAK";
+/// Loudness algorithm the gain values were measured with. Only written by the
+/// BS.1770 modes (`--rg2` / `--r128`) — see [`AnalysisMode::algorithm_tag`].
+///
+/// [`AnalysisMode::algorithm_tag`]: crate::AnalysisMode::algorithm_tag
+pub const TAG_REPLAYGAIN_ALGORITHM: &str = "REPLAYGAIN_ALGORITHM";
 
 /// APEv2 tag item
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -126,11 +131,12 @@ impl ApeTag {
 
     /// Set the `REPLAYGAIN_*` items present in `rg` (issue #232).
     pub(crate) fn set_replaygain(&mut self, rg: &ApeReplayGain) {
-        let fields: [(&str, &Option<String>); 4] = [
+        let fields: [(&str, &Option<String>); 5] = [
             (TAG_REPLAYGAIN_TRACK_GAIN, &rg.track_gain),
             (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
             (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
             (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
+            (TAG_REPLAYGAIN_ALGORITHM, &rg.algorithm),
         ];
         for (key, value) in fields {
             if let Some(v) = value {
@@ -460,13 +466,15 @@ pub struct ApeReplayGain {
     pub track_peak: Option<String>,
     pub album_gain: Option<String>,
     pub album_peak: Option<String>,
+    /// `REPLAYGAIN_ALGORITHM`; `None` in the mp3gain-compatible RG1 mode.
+    pub algorithm: Option<String>,
 }
 
 /// Add (or replace) the `REPLAYGAIN_*` items in `file_path`'s APEv2 tag.
 ///
 /// Existing items written by the gain-apply step (`MP3GAIN_UNDO`,
-/// `MP3GAIN_MINMAX`) are preserved — only the four ReplayGain keys present
-/// in `rg` are set.
+/// `MP3GAIN_MINMAX`) are preserved — only the ReplayGain keys present in
+/// `rg` are set.
 pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> {
     rewrite_ape_tail(file_path, |tag| tag.set_replaygain(rg))
 }
@@ -646,6 +654,7 @@ mod tests {
             track_peak: Some("0.250000".to_string()),
             album_gain: None,
             album_peak: None,
+            algorithm: None,
         };
         write_ape_replaygain(&path, &rg).unwrap();
 
@@ -656,6 +665,29 @@ mod tests {
         assert_eq!(out.get(TAG_REPLAYGAIN_TRACK_PEAK), Some("0.250000"));
         // Album fields were None, so they must not be written.
         assert_eq!(out.get(TAG_REPLAYGAIN_ALBUM_GAIN), None);
+        // RG1 writes no algorithm tag.
+        assert_eq!(out.get(TAG_REPLAYGAIN_ALGORITHM), None);
+    }
+
+    /// The BS.1770 modes record `REPLAYGAIN_ALGORITHM` so players
+    /// can tell an RG2/R128 measurement from a classic mp3gain one.
+    #[test]
+    fn write_ape_replaygain_records_algorithm() {
+        let data = replace_ape_tag(&vec![0u8; 20_000], &ApeTag::new());
+        let path = write_temp("rg_algorithm.mp3", &data);
+
+        let rg = ApeReplayGain {
+            track_gain: Some("-2.00 dB".to_string()),
+            track_peak: Some("0.900000".to_string()),
+            algorithm: crate::replaygain::AnalysisMode::Rg2
+                .algorithm_tag()
+                .map(str::to_string),
+            ..Default::default()
+        };
+        write_ape_replaygain(&path, &rg).unwrap();
+
+        let out = read_ape_tag_from_file(&path).unwrap().unwrap();
+        assert_eq!(out.get(TAG_REPLAYGAIN_ALGORITHM), Some("ITU-R BS.1770"));
     }
 
     /// Issue #210: write_ape_album_minmax adds MP3GAIN_ALBUM_MINMAX as `min,max`

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -266,6 +266,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
                 if let Some((album_gain, album_peak)) = res.album {
                     tags.set_album(album_gain, album_peak);
                 }
+                tags.set_algorithm(res.mode);
                 mp4meta::write_replaygain_tags(file_path, &tags)?;
             }
         } else if !ape_rg_folded || needs_reanalysis {
@@ -449,6 +450,7 @@ struct RgResidual {
     track_gain_db: f64,
     track_peak: f64,
     album: Option<(f64, f64)>,
+    mode: crate::replaygain::AnalysisMode,
 }
 
 impl RgResidual {
@@ -458,6 +460,7 @@ impl RgResidual {
             track_peak: Some(ape::format_rg_peak(self.track_peak)),
             album_gain: self.album.map(|(g, _)| ape::format_rg_gain(g)),
             album_peak: self.album.map(|(_, p)| ape::format_rg_peak(p)),
+            algorithm: self.mode.algorithm_tag().map(str::to_string),
         }
     }
 
@@ -468,6 +471,7 @@ impl RgResidual {
             track_peak: ape.track_peak,
             album_gain: ape.album_gain,
             album_peak: ape.album_peak,
+            algorithm: ape.algorithm,
             ..Default::default()
         }
     }
@@ -487,6 +491,9 @@ fn compute_rg_residual(
     reanalyze: bool,
 ) -> Option<RgResidual> {
     let track = opts.track_result.as_ref()?;
+    // Re-analysis must use the mode the original measurement used, or the
+    // residual would mix an RG1 reading into an RG2/R128 gain value.
+    let mode = track.analysis_mode();
 
     let arithmetic = || {
         let db = steps_to_db(actual_steps);
@@ -497,7 +504,7 @@ fn compute_rg_residual(
         )
     };
     let (track_gain_db, track_peak, applied_db) = if reanalyze {
-        match crate::replaygain::analyze_track(modified_path) {
+        match crate::replaygain::analyze_track_with_mode(modified_path, None, mode, None) {
             Ok(post) => (
                 post.gain_db(),
                 post.peak(),
@@ -522,6 +529,7 @@ fn compute_rg_residual(
         track_gain_db,
         track_peak,
         album,
+        mode,
     })
 }
 
@@ -605,6 +613,7 @@ fn apply_mp3_id3v2_bytes(
                 rg.track_peak = values.track_peak;
                 rg.album_gain = values.album_gain;
                 rg.album_peak = values.album_peak;
+                rg.algorithm = values.algorithm;
             }
         }
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -3,7 +3,7 @@ use colored::*;
 use mp3rgain::{
     read_gain_tags_auto, GainTagSource, StoredGainTags, TAG_MP3GAIN_ALBUM_MINMAX,
     TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK,
-    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
+    TAG_REPLAYGAIN_ALGORITHM, TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
@@ -46,6 +46,7 @@ impl CheckTagInfo<'_> {
                     (TAG_REPLAYGAIN_TRACK_PEAK, &tags.track_peak),
                     (TAG_REPLAYGAIN_ALBUM_GAIN, &tags.album_gain),
                     (TAG_REPLAYGAIN_ALBUM_PEAK, &tags.album_peak),
+                    (TAG_REPLAYGAIN_ALGORITHM, &tags.algorithm),
                 ];
                 for (label, value) in rg_fields {
                     if let Some(v) = value {
@@ -61,7 +62,9 @@ impl CheckTagInfo<'_> {
             OutputFormat::Tsv => {
                 writeln!(
                     out,
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    // The algorithm column is appended last so existing
+                    // column indices stay stable for scripts.
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     filename,
                     tags.undo.as_deref().unwrap_or("-"),
                     tags.minmax.as_deref().unwrap_or("-"),
@@ -69,7 +72,8 @@ impl CheckTagInfo<'_> {
                     tags.track_peak.as_deref().unwrap_or("-"),
                     tags.album_gain.as_deref().unwrap_or("-"),
                     tags.album_peak.as_deref().unwrap_or("-"),
-                    tags.album_minmax.as_deref().unwrap_or("-")
+                    tags.album_minmax.as_deref().unwrap_or("-"),
+                    tags.algorithm.as_deref().unwrap_or("-")
                 )
                 .ok();
                 None

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -6,8 +6,8 @@
 
 use crate::ape::{
     parse_undo_values, parse_undo_wrap, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
-    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
-    TAG_REPLAYGAIN_TRACK_PEAK,
+    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_ALGORITHM,
+    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 use crate::error::{Error, Result};
 use crate::gain::apply_undo_to_data;
@@ -25,6 +25,7 @@ const ALL_RG_DESCRIPTIONS: &[&str] = &[
     TAG_REPLAYGAIN_TRACK_PEAK,
     TAG_REPLAYGAIN_ALBUM_GAIN,
     TAG_REPLAYGAIN_ALBUM_PEAK,
+    TAG_REPLAYGAIN_ALGORITHM,
 ];
 
 /// ReplayGain and undo data stored in ID3v2 TXXX frames
@@ -34,6 +35,8 @@ pub struct Id3v2ReplayGain {
     pub track_peak: Option<String>,
     pub album_gain: Option<String>,
     pub album_peak: Option<String>,
+    /// `REPLAYGAIN_ALGORITHM`; `None` in the mp3gain-compatible RG1 mode.
+    pub algorithm: Option<String>,
     pub undo: Option<String>,
     pub minmax: Option<String>,
 }
@@ -135,6 +138,7 @@ pub fn read_id3v2_replaygain(path: &Path) -> Result<Id3v2ReplayGain> {
         track_peak: get_txxx(&tag, TAG_REPLAYGAIN_TRACK_PEAK),
         album_gain: get_txxx(&tag, TAG_REPLAYGAIN_ALBUM_GAIN),
         album_peak: get_txxx(&tag, TAG_REPLAYGAIN_ALBUM_PEAK),
+        algorithm: get_txxx(&tag, TAG_REPLAYGAIN_ALGORITHM),
         undo: get_txxx(&tag, TAG_MP3GAIN_UNDO),
         minmax: get_txxx(&tag, TAG_MP3GAIN_MINMAX),
     })
@@ -148,6 +152,7 @@ fn add_rg_frames(tag: &mut id3::Tag, rg: &Id3v2ReplayGain) {
         (TAG_REPLAYGAIN_TRACK_PEAK, &rg.track_peak),
         (TAG_REPLAYGAIN_ALBUM_GAIN, &rg.album_gain),
         (TAG_REPLAYGAIN_ALBUM_PEAK, &rg.album_peak),
+        (TAG_REPLAYGAIN_ALGORITHM, &rg.algorithm),
     ];
 
     for &(desc, value) in fields {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@ pub use analysis::{
 pub use ape::{
     delete_ape_tag, read_ape_tag, read_ape_tag_from_file, write_ape_album_minmax, write_ape_tag,
     ApeItem, ApeTag, TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
-    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_TRACK_GAIN,
-    TAG_REPLAYGAIN_TRACK_PEAK,
+    TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_ALGORITHM,
+    TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 pub use apply::{
     apply_with_options, predict_apply, write_album_minmax, AacAlbumInfo, ApplyOptions, ApplyReport,
@@ -213,6 +213,9 @@ pub struct StoredGainTags {
     pub track_peak: Option<String>,
     pub album_gain: Option<String>,
     pub album_peak: Option<String>,
+    /// `REPLAYGAIN_ALGORITHM`; only written by the `--rg2` / `--r128` modes,
+    /// so `None` on anything measured with mp3gain-compatible ReplayGain 1.0.
+    pub algorithm: Option<String>,
     pub undo: Option<String>,
     pub minmax: Option<String>,
     /// APE-only `MP3GAIN_ALBUM_MINMAX`; always `None` for AAC and ID3v2.
@@ -227,6 +230,7 @@ impl StoredGainTags {
             track_peak: None,
             album_gain: None,
             album_peak: None,
+            algorithm: None,
             undo: None,
             minmax: None,
             album_minmax: None,
@@ -239,6 +243,7 @@ impl StoredGainTags {
             || self.track_peak.is_some()
             || self.album_gain.is_some()
             || self.album_peak.is_some()
+            || self.algorithm.is_some()
             || self.undo.is_some()
             || self.minmax.is_some()
             || self.album_minmax.is_some()
@@ -264,6 +269,7 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
                 track_peak: rg_tags.track_peak().map(str::to_string),
                 album_gain: rg_tags.album_gain().map(str::to_string),
                 album_peak: rg_tags.album_peak().map(str::to_string),
+                algorithm: rg_tags.algorithm().map(str::to_string),
                 undo: undo_tags.undo().map(str::to_string),
                 minmax: undo_tags.minmax().map(str::to_string),
                 album_minmax: None,
@@ -278,6 +284,7 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
             track_peak: rg.track_peak,
             album_gain: rg.album_gain,
             album_peak: rg.album_peak,
+            algorithm: rg.algorithm,
             undo: rg.undo,
             minmax: rg.minmax,
             album_minmax: None,
@@ -290,6 +297,7 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
             track_peak: tag.get(TAG_REPLAYGAIN_TRACK_PEAK).map(str::to_string),
             album_gain: tag.get(TAG_REPLAYGAIN_ALBUM_GAIN).map(str::to_string),
             album_peak: tag.get(TAG_REPLAYGAIN_ALBUM_PEAK).map(str::to_string),
+            algorithm: tag.get(TAG_REPLAYGAIN_ALGORITHM).map(str::to_string),
             undo: tag.get(TAG_MP3GAIN_UNDO).map(str::to_string),
             minmax: tag.get(TAG_MP3GAIN_MINMAX).map(str::to_string),
             album_minmax: tag.get(TAG_MP3GAIN_ALBUM_MINMAX).map(str::to_string),

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -30,6 +30,7 @@ pub const RG_TRACK_GAIN: &str = "replaygain_track_gain";
 pub const RG_TRACK_PEAK: &str = "replaygain_track_peak";
 pub const RG_ALBUM_GAIN: &str = "replaygain_album_gain";
 pub const RG_ALBUM_PEAK: &str = "replaygain_album_peak";
+pub const RG_ALGORITHM: &str = "replaygain_algorithm";
 
 /// Undo tag keys (iTunes freeform format, same namespace)
 pub const UNDO_TAG: &str = "mp3rgain_undo";
@@ -161,6 +162,7 @@ pub struct ReplayGainTags {
     track_peak: Option<String>,
     album_gain: Option<String>,
     album_peak: Option<String>,
+    algorithm: Option<String>,
 }
 
 impl ReplayGainTags {
@@ -176,6 +178,9 @@ impl ReplayGainTags {
     pub fn album_peak(&self) -> Option<&str> {
         self.album_peak.as_deref()
     }
+    pub fn algorithm(&self) -> Option<&str> {
+        self.algorithm.as_deref()
+    }
 
     pub fn set_track(&mut self, gain_db: f64, peak: f64) {
         self.track_gain = Some(crate::ape::format_rg_gain(gain_db));
@@ -187,11 +192,18 @@ impl ReplayGainTags {
         self.album_peak = Some(crate::ape::format_rg_peak(peak));
     }
 
+    /// Record the loudness algorithm `mode` measured with. A no-op for the
+    /// mp3gain-compatible RG1 mode, which writes no algorithm tag.
+    pub fn set_algorithm(&mut self, mode: crate::replaygain::AnalysisMode) {
+        self.algorithm = mode.algorithm_tag().map(str::to_string);
+    }
+
     pub fn is_empty(&self) -> bool {
         self.track_gain.is_none()
             && self.track_peak.is_none()
             && self.album_gain.is_none()
             && self.album_peak.is_none()
+            && self.algorithm.is_none()
     }
 }
 
@@ -210,6 +222,9 @@ impl std::fmt::Display for ReplayGainTags {
         if let Some(ref p) = self.album_peak {
             parts.push(format!("Album Peak: {}", p));
         }
+        if let Some(ref a) = self.algorithm {
+            parts.push(format!("Algorithm: {}", a));
+        }
         if parts.is_empty() {
             f.write_str("(no tags)")
         } else {
@@ -220,11 +235,12 @@ impl std::fmt::Display for ReplayGainTags {
 
 impl ReplayGainTags {
     fn to_freeform_tags(&self) -> Vec<FreeformTag> {
-        let entries: [(&str, &Option<String>); 4] = [
+        let entries: [(&str, &Option<String>); 5] = [
             (RG_TRACK_GAIN, &self.track_gain),
             (RG_TRACK_PEAK, &self.track_peak),
             (RG_ALBUM_GAIN, &self.album_gain),
             (RG_ALBUM_PEAK, &self.album_peak),
+            (RG_ALGORITHM, &self.algorithm),
         ];
 
         entries
@@ -555,6 +571,9 @@ pub fn read_replaygain_tags(file_path: &Path) -> Result<ReplayGainTags> {
             }
             x if x.eq_ignore_ascii_case(RG_ALBUM_PEAK) => {
                 tags.album_peak = Some(tag.value().to_string());
+            }
+            x if x.eq_ignore_ascii_case(RG_ALGORITHM) => {
+                tags.algorithm = Some(tag.value().to_string());
             }
             _ => {}
         }
@@ -897,6 +916,7 @@ fn is_replaygain_freeform(data: &[u8], pos: usize, header: &BoxHeader) -> bool {
             || name.eq_ignore_ascii_case(RG_TRACK_PEAK)
             || name.eq_ignore_ascii_case(RG_ALBUM_GAIN)
             || name.eq_ignore_ascii_case(RG_ALBUM_PEAK)
+            || name.eq_ignore_ascii_case(RG_ALGORITHM)
     })
 }
 

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -309,6 +309,7 @@ fn apply_replaygain_aac_with_album_into(
             apply_gain_to_peak(album.album_peak, applied_db),
         );
     }
+    tags.set_algorithm(result.analysis_mode());
 
     match mp4meta::write_replaygain_tags(file, &tags) {
         Ok(()) => {

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -90,6 +90,22 @@ impl AnalysisMode {
         }
     }
 
+    /// Value for the `REPLAYGAIN_ALGORITHM` tag, or `None` when the mode needs
+    /// no tag. Suggested by skamp on the Hydrogenaudio mp3rgain thread.
+    ///
+    /// [`Rg1`](AnalysisMode::Rg1) writes nothing: every mp3gain-era file in
+    /// existence carries untagged classic values, so an absent tag already
+    /// means "classic" and adding one would gratuitously diverge from
+    /// mp3gain's output. `ITU-R BS.1770` is the string foobar2000 writes for
+    /// the RG2 measurement; R128 shares it because the measurement is the
+    /// same and only the target level differs.
+    pub fn algorithm_tag(&self) -> Option<&'static str> {
+        match self {
+            AnalysisMode::Rg1 => None,
+            AnalysisMode::Rg2 | AnalysisMode::R128 => Some("ITU-R BS.1770"),
+        }
+    }
+
     /// Lowercase short name (`"rg1"` / `"rg2"` / `"r128"`) for machine-readable
     /// output, following the [`Channel::name`](crate::Channel::name) convention.
     pub fn name(&self) -> &'static str {


### PR DESCRIPTION
Suggested by **skamp** on the [Hydrogenaudio mp3rgain thread](https://hydrogenaud.io/), following the v3.0 `--rg2` / `--r128` announcement:

> May I suggest that you also add the REPLAYGAIN_ALGORITHM tag to differentiate between both algorithms? foobar2000 writes `ITU-R BS.1770` for the latest one, and `Classic ReplayGain` for the original one.
>
> 1. I think it's important that users know which algorithm their files have been scanned with (even if they did it themselves, they may not remember years later)
> 2. I believe `ITU-R BS.1770` is the proper value for the latest algorithm

## Change

Files scanned with `--rg2` / `--r128` now record `REPLAYGAIN_ALGORITHM = "ITU-R BS.1770"` — the string foobar2000 writes — across all three tag backends:

| Backend | Key |
|---|---|
| APEv2 | `REPLAYGAIN_ALGORITHM` |
| ID3v2 | TXXX `REPLAYGAIN_ALGORITHM` |
| MP4 / M4A | iTunes freeform `replaygain_algorithm` |

Read back by `-s c` and cleared by `-s d` alongside the other ReplayGain keys.

## Why RG1 writes nothing

Point 3 of skamp's message says the old algorithm's tag value doesn't matter as long as the distinction is clear. It is cleaner to make it by absence: every mp3gain-era file in existence already carries untagged classic values, so **absent = classic** with no ambiguity, and the default mode's output stays byte-identical to mp3gain's. Writing `Classic ReplayGain` would only diverge from mp3gain for files that are already unambiguous.

RG2 and R128 share one value because the measurement is identical and only the target level differs. Distinguishing them would need `REPLAYGAIN_REFERENCE_LOUDNESS`; deliberately out of scope here.

## Also fixes: RG1 leaking into BS.1770 residuals

`compute_rg_residual()` re-analysed with a hardcoded `analyze_track()` (RG1). Under `-w` or `global_gain` saturation the post-apply re-scan therefore ran the classic algorithm even when the original measurement was RG2/R128, mixing an RG1 reading into a BS.1770 gain value. Now re-analyses with the track's own mode. Present since v3.0.0.

## Testing

Verified on real MP3 and M4A files (copies; originals untouched):

- APEv2, ID3v2, and MP4 paths all write / read back / delete the tag correctly
- ID3v2 cross-checked with an independent reader — `ffprobe` reports `TAG:REPLAYGAIN_ALGORITHM=ITU-R BS.1770`
- Default RG1 output unchanged: no algorithm tag appears
- Text and TSV `-s c` output (the TSV column is appended last, so existing column indices are stable)
- 2 new unit tests in `ape.rs`; full suite 145 passed, `cargo fmt --check` clean, no new clippy warnings

Rebased onto current master; the 3 remaining clippy warnings are pre-existing (`bs1770.rs:378`, `replaygain.rs:2372`, both test code).