### PR TITLE
docs: stop framing mp3rgain as an alternative to ReplayGain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mp3rgain adjusts MP3 and AAC volume without re-encoding by modifying the `global
 
 - **CLI lossless AAC bitstream gain**: re-encode-free `global_gain` rewrite for AAC/M4A — replacing the long-abandoned aacgain, with `-u` undo (foobar2000's GUI equivalent has no undo path)
 - **Lossless & Reversible**: No re-encoding, all changes can be undone (MP3 and AAC)
-- **ReplayGain**: Track and album gain analysis for MP3 and AAC/M4A
+- **ReplayGain**: Track and album gain analysis for MP3 and AAC/M4A, with standard `REPLAYGAIN_*` tags written alongside the bitstream change (APEv2, ID3v2 TXXX, or MP4 freeform)
 - **Zero dependencies**: Single static binary (no ffmpeg, no mp3gain, no aacgain)
 - **Cross-platform**: macOS, Linux, Windows (x86_64 and ARM64)
 - **mp3gain / aacgain compatible**: Drop-in replacement with identical CLI
@@ -165,14 +165,18 @@ real-corpus benchmark numbers.
 
 The original [mp3gain](http://mp3gain.sourceforge.net/) has been unmaintained upstream since ~2015 (though distribution maintainers continue to apply security patches). [aacgain](http://aacgain.altosdesign.com/), its AAC counterpart, has been unmaintained since ~2009 and is effectively unbuildable on modern 64-bit systems. mp3rgain is a modern, memory-safe replacement written in Rust that covers both.
 
-**AAC/M4A on the CLI is the differentiator.** Among CLIs, rsgain / loudgain / FFmpeg either only write ReplayGain tags (which non-compliant players ignore) or re-encode the audio. [foobar2000](https://www.foobar2000.org/) has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only, has no undo, and is not built for batch, headless, or container workflows. mp3rgain fills the cross-platform, scriptable, reversible niche.
+These are all ReplayGain tools, mp3rgain included — it runs a ReplayGain analysis and writes the standard `REPLAYGAIN_*` tags like any tagger. What separates them is where the correction ends up. rsgain / loudgain / FFmpeg `-af replaygain` stop at the tags, which non-compliant players ignore; `ffmpeg loudnorm` re-encodes. The mp3gain lineage — mp3gain, aacgain, and now mp3rgain — writes the tags *and* bakes the gain into the bitstream, losslessly and reversibly.
+
+**AAC/M4A on the CLI is the differentiator.** That combination is what has no other maintained CLI implementation: [foobar2000](https://www.foobar2000.org/) offers an equivalent "Apply ReplayGain to file content" pass for AAC in MP4/MKA, but it is Windows GUI only, has no undo, and is not built for batch, headless, or container workflows. mp3rgain fills the cross-platform, scriptable, reversible niche.
 
 > [!TIP]
-> **On Windows with a GUI, and want current ReplayGain? Use [foobar2000](https://www.foobar2000.org/).**
-> Its ReplayGain scanner is BS.1770-based, it covers more formats than mp3rgain does, and it can
-> bake gain into MP3 and AAC bitstreams too. mp3rgain is the better fit when you need a command
-> line, a non-Windows host, mp3gain-identical ReplayGain 1.0 values, or an undo path — and the two
-> coexist fine, since mp3rgain writes the same standard `REPLAYGAIN_*` tags foobar2000 reads.
+> **Want the most standards-faithful ReplayGain, on Windows, in a GUI? Use [foobar2000](https://www.foobar2000.org/).**
+> It is the closest thing ReplayGain 2.0 has to a reference implementation — a full BS.1770 scanner
+> whose numbers other tools get checked against — it tags far more formats than mp3rgain does, and
+> it can bake gain into MP3 and AAC bitstreams too. mp3rgain is the better fit when you need a
+> command line, a non-Windows host, mp3gain-identical ReplayGain 1.0 values, or an undo path — and
+> the two coexist fine, since mp3rgain writes the same standard `REPLAYGAIN_*` tags foobar2000
+> reads, with `--rg2` deliberately matching its measurement.
 
 mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 
@@ -184,8 +188,8 @@ Official multi-arch images (`linux/amd64`, `linux/arm64`) are published to GHCR:
 
 ```
 ghcr.io/m-igashi/mp3rgain:latest
