### PR TITLE
Fix album zero-gain tags, and write ReplayGain where players read it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Run integration tests
         run: cargo test --test integration_tests --verbose
 
+      - name: Run CLI tests
+        run: cargo test --test cli_tests --verbose
+
       - name: Build with replaygain feature
         run: cargo build --features replaygain --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp3rgain"
-version = "3.1.1"
+version = "3.2.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Jesse Pinkman <M-Igashi@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A native GUI application (`mp3rgui`) is available for users who prefer a graphic
 - Drag-and-drop file / folder loading (recurses subfolders)
 - Track and Album ReplayGain analysis (parallel, with Cancel)
 - Apply Track / Album Gain — shares the same `apply_with_options` pipeline as the CLI
-- **Options panel:** Prevent clipping (`-k`), Preserve mtime (`-p`), Wrap mode (`-w`), Use ID3v2 (`-s i`), Dry run (`-n`)
+- **Options panel:** Prevent clipping (`-k`), Preserve mtime (`-p`), Wrap mode (`-w`), MP3 tag layout (`-s a` / `-s i`), Dry run (`-n`)
 - **Modify Gain menu:** Apply Track / Album / Manual (`-g`) / Channel (`-l`) Gain, Undo (`-u`), Delete Stored Tags (`-s d`)
 - **Analysis menu:** Track / Album Analysis, Find Max Amplitude (`-x`), Check Stored Tags (`-s c`)
 - **Stored RG** table column shows existing ReplayGain / undo tags (APE / ID3v2 / MP4 freeform) with a per-tag breakdown on hover
@@ -176,8 +176,7 @@ These are all ReplayGain tools, mp3rgain included — it runs a ReplayGain analy
 > it can bake gain into MP3 and AAC bitstreams too. mp3rgain is the better fit when you need a
 > command line, a non-Windows host, mp3gain-identical ReplayGain 1.0 values, or an undo path — and
 > the two coexist fine, since mp3rgain writes the same standard `REPLAYGAIN_*` tags foobar2000
-> reads, with `--rg2` deliberately matching its measurement. For MP3, add `-s i` so those tags
-> land in ID3v2 — see below.
+> reads — in ID3v2, where it looks for them — with `--rg2` deliberately matching its measurement.
 
 mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 
@@ -185,13 +184,26 @@ Files scanned with `--rg2` / `--r128` also carry a `REPLAYGAIN_ALGORITHM` tag se
 
 ### Where the tags go (MP3)
 
-By default mp3rgain writes **APEv2**, exactly where mp3gain put its tags. Some players — foobar2000 among them — only look for ReplayGain in **ID3v2** on MP3, so they will not see the default tags. Pass `-s i` to write them as ID3v2 `TXXX` frames instead:
+MP3 has two competing metadata containers, and the two tag families mp3rgain writes have different audiences. By default each goes where its readers are:
+
+| Tag | Container | Read by |
+|-----|-----------|---------|
+| `REPLAYGAIN_*` | ID3v2 `TXXX` | Players. ffmpeg — and everything built on it — does not read APEv2 on MP3 at all, and Rockbox only handles APE tags for WavPack/Musepack. foobar2000 writes ReplayGain to ID3v2 and expects it there. |
+| `MP3GAIN_UNDO`, `MP3GAIN_MINMAX` | APEv2 | Nothing but the mp3gain lineage, which looks in APEv2. Keeping them there is what makes `-u` work on a library mp3gain already processed. |
+
+Two flags override the split when you want everything in one place:
 
 ```bash
-mp3rgain -r -s i *.mp3     # ReplayGain tags foobar2000 will read
+mp3rgain -r *.mp3          # default: ReplayGain in ID3v2, undo in APEv2
+mp3rgain -r -s a *.mp3     # everything in APEv2 — byte-for-byte mp3gain
+mp3rgain -r -s i *.mp3     # everything in ID3v2
 ```
 
-`-s i` covers the whole round trip: the `REPLAYGAIN_*` values, `MP3GAIN_UNDO`, `-s c` inspection, and `-u` undo all use ID3v2 in that mode. The one APEv2-only extra is `MP3GAIN_ALBUM_MINMAX`. AAC/M4A is unaffected — it always uses MP4 freeform atoms, which foobar2000 reads.
+`MP3GAIN_ALBUM_MINMAX` is APEv2-only in every mode. AAC/M4A is unaffected — it always uses MP4 freeform atoms.
+
+`-s c` reads both containers and merges them, and `-u` finds the undo tag in either, so files tagged by mp3gain or by an earlier `-s i` run still inspect and roll back correctly.
+
+> **Changed in 3.2.0.** Earlier versions put everything in APEv2. If you depend on the old layout, `-s a` restores it exactly. Re-running the default over an APEv2-tagged file moves the ReplayGain values to ID3v2 and clears the APEv2 copies so the two cannot disagree.
 
 ## Use mp3rgain in Docker / CI
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,22 @@ These are all ReplayGain tools, mp3rgain included — it runs a ReplayGain analy
 > it can bake gain into MP3 and AAC bitstreams too. mp3rgain is the better fit when you need a
 > command line, a non-Windows host, mp3gain-identical ReplayGain 1.0 values, or an undo path — and
 > the two coexist fine, since mp3rgain writes the same standard `REPLAYGAIN_*` tags foobar2000
-> reads, with `--rg2` deliberately matching its measurement.
+> reads, with `--rg2` deliberately matching its measurement. For MP3, add `-s i` so those tags
+> land in ID3v2 — see below.
 
 mp3rgain implements the **ReplayGain 1.0 algorithm** (89 dB reference level) by default for full compatibility with the original mp3gain / aacgain — an existing library re-scans to identical values. Modern BS.1770 loudness measurement is available as an opt-in: `--rg2` (ReplayGain 2.0, −18 LUFS reference) and `--r128` (EBU R128, −23 LUFS target) produce values consistent with foobar2000, loudgain, and ffmpeg loudnorm.
 
 Files scanned with `--rg2` / `--r128` also carry a `REPLAYGAIN_ALGORITHM` tag set to `ITU-R BS.1770`, so a player (or you, years later) can tell which measurement produced the stored values. The default RG1 mode writes no such tag — an absent one means the classic mp3gain measurement, which is what every pre-existing tagged file already implies.
+
+### Where the tags go (MP3)
+
+By default mp3rgain writes **APEv2**, exactly where mp3gain put its tags. Some players — foobar2000 among them — only look for ReplayGain in **ID3v2** on MP3, so they will not see the default tags. Pass `-s i` to write them as ID3v2 `TXXX` frames instead:
+
+```bash
+mp3rgain -r -s i *.mp3     # ReplayGain tags foobar2000 will read
+```
+
+`-s i` covers the whole round trip: the `REPLAYGAIN_*` values, `MP3GAIN_UNDO`, `-s c` inspection, and `-u` undo all use ID3v2 in that mode. The one APEv2-only extra is `MP3GAIN_ALBUM_MINMAX`. AAC/M4A is unaffected — it always uses MP4 freeform atoms, which foobar2000 reads.
 
 ## Use mp3rgain in Docker / CI
 

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -84,7 +84,7 @@ are worth knowing:
 | `-w` | Wrap gain values instead of clamping |
 | `-n`, `--dry-run` | Preview changes without writing |
 | `-o text` / `-o json` / `-o tsv` | Explicit output format selection |
-| `-s i` | Use ID3v2 ReplayGain tags instead of APEv2 (partial) |
+| `-s i` | Write ReplayGain and undo tags as ID3v2 `TXXX` instead of APEv2 — needed for players that only read ID3v2 on MP3, foobar2000 included |
 | `-j <n>` / `--threads <n>` | Worker threads for ReplayGain analysis (default: auto). `MP3RGAIN_THREADS` env var also honored. `-j 1` reproduces mp3gain's serial behavior. See [docs/perf-parallel.md](perf-parallel.md). |
 | `--skip-errors` | Keep album analysis (`-a`) going past unreadable files; failed files are reported and excluded from the album gain |
 
@@ -136,7 +136,7 @@ These are the only behaviour differences worth knowing about:
 | Undo cleanup | mp3gain leaves empty APEv2 tags after `-u`; mp3rgain removes them | Audio data is identical; only the tag block differs |
 | ReplayGain analysis | mp3gain uses LAME; mp3rgain uses Symphonia + native Rust | Track/album gain values may differ by <0.1 dB. The *applied* gain is bit-identical for any given step value |
 | Format coverage | mp3gain handles MP3 only | mp3rgain also handles AAC/M4A/.mp4 (lossless `global_gain` rewrite, the same idea aacgain used) |
