### PR TITLE
Fix gain step constant: use exact 20*log10(2)/4 instead of 1.5

### DIFF
--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -135,7 +135,7 @@ fn render_manual_gain_modal(app: &mut Mp3rgainApp, ctx: &egui::Context) {
                 let db = mp3rgain::steps_to_db(modal_state.steps);
                 ui.label(format!("= {:+.2} dB", db));
             });
-            ui.label("1 step = 1.5 dB. Negative values lower the volume.");
+            ui.label("1 step ≈ 1.5 dB. Negative values lower the volume.");
             modal_state.steps != 0
         },
     );

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -8,7 +8,7 @@ pub fn print_version() {
     println!("mp3rgain version {}", VERSION);
     println!("A modern mp3gain replacement written in Rust");
     println!();
-    println!("Each gain step = {} dB", GAIN_STEP_DB);
+    println!("Each gain step = {:.4} dB", GAIN_STEP_DB);
 }
 
 pub fn print_usage() {
@@ -20,7 +20,7 @@ pub fn print_usage() {
     println!();
     println!("{}", "OPTIONS:".cyan().bold());
     println!(
-        "    -g <i>      Apply gain of i steps (each step = {} dB)",
+        "    -g <i>      Apply gain of i steps (each step = {:.4} dB)",
         GAIN_STEP_DB
     );
     println!("    -d <n>      Modify suggested/target gain by n dB (rounded to nearest step)");
@@ -61,8 +61,8 @@ pub fn print_usage() {
     println!();
     println!("{}", "EXAMPLES:".cyan().bold());
     println!("    mp3rgain song.mp3              Show file info");
-    println!("    mp3rgain -g 2 song.mp3         Apply +2 steps (+3.0 dB)");
-    println!("    mp3rgain -g -3 song.mp3        Apply -3 steps (-4.5 dB)");
+    println!("    mp3rgain -g 2 song.mp3         Apply +2 steps (+3.01 dB)");
+    println!("    mp3rgain -g -3 song.mp3        Apply -3 steps (-4.52 dB)");
     println!("    mp3rgain -r -d 4.5 song.mp3    Apply track gain, target +4.5 dB louder");
     println!("    mp3rgain -r song.mp3           Analyze and apply track gain");
     println!("    mp3rgain -a *.mp3              Analyze and apply album gain");
@@ -89,7 +89,7 @@ pub fn print_usage() {
     println!();
     println!("{}", "NOTES:".cyan().bold());
     println!(
-        "    - Each gain step = {} dB (fixed by MP3 specification)",
+        "    - Each gain step = {:.4} dB (fixed by MP3 specification)",
         GAIN_STEP_DB
     );
     println!("    - Changes are lossless and reversible");

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -9,8 +9,15 @@ use crate::frame::{apply_gain_to_data, scan_gain_range, GainMode, SaturationStat
 use std::fs;
 use std::path::Path;
 
-/// MP3 gain step size in dB (fixed by format specification)
-pub const GAIN_STEP_DB: f64 = 1.5;
+/// MP3 gain step size in dB (fixed by format specification).
+///
+/// One `global_gain` step scales amplitude by 2^(1/4), i.e. exactly
+/// `20*log10(2)/4 ≈ 1.50515 dB` — commonly rounded to "1.5 dB" in docs and
+/// UI. mp3gain itself divides by `5.0 * log10(2.0)` when converting dB to
+/// steps, so using the exact value here matches its rounding. The previous
+/// approximation of 1.5 made post-apply residual ReplayGain tags drift by
+/// ~0.005 dB per applied step (issue #291).
+pub const GAIN_STEP_DB: f64 = 1.505_149_978_319_906;
 
 /// Maximum global_gain value
 pub const MAX_GAIN: u8 = 255;
@@ -511,13 +518,35 @@ mod tests {
         assert_eq!(db_to_steps(1.5), 1);
         assert_eq!(db_to_steps(3.0), 2);
         assert_eq!(db_to_steps(-1.5), -1);
-        assert_eq!(db_to_steps(2.25), 2);
+        // 2.25 / 1.50515 = 1.495 -> 1 step, matching mp3gain's own rounding
+        // (it divides by 5*log10(2), not by 1.5).
+        assert_eq!(db_to_steps(2.25), 1);
     }
 
     #[test]
     fn test_steps_to_db() {
         assert_eq!(steps_to_db(0), 0.0);
-        assert_eq!(steps_to_db(1), 1.5);
-        assert_eq!(steps_to_db(-2), -3.0);
+        assert!((steps_to_db(1) - 1.505_149_978).abs() < 1e-9);
+        assert!((steps_to_db(-2) - -3.010_299_957).abs() < 1e-9);
+    }
+
+    /// The exact step constant: 20*log10(2)/4.
+    #[test]
+    fn gain_step_matches_physical_constant() {
+        assert!((GAIN_STEP_DB - 20.0 * 2.0_f64.log10() / 4.0).abs() < 1e-15);
+    }
+
+    /// Issue #291: the residual after N steps must be exact, so applying and
+    /// re-measuring cannot drift. 7 steps at the old 1.5 constant drifted by
+    /// 0.036 dB; with the exact constant the round-trip is lossless.
+    #[test]
+    fn steps_to_db_roundtrip_has_no_drift() {
+        for steps in -15..=15 {
+            let db = steps_to_db(steps);
+            assert_eq!(db_to_steps(db), steps);
+            // physical shift of `steps` global_gain steps
+            let physical = 20.0 * (2.0_f64.powf(steps as f64 / 4.0)).log10();
+            assert!((db - physical).abs() < 1e-9, "steps={steps}");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! ## Technical Details
 //!
-//! Each gain step equals 1.5 dB (fixed by MP3 specification).
+//! Each gain step scales amplitude by 2^(1/4) ≈ 1.505 dB (fixed by MP3 specification).
 //! The global_gain field is 8 bits, allowing values 0-255.
 
 #[cfg(feature = "aac")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -555,8 +555,8 @@ fn test_headroom_calculation() {
     // Headroom should be 255 - max_gain
     assert_eq!(info.headroom_steps(), (255 - info.max_gain()) as i32);
 
-    // Headroom in dB should be steps * 1.5
-    let expected_db = info.headroom_steps() as f64 * 1.5;
+    // Headroom in dB should be steps * GAIN_STEP_DB (2^(1/4) per step)
+    let expected_db = info.headroom_steps() as f64 * mp3rgain::GAIN_STEP_DB;
     assert!((info.headroom_db() - expected_db).abs() < 0.01);
 }
 


### PR DESCRIPTION
## Summary

`GAIN_STEP_DB` was defined as exactly `1.5`, but one MP3 `global_gain` step physically changes amplitude by 2^(1/4) = **1.50515 dB** (`20*log10(2)/4`). Every steps→dB conversion therefore understated the real loudness shift by ~0.00515 dB per step, which surfaced as residual ReplayGain tag drift on repeated `-a --rg2 -c` runs (0.036 dB observed for a 7-step album apply — exactly `7 × (1.50515 − 1.5)`).

## Changes

- `GAIN_STEP_DB` is now the exact constant `1.505149978319906`. `steps_to_db` / `db_to_steps`, the residual computation in `apply.rs` (`compute_rg_residual`), the AAC residual path, headroom math, and the GUI all pick it up automatically since they derive from the constant.
- **mp3gain compatibility check (as flagged in the issue):** mp3gain itself computes `intGainChange = (int)(dBchange / (5.0 * log10(2.0)) + 0.5)` — i.e. it already divides by the exact constant. `db_to_steps` rounding now *matches* mp3gain where it previously diverged near step boundaries (e.g. `-d 2.25` now rounds to 1 step, same as mp3gain).
- CLI help/version strings print the step as `1.5051 dB`; prose docs say `≈ 1.5 dB`.
- New tests: constant matches `20*log10(2)/4`, and a drift regression test asserting the steps→dB→steps round-trip is lossless for ±15 steps.

## Impact

- Residual `REPLAYGAIN_*` tags no longer drift on repeated runs and now agree with rsgain/loudgain re-scans.
- Zero-step runs are unaffected.
- `db_to_steps` boundary cases can shift by one step (now matching mp3gain's own rounding).

Fixes #291