-ghcr.io/m-igashi/mp3rgain:v2          # latest 2.x
-ghcr.io/m-igashi/mp3rgain:v2.8.0      # exact version
+ghcr.io/m-igashi/mp3rgain:v3          # latest 3.x
+ghcr.io/m-igashi/mp3rgain:v3.1.0      # exact version
 ```
 
 The image is built `FROM scratch` with a fully static (musl) binary — no

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,13 @@
 
 This document provides a detailed comparison between mp3rgain and the original aacgain/mp3gain tools.
 
-> **Headline:** mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. aacgain has been effectively abandoned since ~2009 and is unbuildable on most modern 64-bit systems; among other CLIs, rsgain / loudgain / FFmpeg either tags-only or re-encodes. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only with no undo and is not built for batch / headless / CI use. If you need re-encode-free AAC volume adjustment from a script, container, or non-Windows host in 2026, mp3rgain is the only practical choice — **on a Windows desktop with a GUI, foobar2000 is the one to reach for.**
+> **Headline:** mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. aacgain has been effectively abandoned since ~2009 and is unbuildable on most modern 64-bit systems; among other CLIs, rsgain / loudgain stop at ReplayGain tags and FFmpeg re-encodes. foobar2000 has a comparable "Apply ReplayGain to file content" feature for AAC in MP4/MKA, but it is Windows GUI only with no undo and is not built for batch / headless / CI use. If you need re-encode-free AAC volume adjustment from a script, container, or non-Windows host in 2026, mp3rgain is the only practical choice — **on a Windows desktop with a GUI, foobar2000 is the one to reach for.**
+
+> **A framing note before the tables:** every tool discussed here is a ReplayGain tool, mp3rgain
+> included. The mp3gain lineage (mp3gain, aacgain, mp3rgain) runs a ReplayGain analysis, writes the
+> standard `REPLAYGAIN_*` tags, *and* bakes the correction into the bitstream; foobar2000 can do
+> both as well. "Tagger vs gain tool" is the wrong axis — the axis that matters is whether a tool
+> can touch the bitstream at all, and whether it can put it back.
 
 ## Overview
 
@@ -11,7 +17,7 @@ This document provides a detailed comparison between mp3rgain and the original a
 | **Language** | Rust | C | C |
 | **Last Update** | Active (2026) | 2022 | 2018 |
 | **License** | MIT | LGPL | LGPL |
-| **Version** | 2.8.0 | 1.8.2 | 1.6.2 |
+| **Version** | 3.1.0 | 1.8.2 | 1.6.2 |
 | **Repository** | [M-Igashi/mp3rgain](https://github.com/M-Igashi/mp3rgain) | [dgilman/aacgain](https://github.com/dgilman/aacgain) | SourceForge |
 
 ## Feature Comparison
@@ -254,20 +260,20 @@ If you apply `global_gain` adjustment with mp3rgain and later add ReplayGain tag
 
 For AAC/M4A files specifically, the choice of tool matters more than for MP3, because almost no other modern tool can avoid re-encoding:
 
-| Tool | AAC approach | Lossless? | Player-agnostic? | Maintained? | CLI / scriptable? |
-|------|--------------|-----------|------------------|-------------|-------------------|
-| **mp3rgain** | `global_gain` rewrite | **Yes** | **Yes** | **Yes (active)** | **Yes** |
-| aacgain | `global_gain` rewrite | Yes | Yes | No (~2009) | Yes |
-| foobar2000 "Apply ReplayGain to file content" | scalefactor rewrite (MP4/MKA AAC) | Yes (one-shot, no undo) | Yes | Yes | No (Windows GUI only) |
-| rsgain | ReplayGain 2.0 tags | Yes (file untouched) | No (player must read tags) | Yes | Yes |
-| loudgain | ReplayGain 2.0 tags | Yes (file untouched) | No (player must read tags) | Yes | Yes |
-| FFmpeg `volume` | Re-encode | No (lossy) | Yes | Yes | Yes |
-| FFmpeg `loudnorm` | Re-encode | No (lossy) | Yes | Yes | Yes |
-| beets ReplayGain plugin | Tags via backend | Yes (file untouched) | No (player must read tags) | Yes | Yes |
+| Tool | AAC approach | Writes RG tags? | Lossless? | Player-agnostic? | Maintained? | CLI / scriptable? |
+|------|--------------|-----------------|-----------|------------------|-------------|-------------------|
+| **mp3rgain** | `global_gain` rewrite | **Yes (RG1 / RG2 / R128)** | **Yes** | **Yes** | **Yes (active)** | **Yes** |
+| aacgain | `global_gain` rewrite | Yes (RG1) | Yes | Yes | No (~2009) | Yes |
+| foobar2000 "Apply ReplayGain to file content" | scalefactor rewrite (MP4/MKA AAC) | Yes (RG2 — reference implementation) | Yes (one-shot, no undo) | Yes | Yes | No (Windows GUI only) |
+| rsgain | ReplayGain 2.0 tags | Yes (RG2 / R128) | Yes (file untouched) | No (player must read tags) | Yes | Yes |
+| loudgain | ReplayGain 2.0 tags | Yes (RG2 / R128) | Yes (file untouched) | No (player must read tags) | Yes | Yes |
+| FFmpeg `volume` | Re-encode | No | No (lossy) | Yes | Yes | Yes |
+| FFmpeg `loudnorm` | Re-encode | No | No (lossy) | Yes | Yes | Yes |
+| beets ReplayGain plugin | Tags via backend | Yes (backend-dependent) | Yes (file untouched) | No (player must read tags) | Yes | Yes |
 
 **The "lossless + player-agnostic + maintained + CLI/scriptable + reversible" intersection contains exactly one tool: mp3rgain.** This matters for DJ equipment, car audio, smart speakers, batch / Docker / CI pipelines, and any environment where the playback device ignores ReplayGain tags or where a desktop GUI is not an option.
 
-That is a statement about the intersection, not a ranking. [foobar2000](https://www.foobar2000.org/) covers the lossless / player-agnostic / maintained cells and does so well; what it does not offer is a command line, a non-Windows host, or an undo path. **If you are on Windows, working in a GUI, and want current BS.1770 ReplayGain, foobar2000 is the tool to recommend** — it also covers more formats than mp3rgain and its scanner is the reference many people compare against. The two interoperate: mp3rgain writes the standard `REPLAYGAIN_*` tags foobar2000 reads, and `--rg2` matches its measurement.
+That is a statement about the intersection, not a ranking. [foobar2000](https://www.foobar2000.org/) covers the lossless / player-agnostic / maintained cells and does so well; what it does not offer is a command line, a non-Windows host, or an undo path. **If you are on Windows, working in a GUI, and want the most standards-faithful ReplayGain, foobar2000 is the tool to recommend** — it is the closest thing ReplayGain 2.0 has to a reference implementation, and it tags far more formats than mp3rgain does. The two interoperate by design: mp3rgain writes the standard `REPLAYGAIN_*` tags foobar2000 reads, and `--rg2` is built to reproduce its measurement rather than to offer a rival one.
 
 ### When to Use global_gain vs ReplayGain Tags
 
@@ -281,6 +287,11 @@ That is a statement about the intersection, not a ranking. [foobar2000](https://
 | Maximum flexibility | ReplayGain tags (rsgain) |
 
 For most modern listening setups, **ReplayGain tags are the cleaner solution**. Use `global_gain` adjustment when your playback device doesn't support ReplayGain tags.
+
+Note that this is not an either/or for mp3rgain users: applying gain also writes the standard
+`REPLAYGAIN_TRACK_GAIN` / `REPLAYGAIN_ALBUM_GAIN` tags (residual values, per mp3gain's convention),
+so a tag-aware player and a tag-blind one converge on the same loudness. `-s s` skips the tags if
+you want the bitstream change alone.
 
 ## Security
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current Status: v3.1.0 (Production Ready)
 
-**Positioning:** mp3rgain is the only actively maintained CLI that performs lossless `global_gain` rewrite on AAC/M4A files (aacgain has been abandoned since ~2009; foobar2000's "Apply ReplayGain to file content" offers a comparable scalefactor-based AAC rewrite but is Windows GUI only with no undo). For MP3 it's a modern drop-in replacement for mp3gain; for AAC on the command line it has no equivalent.
+**Positioning:** mp3rgain is a ReplayGain tool in the mp3gain lineage — it analyses, writes standard `REPLAYGAIN_*` tags, and bakes the correction into the bitstream — and it is the only actively maintained CLI doing that for AAC/M4A (aacgain has been abandoned since ~2009; foobar2000 is the reference-grade ReplayGain suite and its "Apply ReplayGain to file content" offers a comparable scalefactor-based AAC rewrite, but it is Windows GUI only with no undo). For MP3 it's a modern drop-in replacement for mp3gain; for AAC on the command line it has no equivalent.
 
 All core functionality complete:
 - [x] MP3 frame parsing (MPEG 1/2/2.5 Layer III)

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -4,7 +4,7 @@ This document describes real-world use cases for mp3rgain.
 
 ## Standout Capability: Lossless AAC Volume Adjustment on the CLI
 
-mp3rgain is the **only actively maintained CLI** that performs lossless `global_gain` rewrite on AAC/M4A files. ([foobar2000](https://www.foobar2000.org/)'s "Apply ReplayGain to file content" does a comparable scalefactor-based AAC adjustment in MP4/MKA — if you are on a Windows desktop and happy in a GUI, use it. It has no undo path and no command line.) Use cases that specifically benefit from a scriptable, cross-platform option:
+mp3rgain is the **only actively maintained CLI** that runs a ReplayGain analysis and then performs a lossless `global_gain` rewrite on AAC/M4A files — tags *and* baked-in gain, the way aacgain used to. ([foobar2000](https://www.foobar2000.org/) is the reference-grade ReplayGain suite and its "Apply ReplayGain to file content" does a comparable scalefactor-based AAC adjustment in MP4/MKA — if you are on a Windows desktop and happy in a GUI, use it. It has no undo path and no command line.) Use cases that specifically benefit from a scriptable, cross-platform option:
 
 - **iTunes / Apple Music libraries on macOS / Linux**: Most personal music libraries on Apple platforms are AAC/M4A. Normalizing them without re-encoding from a non-Windows host previously had no maintained option.
 - **DJ workflows with AAC**: DJ hardware (CDJs, XDJs, controllers) ignores ReplayGain tags. AAC tracks bought from iTunes Store or other M4A sources previously had to be re-encoded to lose loudness, sacrificing quality.


### PR DESCRIPTION
## Why

The README and comparison docs presented the landscape as "tag tools (rsgain, loudgain) vs gain tools (mp3gain, aacgain, mp3rgain)". That is the wrong axis:

- **mp3rgain is a ReplayGain tool.** It runs the analysis and writes standard `REPLAYGAIN_TRACK_GAIN` / `REPLAYGAIN_ALBUM_GAIN` / `_PEAK` tags (plus `REPLAYGAIN_ALGORITHM` in the BS.1770 modes) alongside the bitstream rewrite — as mp3gain and aacgain always have. The residual-value convention means tag-aware and tag-blind players converge on the same loudness.
- **foobar2000 was undersold.** It is the closest thing ReplayGain 2.0 has to a reference implementation, tags far more formats than mp3rgain does, and `--rg2` exists to reproduce its numbers rather than compete with them.

The real distinction is whether a tool can touch the bitstream at all, and whether it can put it back.

## Changes

- `README.md` — rewrite the "Why mp3rgain?" framing, strengthen the foobar2000 tip, note tag writing in the ReplayGain feature bullet
- `docs/COMPARISON.md` — add a framing note under the headline, add a "Writes RG tags?" column to the AAC landscape table, clarify the global_gain-vs-tags section is not an either/or for mp3rgain
- `docs/use-cases.md`, `docs/roadmap.md` — same nuance in the positioning statements

Also refreshes two stale values found in passing: the GHCR tag example (`v2` → `v3`) and the version cell in `COMPARISON.md` (2.8.0 → 3.1.0).

The matching changes are already live on <https://mp3rgain.tyna.ninja/vs-mp3gain>.