-| `-s i` (ID3v2) | Not supported in mp3gain | Marked "not fully supported" in `--help` — prefer the default APEv2 path unless you specifically need ReplayGain TXXX tags |
+| `-s i` (ID3v2) | Not supported in mp3gain | Writing, `-s c` inspection and `-u` undo all work against ID3v2 in this mode; `MP3GAIN_ALBUM_MINMAX` is the one APEv2-only extra. Keep the default APEv2 path for mp3gain interop, use `-s i` when a player needs ID3v2 ReplayGain |
 
 If you discover a case where mp3rgain produces non-identical output for an
 operation listed under [Identical behaviour](#identical-behaviour), please

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -69,7 +69,7 @@ flags are accepted with the same semantics; mp3rgain adds a few extensions.
 | `-f` | Assume MPEG2 Layer III | Accepted; no effect (mp3rgain auto-detects) |
 | `-q` | Quiet mode | |
 | `-R` | Process directories recursively | |
-| `-s c` / `-s d` / `-s s` / `-s r` / `-s a` | Stored-tag handling: check / delete / skip / recalc / APEv2 (default) | Same modes as mp3gain |
+| `-s c` / `-s d` / `-s s` / `-s r` / `-s a` | Stored-tag handling: check / delete / skip / recalc / all-APEv2 | Same modes as mp3gain. `-s a` pins every tag to APEv2, which is mp3gain's layout and was mp3rgain's default before 3.2.0 |
 | `-o` (no argument) | TSV output | Default header matches mp3gain exactly (see [Output format](#output-format)) |
 
 ### mp3rgain extensions
@@ -84,7 +84,7 @@ are worth knowing:
 | `-w` | Wrap gain values instead of clamping |
 | `-n`, `--dry-run` | Preview changes without writing |
 | `-o text` / `-o json` / `-o tsv` | Explicit output format selection |
-| `-s i` | Write ReplayGain and undo tags as ID3v2 `TXXX` instead of APEv2 — needed for players that only read ID3v2 on MP3, foobar2000 included |
+| `-s i` | Put *every* tag in ID3v2 `TXXX`, undo included. Since 3.2.0 the default already writes `REPLAYGAIN_*` to ID3v2, so this is only needed when you want `MP3GAIN_UNDO` there too |
 | `-j <n>` / `--threads <n>` | Worker threads for ReplayGain analysis (default: auto). `MP3RGAIN_THREADS` env var also honored. `-j 1` reproduces mp3gain's serial behavior. See [docs/perf-parallel.md](perf-parallel.md). |
 | `--skip-errors` | Keep album analysis (`-a`) going past unreadable files; failed files are reported and excluded from the album gain |
 
@@ -119,8 +119,8 @@ For new integrations, prefer `-o json`, which is structured and stable.
 |--------------|---------|----------|---------|
 | APEv2 `mp3gain_undo` (MP3) | Written | Written | Bidirectional — either tool can undo the other's changes ([#210](https://github.com/M-Igashi/mp3rgain/issues/210); files written by mp3rgain ≤ 2.8.x used the opposite sign) |
 | APEv2 `mp3gain_minmax` (MP3) | Written | Written | Same |
-| APEv2 ReplayGain (`mp3gain_album_*`, `replaygain_*`) | Written | Written | Same |
-| ID3v2 TXXX/RVA2 ReplayGain | Not written | Written with `-s i` | Standard ReplayGain readers (foobar2000, mpd, etc.) recognise it |
+| APEv2 ReplayGain (`mp3gain_album_*`, `replaygain_*`) | Written | Written with `-s a` | Since 3.2.0 the default puts `REPLAYGAIN_*` in ID3v2 instead, and clears stale APEv2 copies so the two cannot disagree. `-s a` restores mp3gain's layout exactly |
+| ID3v2 TXXX ReplayGain | Not written | Written by default since 3.2.0 | Where standard ReplayGain readers look. ffmpeg does not read APEv2 on MP3 at all, and Rockbox only handles APE tags for WavPack/Musepack |
 | MP4 freeform metadata (AAC/M4A) | N/A | Written | mp3gain has no AAC support; mp3rgain stores AAC undo and ReplayGain in `com.apple.metadata.mdta:ReplayGain_*` and a `mp3gain_undo` freeform atom |
 
 For more on the choice between bitstream `global_gain` rewriting and
@@ -136,7 +136,7 @@ These are the only behaviour differences worth knowing about:
 | Undo cleanup | mp3gain leaves empty APEv2 tags after `-u`; mp3rgain removes them | Audio data is identical; only the tag block differs |
 | ReplayGain analysis | mp3gain uses LAME; mp3rgain uses Symphonia + native Rust | Track/album gain values may differ by <0.1 dB. The *applied* gain is bit-identical for any given step value |
 | Format coverage | mp3gain handles MP3 only | mp3rgain also handles AAC/M4A/.mp4 (lossless `global_gain` rewrite, the same idea aacgain used) |
-| `-s i` (ID3v2) | Not supported in mp3gain | Writing, `-s c` inspection and `-u` undo all work against ID3v2 in this mode; `MP3GAIN_ALBUM_MINMAX` is the one APEv2-only extra. Keep the default APEv2 path for mp3gain interop, use `-s i` when a player needs ID3v2 ReplayGain |
+| Tag placement | mp3gain puts everything in APEv2 | Since 3.2.0 mp3rgain splits: `REPLAYGAIN_*` to ID3v2 where players look, `MP3GAIN_UNDO`/`MINMAX` to APEv2 where mp3gain looks. `-s a` restores the all-APEv2 layout; `-s i` puts everything in ID3v2. `MP3GAIN_ALBUM_MINMAX` is APEv2-only in every mode |
 
 If you discover a case where mp3rgain produces non-identical output for an
 operation listed under [Identical behaviour](#identical-behaviour), please

--- a/mp3rgui/Cargo.lock
+++ b/mp3rgui/Cargo.lock
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgain"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "mp3rgui"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "eframe",
  "egui",

--- a/mp3rgui/Cargo.toml
+++ b/mp3rgui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp3rgui"
-version = "3.1.1"
+version = "3.2.0"
 edition = "2021"
 authors = ["Jesse Pinkman <M-Igashi@users.noreply.github.com>"]
 description = "GUI application for mp3rgain - lossless MP3 volume adjustment"

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -803,12 +803,12 @@ impl Mp3rgainApp {
             self.files[job_idx].status = FileStatus::Pending;
         }
         let count = jobs.len();
-        let use_id3v2 = self.apply_options.use_id3v2;
+        let layout = self.apply_options.tag_layout;
         let preserve = self.apply_options.preserve_timestamp;
         self.begin_worker(
             WorkerKind::DeleteTags,
             count,
-            worker::spawn_delete_tags(ctx.clone(), jobs, use_id3v2, preserve),
+            worker::spawn_delete_tags(ctx.clone(), jobs, layout, preserve),
         );
     }
 
@@ -860,11 +860,11 @@ impl Mp3rgainApp {
             })
             .collect();
         let count = jobs.len();
-        let use_id3v2 = self.apply_options.use_id3v2;
+        let layout = self.apply_options.tag_layout;
         self.begin_worker(
             WorkerKind::CheckTags,
             count,
-            worker::spawn_check_stored_tags(ctx.clone(), jobs, use_id3v2),
+            worker::spawn_check_stored_tags(ctx.clone(), jobs, layout),
         );
     }
 
@@ -891,11 +891,11 @@ impl Mp3rgainApp {
             return;
         }
         let count = jobs.len();
-        let use_id3v2 = self.apply_options.use_id3v2;
+        let layout = self.apply_options.tag_layout;
         self.begin_worker(
             WorkerKind::ImportScan,
             count,
-            worker::spawn_check_stored_tags(ctx.clone(), jobs, use_id3v2),
+            worker::spawn_check_stored_tags(ctx.clone(), jobs, layout),
         );
     }
 
@@ -978,7 +978,7 @@ impl Mp3rgainApp {
     }
 
     /// Undo gain changes on selected files (or all files when no selection).
-    /// Library calls dispatch internally on file format and `use_id3v2`.
+    /// Library calls dispatch internally on file format and `TagLayout`.
     pub fn start_undo(&mut self, ctx: &egui::Context) {
         if self.files.is_empty() || self.is_processing() {
             return;

--- a/mp3rgui/src/ui/options.rs
+++ b/mp3rgui/src/ui/options.rs
@@ -1,5 +1,6 @@
 use crate::app::Mp3rgainApp;
 use mp3rgain::replaygain::AnalysisMode;
+use mp3rgain::TagLayout;
 
 /// Apply-options checkbox row, shown right below the toolbar.
 ///
@@ -30,12 +31,34 @@ pub fn render(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                          Disables the clipping check. CLI -w. Rarely useful — leave off.",
                     );
 
-                ui.checkbox(&mut app.apply_options.use_id3v2, "Use ID3v2 (MP3)")
-                    .on_hover_text(
-                        "MP3 only: store undo + ReplayGain tags in ID3v2 TXXX frames \
-                         instead of APE. Required for foobar2000 / Winamp / Rockbox \
-                         to see ReplayGain values on MP3. CLI -s i.",
-                    );
+                ui.horizontal(|ui| {
+                    ui.label("MP3 tags:");
+                    let layout = &mut app.apply_options.tag_layout;
+                    egui::ComboBox::from_id_salt("tag_layout")
+                        .selected_text(match layout {
+                            TagLayout::Split => "ReplayGain in ID3v2",
+                            TagLayout::Ape => "All in APEv2",
+                            TagLayout::Id3v2 => "All in ID3v2",
+                        })
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(layout, TagLayout::Split, "ReplayGain in ID3v2")
+                                .on_hover_text(
+                                    "Default. REPLAYGAIN_* in ID3v2 TXXX where players \
+                                 look, MP3GAIN_UNDO / MINMAX in APEv2 where mp3gain \
+                                 looks.",
+                                );
+                            ui.selectable_value(layout, TagLayout::Ape, "All in APEv2")
+                                .on_hover_text(
+                                    "Byte-for-byte mp3gain behaviour. ReplayGain-aware \
+                                     players will not find the values. CLI -s a.",
+                                );
+                            ui.selectable_value(layout, TagLayout::Id3v2, "All in ID3v2")
+                                .on_hover_text(
+                                    "Undo and ReplayGain both in ID3v2 TXXX frames. \
+                                     CLI -s i.",
+                                );
+                        });
+                });
 
                 ui.separator();
 

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -13,7 +13,7 @@ use mp3rgain::apply::{
     ApplyOptions,
 };
 use mp3rgain::replaygain::{self, AnalysisMode, ReplayGainResult};
-use mp3rgain::{read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource};
+use mp3rgain::{read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource, TagLayout};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -188,7 +188,10 @@ pub struct ApplyOptionsUi {
     pub prevent_clipping: bool,
     pub wrap: bool,
     pub preserve_timestamp: bool,
-    pub use_id3v2: bool,
+    /// Which container MP3 tags go in. `serde(default)` so settings files
+    /// written before this field existed load as the default split layout.
+    #[serde(default)]
+    pub tag_layout: TagLayout,
     /// When true, Apply Track / Album Gain runs in dry-run mode: the worker
     /// reports what `apply_with_options` *would* do but doesn't touch the
     /// file. Equivalent to the CLI's -n flag.
@@ -197,14 +200,13 @@ pub struct ApplyOptionsUi {
 
 impl Default for ApplyOptionsUi {
     fn default() -> Self {
-        // Safe defaults: prevent clipping, keep mtime, no wrap, no
-        // ID3v2-on-MP3 (the existing APE undo path is still the more
-        // widely compatible option).
+        // Safe defaults: prevent clipping, keep mtime, no wrap, and the
+        // split tag layout so players actually find the ReplayGain values.
         Self {
             prevent_clipping: true,
             wrap: false,
             preserve_timestamp: true,
-            use_id3v2: false,
+            tag_layout: TagLayout::default(),
             dry_run: false,
         }
     }
@@ -443,14 +445,15 @@ pub fn spawn_apply(
         // album-wide MP3GAIN_ALBUM_MINMAX after all files are applied — the
         // same mp3gain-parity step the CLI does (issue #210). APEv2 only and
         // not in dry-run.
-        let album_minmax_paths: Vec<PathBuf> = if !ui_opts.dry_run && !ui_opts.use_id3v2 {
-            jobs.iter()
-                .filter(|j| j.album_info.is_some())
-                .map(|j| j.path.clone())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let album_minmax_paths: Vec<PathBuf> =
+            if !ui_opts.dry_run && !ui_opts.tag_layout.mp3gain_in_id3v2() {
+                jobs.iter()
+                    .filter(|j| j.album_info.is_some())
+                    .map(|j| j.path.clone())
+                    .collect()
+            } else {
+                Vec::new()
+            };
         // Post-apply (max, min) global_gain range per album file, taken from
         // the apply reports so the MINMAX step below doesn't re-analyze every
         // file (issue #232).
@@ -464,8 +467,9 @@ pub fn spawn_apply(
             run_job_pool(jobs, &cancel_w, move |job: ApplyJob| {
                 send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-                let album_member =
-                    !ui_opts.dry_run && !ui_opts.use_id3v2 && job.album_info.is_some();
+                let album_member = !ui_opts.dry_run
+                    && !ui_opts.tag_layout.mp3gain_in_id3v2()
+                    && job.album_info.is_some();
                 let opts = build_apply_options(
                     job.steps,
                     job.track_result,
@@ -583,7 +587,7 @@ pub fn spawn_apply(
 /// parallelizes the same way apply does). Dispatches per file to the
 /// correct undo path:
 ///   - AAC: `mp3rgain::aac::undo_aac_gain`
-///   - MP3 + `use_id3v2`: `mp3rgain::undo_gain_id3v2`
+///   - MP3 + `TagLayout::Id3v2`: `mp3rgain::undo_gain_id3v2`
 ///   - MP3 (default APE): `mp3rgain::undo_gain`
 ///
 /// Mirrors the CLI's `process_undo` dispatch so behavior matches.
@@ -610,9 +614,9 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
                 // UI how many steps to reverse on the display. We can't read
                 // it after undo because undo_gain_auto deletes the tag (issue #171).
                 let steps_undone =
-                    mp3rgain::read_undo_steps(&job.path, ui_opts.use_id3v2).unwrap_or(0);
+                    mp3rgain::read_undo_steps(&job.path, ui_opts.tag_layout).unwrap_or(0);
 
-                let result = mp3rgain::undo_gain_auto(&job.path, ui_opts.use_id3v2);
+                let result = mp3rgain::undo_gain_auto(&job.path, ui_opts.tag_layout);
                 match result {
                     Ok(0) => {
                         skipped.fetch_add(1, Ordering::Relaxed);
@@ -680,12 +684,12 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
 ///
 /// Dispatch mirrors the CLI's `process_delete_tags`:
 ///   - AAC: `mp4meta::delete_replaygain_tags` + `delete_undo_tags`
-///   - MP3 + `use_id3v2`: `mp3rgain::delete_id3v2_replaygain`
+///   - MP3 + `TagLayout::Id3v2`: `mp3rgain::delete_id3v2_replaygain`
 ///   - MP3 (default APE): `mp3rgain::delete_ape_tag`
 pub fn spawn_delete_tags(
     ctx: egui::Context,
     jobs: Vec<DeleteTagsJob>,
-    use_id3v2: bool,
+    layout: TagLayout,
     preserve_timestamp: bool,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
@@ -705,7 +709,7 @@ pub fn spawn_delete_tags(
 
                 let original_mtime = saved_mtime(&job.path, preserve_timestamp);
 
-                let result = mp3rgain::delete_gain_tags_auto(&job.path, use_id3v2);
+                let result = mp3rgain::delete_gain_tags_auto(&job.path, layout);
 
                 match result {
                     Ok(()) => {
@@ -838,12 +842,12 @@ pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>
 ///
 /// Dispatch is shared with the CLI via `mp3rgain::read_gain_tags_auto`:
 ///   - AAC: MP4 freeform RG + undo
-///   - MP3 + `use_id3v2`: ID3v2 TXXX RG
+///   - MP3 + `TagLayout::Id3v2`: ID3v2 TXXX RG
 ///   - MP3: APE
 pub fn spawn_check_stored_tags(
     ctx: egui::Context,
     jobs: Vec<CheckTagsJob>,
-    use_id3v2: bool,
+    layout: TagLayout,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
@@ -857,7 +861,7 @@ pub fn spawn_check_stored_tags(
                 return;
             }
             send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
-            let view = read_stored_tags(&job.path, use_id3v2);
+            let view = read_stored_tags(&job.path, layout);
             send(
                 &tx,
                 &ctx,
@@ -877,13 +881,14 @@ pub fn spawn_check_stored_tags(
     WorkerHandle { rx, cancel }
 }
 
-fn read_stored_tags(path: &Path, use_id3v2: bool) -> StoredTagsView {
-    match read_gain_tags_auto(path, use_id3v2) {
+fn read_stored_tags(path: &Path, layout: TagLayout) -> StoredTagsView {
+    match read_gain_tags_auto(path, layout) {
         Ok(tags) => StoredTagsView {
             format: Some(match tags.source {
                 GainTagSource::Aac => "MP4",
                 GainTagSource::Id3v2 => "ID3v2",
                 GainTagSource::Ape { .. } => "APE",
+                GainTagSource::Split => "ID3v2+APE",
             }),
             track_gain: tags.track_gain,
             track_peak: tags.track_peak,
@@ -896,7 +901,11 @@ fn read_stored_tags(path: &Path, use_id3v2: bool) -> StoredTagsView {
         // fail-soft branches did. The AAC branch never errors, so the label
         // follows the MP3 tag mode.
         Err(_) => StoredTagsView {
-            format: Some(if use_id3v2 { "ID3v2" } else { "APE" }),
+            format: Some(match layout {
+                TagLayout::Id3v2 => "ID3v2",
+                TagLayout::Ape => "APE",
+                TagLayout::Split => "ID3v2+APE",
+            }),
             ..Default::default()
         },
     }
@@ -924,7 +933,7 @@ fn build_apply_options(
     opts.prevent_clipping = ui_opts.prevent_clipping;
     opts.wrap = ui_opts.wrap;
     opts.preserve_timestamp = ui_opts.preserve_timestamp;
-    opts.use_id3v2 = ui_opts.use_id3v2;
+    opts.tag_layout = ui_opts.tag_layout;
     opts
 }
 

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -144,6 +144,23 @@ impl ApeTag {
             }
         }
     }
+
+    /// Drop every `REPLAYGAIN_*` item, keeping the `MP3GAIN_*` ones.
+    ///
+    /// Needed by [`crate::TagLayout::Split`]: the fresh values go to ID3v2, so
+    /// stale APEv2 copies left by mp3gain or an earlier `-s a` run would
+    /// otherwise linger and disagree with them.
+    pub(crate) fn remove_replaygain(&mut self) {
+        for key in [
+            TAG_REPLAYGAIN_TRACK_GAIN,
+            TAG_REPLAYGAIN_TRACK_PEAK,
+            TAG_REPLAYGAIN_ALBUM_GAIN,
+            TAG_REPLAYGAIN_ALBUM_PEAK,
+            TAG_REPLAYGAIN_ALGORITHM,
+        ] {
+            self.remove(key);
+        }
+    }
 }
 
 impl std::fmt::Display for ApeTag {
@@ -477,6 +494,31 @@ pub struct ApeReplayGain {
 /// `rg` are set.
 pub fn write_ape_replaygain(file_path: &Path, rg: &ApeReplayGain) -> Result<()> {
     rewrite_ape_tail(file_path, |tag| tag.set_replaygain(rg))
+}
+
+/// Drop the `REPLAYGAIN_*` items from `file_path`'s APEv2 tag, keeping
+/// `MP3GAIN_*`.
+///
+/// Used by [`crate::TagLayout::Split`], where the authoritative ReplayGain
+/// values live in ID3v2: an APEv2 copy left behind by mp3gain or an earlier
+/// `-s a` run would go stale the moment the ID3v2 values are rewritten. Files
+/// with no APEv2 ReplayGain items are left untouched rather than rewritten.
+pub(crate) fn remove_ape_replaygain(file_path: &Path) -> Result<()> {
+    let has_rg = read_ape_tag_from_file(file_path)?.is_some_and(|tag| {
+        [
+            TAG_REPLAYGAIN_TRACK_GAIN,
+            TAG_REPLAYGAIN_TRACK_PEAK,
+            TAG_REPLAYGAIN_ALBUM_GAIN,
+            TAG_REPLAYGAIN_ALBUM_PEAK,
+            TAG_REPLAYGAIN_ALGORITHM,
+        ]
+        .iter()
+        .any(|k| tag.get(k).is_some())
+    });
+    if !has_rg {
+        return Ok(());
+    }
+    rewrite_ape_tail(file_path, |tag| tag.remove_replaygain())
 }
 
 /// Add (or replace) the `MP3GAIN_ALBUM_MINMAX` item in `file_path`'s APEv2

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -27,7 +27,7 @@ use crate::gain::{
     MAX_GAIN,
 };
 use crate::replaygain::ReplayGainResult;
-use crate::{ape, id3v2, mp4meta};
+use crate::{ape, id3v2, mp4meta, TagLayout};
 
 /// Per-process counter for `.mp3rgain_temp_*` filenames so parallel
 /// apply tasks operating on files in the same directory don't collide.
@@ -87,19 +87,18 @@ pub struct ApplyOptions {
     /// (issue #227), so the flag is accepted but has no effect.
     pub use_temp_file: bool,
 
-    /// Record an undo tag (APE for MP3, MP4 freeform for AAC, ID3v2 TXXX
-    /// when [`Self::use_id3v2`] is on).
+    /// Record an undo tag (MP4 freeform for AAC; for MP3 the container is
+    /// [`Self::tag_layout`] — APEv2 unless `-s i`).
     pub write_undo: bool,
 
     /// Write ReplayGain metadata tags. Requires [`Self::track_result`] to
-    /// be set. AAC writes to mp4 freeform metadata; MP3 writes ID3v2 TXXX
-    /// frames when [`Self::use_id3v2`] is on, otherwise APEv2 `REPLAYGAIN_*`
-    /// items (issue #204).
+    /// be set. AAC writes to mp4 freeform metadata; MP3 follows
+    /// [`Self::tag_layout`] (issue #204).
     pub write_replaygain_tags: bool,
 
-    /// `-s i`: MP3 only — use ID3v2 TXXX frames for undo and ReplayGain
-    /// instead of APE.
-    pub use_id3v2: bool,
+    /// MP3 only — which container(s) the tags go in. Defaults to
+    /// [`TagLayout::Split`].
+    pub tag_layout: TagLayout,
 
     /// `-l`: MP3 only — apply gain to a single channel (Stereo / Dual
     /// Channel) instead of all channels. AAC has no per-channel apply
@@ -129,7 +128,7 @@ impl ApplyOptions {
             use_temp_file: false,
             write_undo: true,
             write_replaygain_tags: false,
-            use_id3v2: false,
+            tag_layout: TagLayout::default(),
             channel: None,
             skip_clipping_check: false,
         }
@@ -233,11 +232,17 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     let mut ape_rg_folded = false;
     let modified = if is_aac {
         apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
-    } else if opts.use_id3v2 {
+    } else if opts.tag_layout.mp3gain_in_id3v2() {
         saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts, mp3_data.take())?;
         saturation.frames
     } else {
-        let folded_rg = if opts.write_replaygain_tags && opts.channel.is_none() && !opts.wrap {
+        // Under Split the ReplayGain values belong in ID3v2, so nothing is
+        // folded into the APE write here — step 3 handles them.
+        let folded_rg = if opts.write_replaygain_tags
+            && opts.tag_layout == TagLayout::Ape
+            && opts.channel.is_none()
+            && !opts.wrap
+        {
             compute_rg_residual(file_path, opts, actual_steps, false).map(|r| r.to_ape())
         } else {
             None
@@ -256,7 +261,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     // loudness shift is not uniform, so the modified file is re-analyzed for
     // the true post-apply residual and the APE items rewritten; channel
     // applies keep the legacy separate write.
-    if opts.write_replaygain_tags && !opts.use_id3v2 {
+    if opts.write_replaygain_tags && !opts.tag_layout.mp3gain_in_id3v2() {
         let needs_reanalysis =
             !is_aac && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
         if is_aac {
@@ -268,6 +273,15 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
                 }
                 tags.set_algorithm(res.mode);
                 mp4meta::write_replaygain_tags(file_path, &tags)?;
+            }
+        } else if opts.tag_layout == TagLayout::Split {
+            // Clear any APEv2 ReplayGain first: mp3gain or an earlier `-s a`
+            // run may have left values there, and they would now disagree
+            // with the authoritative ID3v2 ones.
+            ape::remove_ape_replaygain(file_path)?;
+            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
+            {
+                id3v2::write_id3v2_replaygain(file_path, &res.to_id3v2())?;
             }
         } else if !ape_rg_folded || needs_reanalysis {
             if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -1,5 +1,5 @@
 use mp3rgain::replaygain::AnalysisMode;
-use mp3rgain::Channel;
+use mp3rgain::{Channel, TagLayout};
 use std::path::PathBuf;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -29,14 +29,14 @@ pub struct Options {
 
     // Mode options
     pub undo: bool, // -u
-    // -s <mode>. Orthogonal to `use_id3v2`: the mode says *what* to do with
-    // stored tags (check / delete / skip writing), while `use_id3v2` says
-    // *where* they live (-s i: ID3v2 frames, -s a: APEv2, the default).
+    // -s <mode>. Orthogonal to `tag_layout`: the mode says *what* to do with
+    // stored tags (check / delete / skip writing), while `tag_layout` says
+    // *where* they live (-s i: all ID3v2, -s a: all APEv2, default: split).
     pub stored_tag_mode: StoredTagMode,
-    pub use_id3v2: bool,    // -s i: use ID3v2 tags instead of APEv2 (-s a resets)
-    pub force_recalc: bool, // -s r: accepted for compatibility (always recalculates)
-    pub track_gain: bool,   // -r (apply track gain)
-    pub album_gain: bool,   // -a (apply album gain)
+    pub tag_layout: TagLayout, // -s i / -s a
+    pub force_recalc: bool,    // -s r: accepted for compatibility (always recalculates)
+    pub track_gain: bool,      // -r (apply track gain)
+    pub album_gain: bool,      // -a (apply album gain)
     // --rg2 / --r128: opt-in BS.1770 loudness modes (issue #269).
     // Default Rg1 keeps mp3gain-identical values.
     pub analysis_mode: AnalysisMode,

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::replaygain::AnalysisMode;
-use mp3rgain::Channel;
+use mp3rgain::{Channel, TagLayout};
 use std::path::PathBuf;
 
 use super::options::{Options, OutputFormat, StoredTagMode};
@@ -129,8 +129,8 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                         // tags as an analysis cache, so "force recalculation"
                         // is always in effect. Accepted with a notice (#253).
                         "r" => opts.force_recalc = true,
-                        "i" => opts.use_id3v2 = true,
-                        "a" => opts.use_id3v2 = false,
+                        "i" => opts.tag_layout = TagLayout::Id3v2,
+                        "a" => opts.tag_layout = TagLayout::Ape,
                         other => {
                             eprintln!(
                                 "{}: unknown -s mode '{}', use c/d/s/r/i/a",
@@ -523,9 +523,9 @@ mod tests {
         assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
         // -s i / -s a toggle the tag format; last one wins
         let opts = parse_args(&args(&["-s", "i"])).unwrap();
-        assert!(opts.use_id3v2);
+        assert_eq!(opts.tag_layout, TagLayout::Id3v2);
         let opts = parse_args(&args(&["-s", "i", "-s", "a"])).unwrap();
-        assert!(!opts.use_id3v2);
+        assert_eq!(opts.tag_layout, TagLayout::Ape);
         assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
     }
 

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -39,8 +39,8 @@ pub fn print_usage() {
     println!("                  d = delete stored tag info");
     println!("                  s = skip (don't write) stored tag info");
     println!("                  r = force recalculation (always on; kept for compatibility)");
-    println!("                  i = use ID3v2 tags (needed for foobar2000 to see them)");
-    println!("                  a = use APEv2 tags (default)");
+    println!("                  i = put all tags in ID3v2");
+    println!("                  a = put all tags in APEv2 (mp3gain-identical)");
     println!("    -p          Preserve original file timestamp");
     println!("    -c          Ignore clipping warnings");
     println!("    -k          Prevent clipping (automatically limit gain)");
@@ -93,7 +93,8 @@ pub fn print_usage() {
         GAIN_STEP_DB
     );
     println!("    - Changes are lossless and reversible");
-    println!("    - Gain changes are stored in APEv2 tags for undo support");
+    println!("    - MP3 tags: REPLAYGAIN_* in ID3v2 (where players look),");
+    println!("      MP3GAIN_UNDO / MINMAX in APEv2 (where mp3gain looks)");
     println!(
         "    - Progress bar shown automatically for {}+ files",
         crate::progress::PROGRESS_THRESHOLD

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -39,7 +39,7 @@ pub fn print_usage() {
     println!("                  d = delete stored tag info");
     println!("                  s = skip (don't write) stored tag info");
     println!("                  r = force recalculation (always on; kept for compatibility)");
-    println!("                  i = use ID3v2 tags (not fully supported)");
+    println!("                  i = use ID3v2 tags (needed for foobar2000 to see them)");
     println!("                  a = use APEv2 tags (default)");
     println!("    -p          Preserve original file timestamp");
     println!("    -c          Ignore clipping warnings");

--- a/src/cli/wildcard.rs
+++ b/src/cli/wildcard.rs
@@ -3,7 +3,7 @@
 //! Unix shells expand `*.mp3` before the process starts, but cmd.exe and
 //! PowerShell hand the pattern through untouched. Without this, a Windows user
 //! typing `mp3rgain *.mp3` gets "Failed to open '*.mp3'" (issue reported on the
-//! foobar2000 forum). The original mp3gain got this for free from the MSVC
+//! Hydrogenaudio forum). The original mp3gain got this for free from the MSVC
 //! `setargv` runtime hook.
 
 use std::path::{Path, PathBuf};

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::replaygain::{self, AlbumAnalysisReport, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{self, AlbumAnalysisReport, AudioFileType, REPLAYGAIN_REFERENCE_DB};
 use mp3rgain::{steps_to_db, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
@@ -177,7 +177,21 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             // Apply album gain to all files
             let steps = modified_gain_steps;
 
-            if steps == 0 {
+            // A net 0-step album adjustment still has work to do when tags
+            // would be written or `-k` must attenuate a clipping track — the
+            // same reasoning as the track path (issue #206). Skipping outright
+            // loses the per-track REPLAYGAIN_* tags for an album that merely
+            // happens to sit on target (reported on the foobar2000 forum:
+            // album gain -0.04 dB, yet track 3 wants +1.46 dB).
+            let writes_rg_tags = opts.stored_tag_mode != StoredTagMode::Skip
+                || album_result
+                    .tracks()
+                    .iter()
+                    .any(|t| t.file_type() == AudioFileType::Aac);
+            let clip_prevention_applies =
+                opts.prevent_clipping && album_result.tracks().iter().any(|t| t.peak() > 1.0);
+
+            if steps == 0 && !writes_rg_tags && !clip_prevention_applies {
                 if opts.output_format == OutputFormat::Json {
                     let json_results: Vec<JsonFileResult> = files
                         .iter()

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -181,7 +181,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             // would be written or `-k` must attenuate a clipping track — the
             // same reasoning as the track path (issue #206). Skipping outright
             // loses the per-track REPLAYGAIN_* tags for an album that merely
-            // happens to sit on target (reported on the foobar2000 forum:
+            // happens to sit on target (reported on the Hydrogenaudio forum:
             // album gain -0.04 dB, yet track 3 wants +1.46 dB).
             let writes_rg_tags = opts.stored_tag_mode != StoredTagMode::Skip
                 || album_result

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -347,7 +347,10 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             // MP3 file after all gain is applied (the range is only known once the
             // whole album is done). APEv2 only — mp3gain has no AAC, and `-s i`
             // uses ID3v2; best-effort, so a tag hiccup never fails the album.
-            if !opts.dry_run && opts.stored_tag_mode != StoredTagMode::Skip && !opts.use_id3v2 {
+            if !opts.dry_run
+                && opts.stored_tag_mode != StoredTagMode::Skip
+                && !opts.tag_layout.mp3gain_in_id3v2()
+            {
                 let album_files: Vec<(&Path, Option<(u8, u8)>)> = successful_indices
                     .iter()
                     .map(|&i| (files[i].as_path(), range_by_idx[i]))

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -143,7 +143,7 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
 
     let original_mtime = save_original_mtime(file, opts);
 
-    let delete_result = mp3rgain::delete_gain_tags_auto(file, opts.use_id3v2);
+    let delete_result = mp3rgain::delete_gain_tags_auto(file, opts.tag_layout);
 
     match delete_result {
         Ok(()) => {
@@ -203,7 +203,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
     let filename = get_filename(file);
     let mut out = String::new();
 
-    let tags = match read_gain_tags_auto(file, opts.use_id3v2) {
+    let tags = match read_gain_tags_auto(file, opts.tag_layout) {
         Ok(tags) => tags,
         Err(e) => return (tag_read_error(file, filename, e, opts), out),
     };
@@ -223,6 +223,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
         GainTagSource::Ape { tag_present: false } => {
             (TAG_MP3GAIN_UNDO, TAG_MP3GAIN_MINMAX, "no APE tag found")
         }
+        GainTagSource::Split => (TAG_MP3GAIN_UNDO, TAG_MP3GAIN_MINMAX, "no gain tags found"),
     };
 
     let info = CheckTagInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,30 +154,81 @@ pub fn apply_gain_db_auto(file_path: &Path, gain_db: f64) -> Result<usize> {
     gain::apply_gain_db(file_path, gain_db)
 }
 
+/// Which container MP3 tags are written to.
+///
+/// The two tag families have different audiences. `REPLAYGAIN_*` is read by
+/// players, and they look in ID3v2 — ffmpeg (and everything built on it) does
+/// not read APEv2 on MP3 at all, and Rockbox only handles APE tags for WavPack
+/// and Musepack. `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` are read by nothing but the
+/// mp3gain lineage, which looks in APEv2. [`TagLayout::Split`] therefore sends
+/// each family where its readers are, and is the default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TagLayout {
+    /// `REPLAYGAIN_*` in ID3v2 TXXX, `MP3GAIN_*` in APEv2. Default.
+    #[default]
+    Split,
+    /// Everything in APEv2 — byte-for-byte mp3gain behaviour (`-s a`).
+    Ape,
+    /// Everything in ID3v2 TXXX (`-s i`).
+    Id3v2,
+}
+
+impl TagLayout {
+    /// Whether `REPLAYGAIN_*` goes to ID3v2 TXXX.
+    pub fn replaygain_in_id3v2(self) -> bool {
+        matches!(self, TagLayout::Split | TagLayout::Id3v2)
+    }
+
+    /// Whether `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` go to ID3v2 TXXX.
+    pub fn mp3gain_in_id3v2(self) -> bool {
+        matches!(self, TagLayout::Id3v2)
+    }
+}
+
 /// Undo previously-applied gain, auto-dispatching by file format and tag mode.
 ///
-/// AAC files go through the AAC undo path. For MP3, `use_id3v2 = true` routes
-/// to ID3v2; otherwise the default APE undo is used.
-pub fn undo_gain_auto(file_path: &Path, use_id3v2: bool) -> Result<usize> {
+/// AAC files go through the AAC undo path. For MP3 the undo tag is read from
+/// wherever `layout` puts it, falling back to the other container so a file
+/// tagged under a different layout still rolls back.
+pub fn undo_gain_auto(file_path: &Path, layout: TagLayout) -> Result<usize> {
     #[cfg(feature = "aac")]
     {
         if mp4meta::is_aac_file(file_path) {
             return aac::undo_aac_gain(file_path);
         }
     }
-    if use_id3v2 {
-        id3v2::undo_gain_id3v2(file_path)
-    } else {
-        gain::undo_gain(file_path)
+    let ape_has_undo = || {
+        ape::read_ape_tag_from_file(file_path)
+            .ok()
+            .flatten()
+            .is_some_and(|t| t.get(TAG_MP3GAIN_UNDO).is_some())
+    };
+    let id3v2_has_undo = || {
+        id3v2::read_id3v2_replaygain(file_path)
+            .ok()
+            .is_some_and(|rg| rg.undo.is_some())
+    };
+
+    if layout.mp3gain_in_id3v2() {
+        if id3v2_has_undo() || !ape_has_undo() {
+            return id3v2::undo_gain_id3v2(file_path);
+        }
+        return gain::undo_gain(file_path);
     }
+    if ape_has_undo() || !id3v2_has_undo() {
+        return gain::undo_gain(file_path);
+    }
+    id3v2::undo_gain_id3v2(file_path)
 }
 
 /// Delete ReplayGain / undo tags, auto-dispatching by file format and tag mode.
 ///
-/// For AAC, deletes both the ReplayGain and undo freeform tags. For MP3,
-/// `use_id3v2 = true` removes the ID3v2 frames; otherwise the APE tag is
-/// removed.
-pub fn delete_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<()> {
+/// For AAC, deletes both the ReplayGain and undo freeform tags. For MP3, both
+/// containers are cleared under [`TagLayout::Split`] — the point of `-s d` is
+/// to leave no gain tags behind, and a split-tagged file has them in two
+/// places.
+pub fn delete_gain_tags_auto(file_path: &Path, layout: TagLayout) -> Result<()> {
     #[cfg(feature = "aac")]
     {
         if mp4meta::is_aac_file(file_path) {
@@ -185,10 +236,13 @@ pub fn delete_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<()> {
             return mp4meta::delete_undo_tags(file_path);
         }
     }
-    if use_id3v2 {
-        id3v2::delete_id3v2_replaygain(file_path)
-    } else {
-        ape::delete_ape_tag(file_path)
+    match layout {
+        TagLayout::Id3v2 => id3v2::delete_id3v2_replaygain(file_path),
+        TagLayout::Ape => ape::delete_ape_tag(file_path),
+        TagLayout::Split => {
+            id3v2::delete_id3v2_replaygain(file_path)?;
+            ape::delete_ape_tag(file_path)
+        }
     }
 }
 
@@ -202,6 +256,8 @@ pub enum GainTagSource {
     /// APEv2 tag. `tag_present` distinguishes a file with no APE tag at all
     /// from one whose APE tag simply carries no mp3gain items.
     Ape { tag_present: bool },
+    /// Both containers were read and merged ([`TagLayout::Split`]).
+    Split,
 }
 
 /// Owned snapshot of the gain tags stored in one file, as returned by
@@ -254,10 +310,13 @@ impl StoredGainTags {
 /// modifying the file, auto-dispatching by file format and tag mode.
 ///
 /// Mirrors [`delete_gain_tags_auto`]'s dispatch: AAC files read the MP4
-/// freeform tags, MP3 files read ID3v2 when `use_id3v2` is set and APE
-/// otherwise. The AAC branch is fail-soft (unreadable tags come back
-/// empty); ID3v2/APE read errors are propagated.
-pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGainTags> {
+/// freeform tags, MP3 files read whichever container(s) `layout` uses. Under
+/// [`TagLayout::Split`] both are read and merged — each field prefers the
+/// container it is written to, then falls back to the other, so tags left by
+/// mp3gain or by an earlier `-s i` run still show up. The AAC branch is
+/// fail-soft (unreadable tags come back empty); ID3v2/APE read errors are
+/// propagated.
+pub fn read_gain_tags_auto(file_path: &Path, layout: TagLayout) -> Result<StoredGainTags> {
     #[cfg(feature = "aac")]
     {
         if mp4meta::is_aac_file(file_path) {
@@ -276,7 +335,7 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
             });
         }
     }
-    if use_id3v2 {
+    if layout.mp3gain_in_id3v2() {
         let rg = id3v2::read_id3v2_replaygain(file_path)?;
         return Ok(StoredGainTags {
             source: GainTagSource::Id3v2,
@@ -288,6 +347,35 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
             undo: rg.undo,
             minmax: rg.minmax,
             album_minmax: None,
+        });
+    }
+    if layout == TagLayout::Split {
+        let id3 = id3v2::read_id3v2_replaygain(file_path)?;
+        let ape_tag = ape::read_ape_tag_from_file(file_path)?;
+        let ape_get = |key: &str| {
+            ape_tag
+                .as_ref()
+                .and_then(|t| t.get(key))
+                .map(str::to_string)
+        };
+        return Ok(StoredGainTags {
+            source: GainTagSource::Split,
+            track_gain: id3
+                .track_gain
+                .or_else(|| ape_get(TAG_REPLAYGAIN_TRACK_GAIN)),
+            track_peak: id3
+                .track_peak
+                .or_else(|| ape_get(TAG_REPLAYGAIN_TRACK_PEAK)),
+            album_gain: id3
+                .album_gain
+                .or_else(|| ape_get(TAG_REPLAYGAIN_ALBUM_GAIN)),
+            album_peak: id3
+                .album_peak
+                .or_else(|| ape_get(TAG_REPLAYGAIN_ALBUM_PEAK)),
+            algorithm: id3.algorithm.or_else(|| ape_get(TAG_REPLAYGAIN_ALGORITHM)),
+            undo: ape_get(TAG_MP3GAIN_UNDO).or(id3.undo),
+            minmax: ape_get(TAG_MP3GAIN_MINMAX).or(id3.minmax),
+            album_minmax: ape_get(TAG_MP3GAIN_ALBUM_MINMAX),
         });
     }
     match ape::read_ape_tag_from_file(file_path)? {
@@ -313,7 +401,7 @@ pub fn read_gain_tags_auto(file_path: &Path, use_id3v2: bool) -> Result<StoredGa
 /// Mirrors [`undo_gain_auto`]'s dispatch so the returned value matches what
 /// `undo_gain_auto` would roll back. Returns `None` if the tag is absent or
 /// unreadable.
-pub fn read_undo_steps(file_path: &Path, use_id3v2: bool) -> Option<i32> {
+pub fn read_undo_steps(file_path: &Path, layout: TagLayout) -> Option<i32> {
     #[cfg(feature = "aac")]
     {
         if mp4meta::is_aac_file(file_path) {
@@ -321,12 +409,25 @@ pub fn read_undo_steps(file_path: &Path, use_id3v2: bool) -> Option<i32> {
             return Some(ape::parse_undo_values(undo_tags.undo()).0);
         }
     }
-    if use_id3v2 {
+    let from_ape = || {
+        ape::read_ape_tag_from_file(file_path)
+            .ok()
+            .flatten()
+            .and_then(|t| t.get_undo_gain())
+    };
+    let from_id3v2 = || {
         let rg = id3v2::read_id3v2_replaygain(file_path).ok()?;
-        return Some(ape::parse_undo_values(rg.undo.as_deref()).0);
+        rg.undo
+            .as_deref()
+            .map(|u| ape::parse_undo_values(Some(u)).0)
+    };
+    // Same fallback order as undo_gain_auto, so the reported value matches
+    // what an undo would actually roll back.
+    if layout.mp3gain_in_id3v2() {
+        from_id3v2().or_else(from_ape)
+    } else {
+        from_ape().or_else(from_id3v2)
     }
-    let tag = ape::read_ape_tag_from_file(file_path).ok()??;
-    tag.get_undo_gain()
 }
 
 fn collect_audio_files_into(dir: &Path, recursive: bool, result: &mut Vec<PathBuf>) -> Result<()> {

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -86,7 +86,7 @@ fn process_apply_into(
     apply_opts.preserve_timestamp = opts.preserve_timestamp;
     apply_opts.use_temp_file = opts.use_temp_file;
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
-    apply_opts.use_id3v2 = opts.use_id3v2;
+    apply_opts.tag_layout = opts.tag_layout;
     // Same reasoning as the dry-run branch above: without -k the steps are
     // never capped, and under -c/-q the clipping warning is never emitted, so
     // the headroom analyze inside check_clipping feeds nothing observable
@@ -232,7 +232,7 @@ fn process_apply_channel_into(
     apply_opts.preserve_timestamp = opts.preserve_timestamp;
     apply_opts.use_temp_file = opts.use_temp_file;
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
-    apply_opts.use_id3v2 = opts.use_id3v2;
+    apply_opts.tag_layout = opts.tag_layout;
     // The channel path never surfaces ApplyReport::clipping_detected and -l
     // has no clipping prevention, so the headroom analyze inside
     // check_clipping is pure waste (issue #232).

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -188,7 +188,7 @@ fn apply_replaygain_with_album_into(
     // `-s i` ID3v2, and AAC all write the REPLAYGAIN_* tags (issue #204).
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.write_replaygain_tags = opts.stored_tag_mode != StoredTagMode::Skip;
-    apply_opts.use_id3v2 = opts.use_id3v2;
+    apply_opts.tag_layout = opts.tag_layout;
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {

--- a/src/processors/undo.rs
+++ b/src/processors/undo.rs
@@ -34,7 +34,7 @@ fn process_undo_into(file: &Path, opts: &Options, out: &mut String) -> Result<Js
         });
     }
 
-    let undo_result = undo_gain_auto(file, opts.use_id3v2);
+    let undo_result = undo_gain_auto(file, opts.tag_layout);
 
     match undo_result {
         Ok(frames) => {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,162 @@
+//! End-to-end tests that drive the `mp3rgain` binary.
+//!
+//! `integration_tests.rs` covers the library API; the command layer
+//! (`src/commands/`) decides *whether* a file is processed at all, and that
+//! logic is only reachable through the CLI. Cargo exposes the built binary as
+//! `CARGO_BIN_EXE_mp3rgain`, so no extra tooling is needed.
+
+use mp3rgain::{read_ape_tag_from_file, TAG_REPLAYGAIN_TRACK_GAIN};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A temp directory holding copies of the requested fixtures, removed on drop
+/// so a failing assertion never leaves files behind.
+struct TempAlbum {
+    dir: PathBuf,
+    files: Vec<PathBuf>,
+}
+
+impl TempAlbum {
+    fn new(fixtures: &[&str]) -> Self {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("mp3rgain_cli_{}_{}", std::process::id(), id));
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let files = fixtures
+            .iter()
+            .map(|name| {
+                let dst = dir.join(name);
+                fs::copy(Path::new("tests/fixtures").join(name), &dst).expect("copy fixture");
+                dst
+            })
+            .collect();
+
+        TempAlbum { dir, files }
+    }
+
+    fn args(&self) -> Vec<&str> {
+        self.files.iter().map(|p| p.to_str().unwrap()).collect()
+    }
+}
+
+impl Drop for TempAlbum {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_mp3rgain"))
+        .args(args)
+        .output()
+        .expect("failed to run mp3rgain")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Album gain in steps, read from the JSON dry-run report.
+fn album_gain_steps(files: &[&str]) -> i64 {
+    let mut args = vec!["-a", "-n", "-s", "s", "-o", "json"];
+    args.extend_from_slice(files);
+    let out = run(&args);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout_of(&out)).expect("album dry run should emit JSON");
+    json["album"]["gain_steps"]
+        .as_i64()
+        .expect("album report should carry gain_steps")
+}
+
+fn track_gain_tag(file: &Path) -> Option<String> {
+    read_ape_tag_from_file(file)
+        .expect("reading the APE tag should not fail")
+        .and_then(|tag| tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string))
+}
+
+/// An album whose gain rounds to 0 steps must still get per-track
+/// ReplayGain tags. Reported on the foobar2000 forum: album gain -0.04 dB
+/// (0 steps) made mp3rgain skip the album outright, discarding a +1.46 dB
+/// track gain it had already measured. The track path fixed the same class
+/// of bug in issue #206.
+#[test]
+fn album_at_zero_steps_still_writes_replaygain_tags() {
+    let album = TempAlbum::new(&["test_stereo.mp3", "test_mono.mp3"]);
+    let files = album.args();
+
+    // Cancel the album gain with -m so the run lands on exactly 0 steps,
+    // whatever the fixtures happen to measure.
+    let offset = (-album_gain_steps(&files)).to_string();
+    let mut args = vec!["-a", "-m", offset.as_str()];
+    args.extend_from_slice(&files);
+    let out = run(&args);
+    assert!(out.status.success(), "album run failed: {:?}", out);
+
+    let gains: Vec<Option<String>> = album.files.iter().map(|f| track_gain_tag(f)).collect();
+    for (file, gain) in album.files.iter().zip(&gains) {
+        assert!(
+            gain.is_some(),
+            "{} got no REPLAYGAIN_TRACK_GAIN despite a 0-step album gain",
+            file.display()
+        );
+    }
+
+    // The whole point of writing them: the per-track values are not the
+    // album value, so dropping them loses real information.
+    assert_ne!(
+        gains[0], gains[1],
+        "fixtures should have distinct track gains for this test to mean anything"
+    );
+}
+
+/// `-s s` opts out of tag writing, so a 0-step album has genuinely nothing
+/// left to do and keeps the cheap skip.
+#[test]
+fn album_at_zero_steps_skips_when_tags_are_disabled() {
+    let album = TempAlbum::new(&["test_stereo.mp3", "test_mono.mp3"]);
+    let files = album.args();
+
+    let offset = (-album_gain_steps(&files)).to_string();
+    let mut args = vec!["-a", "-s", "s", "-m", offset.as_str()];
+    args.extend_from_slice(&files);
+    let out = run(&args);
+    assert!(out.status.success(), "album run failed: {:?}", out);
+    assert!(
+        stdout_of(&out).contains("No adjustment needed"),
+        "expected the skip path, got: {}",
+        stdout_of(&out)
+    );
+
+    for file in &album.files {
+        assert_eq!(
+            track_gain_tag(file),
+            None,
+            "{} should have no tags in -s s mode",
+            file.display()
+        );
+    }
+}
+
+/// Track mode already had this behaviour (issue #206); keep it covered so the
+/// two paths can't drift apart again.
+#[test]
+fn track_at_zero_steps_still_writes_replaygain_tags() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let files = album.args();
+
+    let mut args = vec!["-r"];
+    args.extend_from_slice(&files);
+    assert!(run(&args).status.success());
+
+    // Second pass: the file now sits on target, so the gain is 0 steps.
+    let out = run(&args);
+    assert!(out.status.success(), "second track run failed: {:?}", out);
+    assert!(
+        track_gain_tag(&album.files[0]).is_some(),
+        "an already-normalized track should keep its ReplayGain tags"
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -5,7 +5,7 @@
 //! logic is only reachable through the CLI. Cargo exposes the built binary as
 //! `CARGO_BIN_EXE_mp3rgain`, so no extra tooling is needed.
 
-use mp3rgain::{read_ape_tag_from_file, TAG_REPLAYGAIN_TRACK_GAIN};
+use mp3rgain::{read_ape_tag_from_file, TAG_MP3GAIN_UNDO, TAG_REPLAYGAIN_TRACK_GAIN};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -72,10 +72,17 @@ fn album_gain_steps(files: &[&str]) -> i64 {
         .expect("album report should carry gain_steps")
 }
 
+/// `REPLAYGAIN_TRACK_GAIN` from wherever it is stored, so tests that only care
+/// *whether* the file was tagged stay independent of the container layout.
 fn track_gain_tag(file: &Path) -> Option<String> {
-    read_ape_tag_from_file(file)
-        .expect("reading the APE tag should not fail")
-        .and_then(|tag| tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string))
+    mp3rgain::read_id3v2_replaygain(file)
+        .expect("reading the ID3v2 tag should not fail")
+        .track_gain
+        .or_else(|| {
+            read_ape_tag_from_file(file)
+                .expect("reading the APE tag should not fail")
+                .and_then(|tag| tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string))
+        })
 }
 
 /// An album whose gain rounds to 0 steps must still get per-track
@@ -139,6 +146,147 @@ fn album_at_zero_steps_skips_when_tags_are_disabled() {
             file.display()
         );
     }
+}
+
+fn id3v2_track_gain(file: &Path) -> Option<String> {
+    mp3rgain::read_id3v2_replaygain(file)
+        .expect("reading the ID3v2 tag should not fail")
+        .track_gain
+}
+
+fn ape_has_replaygain(file: &Path) -> bool {
+    read_ape_tag_from_file(file)
+        .expect("reading the APE tag should not fail")
+        .is_some_and(|tag| tag.get(TAG_REPLAYGAIN_TRACK_GAIN).is_some())
+}
+
+fn ape_has_undo(file: &Path) -> bool {
+    read_ape_tag_from_file(file)
+        .expect("reading the APE tag should not fail")
+        .is_some_and(|tag| tag.get(TAG_MP3GAIN_UNDO).is_some())
+}
+
+/// The default layout sends each tag family to the container its readers use:
+/// `REPLAYGAIN_*` to ID3v2 (ffmpeg does not read APEv2 on MP3 at all, and
+/// Rockbox only handles APE tags for WavPack/Musepack), `MP3GAIN_*` to APEv2
+/// where the mp3gain lineage looks.
+#[test]
+fn default_layout_splits_replaygain_into_id3v2() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+
+    let mut args = vec!["-r"];
+    args.extend_from_slice(&album.args());
+    assert!(run(&args).status.success());
+
+    assert!(
+        id3v2_track_gain(file).is_some(),
+        "ReplayGain should land in ID3v2 by default"
+    );
+    assert!(
+        !ape_has_replaygain(file),
+        "APEv2 should not carry a second, divergent copy of the ReplayGain values"
+    );
+    assert!(
+        ape_has_undo(file),
+        "MP3GAIN_UNDO belongs in APEv2 — that is where mp3gain reads it"
+    );
+}
+
+/// `-s a` keeps the historical mp3gain-identical layout.
+#[test]
+fn ape_layout_keeps_everything_in_apev2() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+
+    let mut args = vec!["-r", "-s", "a"];
+    args.extend_from_slice(&album.args());
+    assert!(run(&args).status.success());
+
+    assert!(
+        ape_has_replaygain(file),
+        "-s a should write ReplayGain to APEv2"
+    );
+    assert!(ape_has_undo(file));
+    assert_eq!(
+        id3v2_track_gain(file),
+        None,
+        "-s a should leave ID3v2 alone"
+    );
+}
+
+/// Re-running under the default layout on a file previously tagged with `-s a`
+/// must clear the APEv2 ReplayGain copy — otherwise a reader that prefers
+/// APEv2 would keep seeing values that no longer match the ID3v2 ones.
+#[test]
+fn default_layout_clears_stale_apev2_replaygain() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+    let files = album.args();
+
+    let mut ape_args = vec!["-r", "-s", "a"];
+    ape_args.extend_from_slice(&files);
+    assert!(run(&ape_args).status.success());
+    assert!(
+        ape_has_replaygain(file),
+        "precondition: APEv2 ReplayGain present"
+    );
+
+    let mut args = vec!["-r"];
+    args.extend_from_slice(&files);
+    assert!(run(&args).status.success());
+
+    assert!(
+        !ape_has_replaygain(file),
+        "stale APEv2 ReplayGain should be removed once ID3v2 owns the values"
+    );
+    assert!(id3v2_track_gain(file).is_some());
+    assert!(ape_has_undo(file), "MP3GAIN_UNDO must survive the cleanup");
+}
+
+/// Undo has to find the undo tag under the split layout, and restore the
+/// audio exactly.
+#[test]
+fn undo_works_under_the_default_layout() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+    let before = fs::read(Path::new("tests/fixtures/test_stereo.mp3")).unwrap();
+
+    let mut args = vec!["-r"];
+    args.extend_from_slice(&album.args());
+    assert!(run(&args).status.success());
+
+    let mut undo_args = vec!["-u"];
+    undo_args.extend_from_slice(&album.args());
+    let out = run(&undo_args);
+    assert!(out.status.success(), "undo failed: {:?}", out);
+
+    // Compare the audio payload only: the tags are expected to differ.
+    let after = fs::read(file).unwrap();
+    assert_eq!(
+        audio_payload(&before),
+        audio_payload(&after),
+        "undo should restore the audio bit-for-bit"
+    );
+}
+
+/// Strip a leading ID3v2 tag and a trailing APEv2 tag, leaving the frames.
+fn audio_payload(data: &[u8]) -> &[u8] {
+    let start = if data.starts_with(b"ID3") && data.len() > 10 {
+        let size = ((data[6] as usize) << 21)
+            | ((data[7] as usize) << 14)
+            | ((data[8] as usize) << 7)
+            | (data[9] as usize);
+        10 + size
+    } else {
+        0
+    };
+    let end = data
+        .windows(8)
+        .rposition(|w| w == b"APETAGEX")
+        .filter(|&i| i > start)
+        .unwrap_or(data.len());
+    &data[start..end]
 }
 
 /// Track mode already had this behaviour (issue #206); keep it covered so the

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -86,7 +86,7 @@ fn track_gain_tag(file: &Path) -> Option<String> {
 }
 
 /// An album whose gain rounds to 0 steps must still get per-track
-/// ReplayGain tags. Reported on the foobar2000 forum: album gain -0.04 dB
+/// ReplayGain tags. Reported on the Hydrogenaudio forum: album gain -0.04 dB
 /// (0 steps) made mp3rgain skip the album outright, discarding a +1.46 dB
 /// track gain it had already measured. The track path fixed the same class
 /// of bug in issue #206.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -579,9 +579,10 @@ fn test_file_not_modified_on_zero_gain() {
 // APEv2 ReplayGain tag writing (issue #204)
 // =============================================================================
 
-/// Issue #204: applying track gain in the default APEv2 mode must write the
-/// REPLAYGAIN_TRACK_* analysis tags alongside MP3GAIN_UNDO/MINMAX, matching
+/// Issue #204: applying track gain in the all-APEv2 layout (`-s a`) must write
+/// the REPLAYGAIN_TRACK_* analysis tags alongside MP3GAIN_UNDO/MINMAX, matching
 /// the original mp3gain. Previously only the MP3GAIN_* tags were written.
+/// (The default layout puts REPLAYGAIN_* in ID3v2 instead — see cli_tests.rs.)
 #[test]
 fn test_apply_track_gain_writes_ape_replaygain_tags() {
     use mp3rgain::apply::{apply_with_options, ApplyOptions};
@@ -595,7 +596,8 @@ fn test_apply_track_gain_writes_ape_replaygain_tags() {
 
     let mut opts = ApplyOptions::new(result.gain_steps());
     opts.track_result = Some(result);
-    opts.write_replaygain_tags = true; // default APEv2 path (use_id3v2 = false)
+    opts.write_replaygain_tags = true;
+    opts.tag_layout = mp3rgain::TagLayout::Ape;
     apply_with_options(&path, &opts).unwrap();
 
     let tag = read_ape_tag_from_file(&path).unwrap().expect("APE tag");
@@ -617,7 +619,8 @@ fn test_apply_track_gain_writes_ape_replaygain_tags() {
     cleanup(&path);
 }
 
-/// Album info must additionally populate the REPLAYGAIN_ALBUM_* APEv2 items.
+/// Album info must additionally populate the REPLAYGAIN_ALBUM_* APEv2 items
+/// in the all-APEv2 layout.
 #[test]
 fn test_apply_album_gain_writes_ape_album_replaygain_tags() {
     use mp3rgain::apply::{apply_with_options, AacAlbumInfo, ApplyOptions};
@@ -638,6 +641,7 @@ fn test_apply_album_gain_writes_ape_album_replaygain_tags() {
     opts.track_result = Some(result);
     opts.album_info = Some(album);
     opts.write_replaygain_tags = true;
+    opts.tag_layout = mp3rgain::TagLayout::Ape;
     let report = apply_with_options(&path, &opts).unwrap();
 
     // mp3gain writes the post-apply *residual* album values at 6-decimal


### PR DESCRIPTION
Two fixes from the [Hydrogenaudio mp3rgain thread](https://hydrogenaud.io/index.php/topic,127330.0.html), both raised there by skamp. Targeting **3.2.0** — the second one changes default behaviour.

## 1. Album gain at 0 steps discarded all tags

> One issue that I encountered with Supertramp's "Brother Where You Bound", mp3rgain says that no gain needs to be applied, and as such does not write any tags. rsgain says that the album gain is -0.04 dB, which explains mp3rgain's behavior, using 1.5 dB steps. The problem is that track 3 actually has a track gain of +1.46 dB.

In album mode an album gain that rounds to **0 steps** returned early before any file was touched, throwing away the per-track `REPLAYGAIN_*` values that had just been measured. The track path already handled this (issue #206); the album path never got the same treatment. Now the cheap skip is kept only when no tags would be written (`-s s`) and `-k` has no clipping track to attenuate.

## 2. ReplayGain now goes to ID3v2 by default

> do you know of any player that will read ReplayGain tags in APEv2 tags?

Checked, and the answer looks like *no*:

- **ffmpeg does not read APEv2 on MP3 at all.** Verified against ffprobe 8.1.2: a well-formed APEv2 tag (`APETAGEX` header and footer, readable by `mp3rgain -s c`) produces no tags in `ffprobe -show_entries format_tags`. The same file tagged with `-s i` shows every value. That covers mpv, VLC, Kodi and everything else on libavformat.
- **Rockbox** only supports APE tags for WavPack and Musepack, [not MP3](https://www.rockbox.org/tracker/task/2598).
- **foobar2000** writes ReplayGain to ID3v2 and expects it there.

So the old default hid the ReplayGain values from every player and gained nothing. The two tag families have different audiences, so they now go to different places:

| Tag | Container | Read by |
|-----|-----------|---------|
| `REPLAYGAIN_*` | ID3v2 `TXXX` | Players |
| `MP3GAIN_UNDO`, `MP3GAIN_MINMAX` | APEv2 | Only the mp3gain lineage — which is why `-u` still works on a library mp3gain processed |

This is exactly what skamp proposed earlier in the thread. `TagLayout` makes it explicit:

```
mp3rgain -r *.mp3          # default: split
mp3rgain -r -s a *.mp3     # everything in APEv2 — byte-for-byte mp3gain
mp3rgain -r -s i *.mp3     # everything in ID3v2
```

Details that matter:
- Switching to the default over an `-s a` file **clears the APEv2 ReplayGain copies**, so the two containers can never carry divergent values.
- Reads are forgiving in both directions: `-s c` merges both containers, and `-u` finds the undo tag in either — files from mp3gain or an earlier `-s i` run still inspect and roll back.
- `MP3GAIN_ALBUM_MINMAX` stays APEv2-only in every mode. AAC/M4A is untouched (MP4 freeform atoms).
- GUI: the "Use ID3v2" checkbox becomes a three-way selector. Settings files predating the field load as the default.

## Tests

`src/commands/` had no coverage at all — `integration_tests.rs` exercises the library API, while the command layer decides *whether* a file is processed. Added `tests/cli_tests.rs`, driving the built binary via `CARGO_BIN_EXE_mp3rgain` (no new dependency), plus a CI step, since CI previously ran only `--lib` and `--test integration_tests`.

Seven cases cover the zero-step album/track paths, each layout, the stale-APEv2 cleanup, and a bit-for-bit undo round trip. The album regression test was confirmed to fail without the fix, against both the committed fixtures and the ffmpeg-generated ones CI builds.

The two `integration_tests.rs` cases from issue #204 now pin `TagLayout::Ape` explicitly — that is what they were always testing.
