### PR TITLE
Add opt-in --true-peak (BS.1770-4 Annex 2) for --rg2 / --r128 peaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A native GUI application (`mp3rgui`) is available for users who prefer a graphic
 | `-a` | Apply Album gain (ReplayGain) |
 | `--rg2` | Use ReplayGain 2.0 analysis (BS.1770, −18 LUFS reference) |
 | `--r128` | Use EBU R128 analysis (BS.1770, −23 LUFS target) |
+| `--true-peak` | Measure true peak (BS.1770-4 Annex 2) for `REPLAYGAIN_*_PEAK` (with `--rg2` / `--r128`; default is sample peak) |
 | `-g <i>` | Apply gain of i steps (1 step = 1.5 dB) |
 | `-d <n>` | Modify suggested dB gain by n (mp3gain-compatible; applied with `-r` / `-a`) |
 | `-u` | Undo gain changes |

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -518,7 +518,14 @@ fn compute_rg_residual(
         )
     };
     let (track_gain_db, track_peak, applied_db) = if reanalyze {
-        match crate::replaygain::analyze_track_with_mode(modified_path, None, mode, None) {
+        // Match the original measurement exactly: same mode, and true peak
+        // when the original peak was a true peak (issue #292).
+        let reopts = crate::replaygain::TrackAnalysisOptions {
+            mode,
+            true_peak: track.is_true_peak(),
+            ..Default::default()
+        };
+        match crate::replaygain::analyze_track_with_options(modified_path, &reopts) {
             Ok(post) => (
                 post.gain_db(),
                 post.peak(),

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -213,6 +213,78 @@ fn gated_mean(energies: &[f64], gate: f64) -> Option<f64> {
     (count > 0).then(|| sum / count as f64)
 }
 
+/// BS.1770-4 Annex 2 true-peak meter (issue #292).
+///
+/// Estimates inter-sample peaks by oversampling the input with a polyphase
+/// FIR interpolator — a 49-tap Hann-windowed sinc, the same design as
+/// libebur128. 4× oversampling at the common rates; 2× is sufficient at
+/// ≥ 88.2 kHz where a further octave of oversampling adds nothing below
+/// the original Nyquist.
+///
+/// The center tap lands exactly on one polyphase phase, so that phase
+/// reproduces the input samples unchanged — the reported peak is therefore
+/// always ≥ the sample peak. Values above 1.0 are expected for lossy codecs
+/// that reconstruct above the sample grid.
+pub struct TruePeakMeter {
+    /// Polyphase sub-filters: `factor` phases of up to `TAPS/factor + 1`
+    /// coefficients each. `phases[p][k]` multiplies the input from `k`
+    /// samples ago.
+    phases: Vec<Vec<f64>>,
+    /// Per-channel input history, most recent first.
+    history: Vec<Vec<f64>>,
+    peak: f64,
+}
+
+impl TruePeakMeter {
+    const TAPS: usize = 49;
+
+    pub fn new(sample_rate: u32, channels: usize) -> Self {
+        let factor: usize = if sample_rate >= 88_200 { 2 } else { 4 };
+        let mut phases = vec![Vec::new(); factor];
+        for j in 0..Self::TAPS {
+            let m = j as f64 - (Self::TAPS - 1) as f64 / 2.0;
+            let sinc = if m.abs() > 1e-9 {
+                let x = m * std::f64::consts::PI / factor as f64;
+                x.sin() / x
+            } else {
+                1.0
+            };
+            let window = 0.5
+                * (1.0 - (2.0 * std::f64::consts::PI * j as f64 / (Self::TAPS - 1) as f64).cos());
+            phases[j % factor].push(sinc * window);
+        }
+        let history_len = phases.iter().map(Vec::len).max().unwrap_or(0);
+        Self {
+            phases,
+            history: vec![vec![0.0; history_len]; channels.max(1)],
+            peak: 0.0,
+        }
+    }
+
+    /// Add one frame of normalized samples (full scale = 1.0), one per
+    /// channel. Extra samples beyond the configured channel count are
+    /// ignored.
+    #[inline]
+    pub fn add_frame(&mut self, frame: &[f64]) {
+        for (history, &sample) in self.history.iter_mut().zip(frame) {
+            history.rotate_right(1);
+            history[0] = sample;
+            for phase in &self.phases {
+                let mut acc = 0.0;
+                for (&c, &x) in phase.iter().zip(history.iter()) {
+                    acc += c * x;
+                }
+                self.peak = self.peak.max(acc.abs());
+            }
+        }
+    }
+
+    /// Maximum absolute interpolated amplitude seen so far.
+    pub fn peak(&self) -> f64 {
+        self.peak
+    }
+}
+
 /// Streaming BS.1770 analyzer for one track.
 ///
 /// Feed decoded frames with [`add_frame`](Self::add_frame), then take the
@@ -221,6 +293,9 @@ fn gated_mean(energies: &[f64], gate: f64) -> Option<f64> {
 pub struct Bs1770Analyzer {
     filters: Vec<KWeightingFilter>,
     weights: Vec<f64>,
+    /// Optional BS.1770-4 Annex 2 true-peak meter, fed the raw (pre
+    /// K-weighting) samples of every frame (issue #292).
+    true_peak: Option<TruePeakMeter>,
     /// Samples per 100 ms sub-block (rounded for rates not divisible by 10,
     /// e.g. 11025 Hz).
     subblock_len: usize,
@@ -242,6 +317,7 @@ impl Bs1770Analyzer {
         Self {
             filters: vec![KWeightingFilter::new(sample_rate); channels],
             weights: channel_weights(channels),
+            true_peak: None,
             subblock_len: (sample_rate as usize + 5) / 10,
             subblock_sum: 0.0,
             subblock_samples: 0,
@@ -251,11 +327,28 @@ impl Bs1770Analyzer {
         }
     }
 
+    /// [`new`](Self::new) plus a [`TruePeakMeter`] measuring the raw input
+    /// alongside the loudness analysis (issue #292).
+    pub fn new_with_true_peak(sample_rate: u32, channels: usize) -> Self {
+        let mut analyzer = Self::new(sample_rate, channels);
+        analyzer.true_peak = Some(TruePeakMeter::new(sample_rate, channels.max(1)));
+        analyzer
+    }
+
+    /// True peak measured so far; `None` unless constructed with
+    /// [`new_with_true_peak`](Self::new_with_true_peak).
+    pub fn true_peak(&self) -> Option<f64> {
+        self.true_peak.as_ref().map(TruePeakMeter::peak)
+    }
+
     /// Add one frame of normalized samples (full scale = 1.0), one per
     /// channel. Extra samples beyond the configured channel count are
     /// ignored; missing ones count as silence.
     #[inline]
     pub fn add_frame(&mut self, frame: &[f64]) {
+        if let Some(meter) = &mut self.true_peak {
+            meter.add_frame(frame);
+        }
         let mut acc = 0.0;
         for ((filter, &weight), &sample) in self.filters.iter_mut().zip(&self.weights).zip(frame) {
             let y = filter.process(sample);
@@ -441,5 +534,72 @@ mod tests {
         append_sine(&mut samples, -23.0, 20.0, 11025);
         let lufs = integrated_stereo(&samples, 11025);
         assert!((lufs - -23.0).abs() < 0.2, "got {:.3}", lufs);
+    }
+
+    /// Worst-case inter-sample peak: a sine at fs/4 sampled at ±45° phase
+    /// hits only ±sin(45°) ≈ 0.707 on the sample grid while the waveform
+    /// peaks at 1.0. The sample peak underreads by 3 dB; the true-peak
+    /// meter must recover ≈ 0 dBTP (EBU Tech 3341 cases 17/18 allow
+    /// +0.2/−0.4 dB).
+    #[test]
+    fn true_peak_recovers_intersample_peak() {
+        for &rate in &[44100u32, 48000] {
+            let mut meter = TruePeakMeter::new(rate, 1);
+            let mut sample_peak = 0.0f64;
+            let step = 2.0 * std::f64::consts::PI / 4.0; // fs/4 tone
+            for n in 0..rate as usize {
+                let s = (step * n as f64 + std::f64::consts::PI / 4.0).sin();
+                sample_peak = sample_peak.max(s.abs());
+                meter.add_frame(&[s]);
+            }
+            assert!((sample_peak - 0.707).abs() < 0.01);
+            let tp_db = 20.0 * meter.peak().log10();
+            assert!(
+                tp_db > -0.4 && tp_db < 0.2,
+                "expected ~0 dBTP at {} Hz, got {:.3} dBTP",
+                rate,
+                tp_db
+            );
+        }
+    }
+
+    /// The center tap lands on one polyphase phase, so the interpolated
+    /// peak can never read below the sample peak.
+    #[test]
+    fn true_peak_never_below_sample_peak() {
+        let mut meter = TruePeakMeter::new(48000, 2);
+        let mut sample_peak = 0.0f64;
+        // Deterministic irregular signal.
+        let mut x = 0.123f64;
+        for _ in 0..48000 {
+            x = (x * 997.0).sin();
+            sample_peak = sample_peak.max(x.abs());
+            meter.add_frame(&[x, -x]);
+        }
+        assert!(meter.peak() >= sample_peak - 1e-12);
+    }
+
+    /// At ≥ 88.2 kHz the meter drops to 2× oversampling; a plain sine
+    /// aligned with the grid must still read its amplitude, not more than
+    /// a fraction of a dB high.
+    #[test]
+    fn true_peak_2x_at_high_rates() {
+        let mut meter = TruePeakMeter::new(96000, 1);
+        let mut samples = Vec::new();
+        append_sine(&mut samples, -6.0, 1.0, 96000);
+        for &s in &samples {
+            meter.add_frame(&[s]);
+        }
+        let expected = crate::gain::db_to_linear(-6.0);
+        assert!((meter.peak() - expected).abs() / expected < 0.01);
+    }
+
+    #[test]
+    fn true_peak_silence_is_zero() {
+        let mut meter = TruePeakMeter::new(44100, 2);
+        for _ in 0..44100 {
+            meter.add_frame(&[0.0, 0.0]);
+        }
+        assert_eq!(meter.peak(), 0.0);
     }
 }

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -40,6 +40,9 @@ pub struct Options {
     // --rg2 / --r128: opt-in BS.1770 loudness modes (issue #269).
     // Default Rg1 keeps mp3gain-identical values.
     pub analysis_mode: AnalysisMode,
+    // --true-peak: BS.1770-4 Annex 2 true peak for REPLAYGAIN_*_PEAK in the
+    // BS.1770 modes (issue #292). Requires --rg2 or --r128.
+    pub true_peak: bool,
     pub skip_album: bool,         // -e: skip album analysis
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -50,6 +50,12 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
             continue;
         }
 
+        if arg == "--true-peak" {
+            opts.true_peak = true;
+            i += 1;
+            continue;
+        }
+
         if arg == "--help" {
             print_usage();
             std::process::exit(0);
@@ -316,6 +322,13 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         }
 
         i += 1;
+    }
+
+    // RG1's peak is mp3gain's MAX_AMPLITUDE semantics and must stay
+    // bit-compatible, so true peak is only defined for the BS.1770 modes
+    // (issue #292). Checked after the loop so flag order doesn't matter.
+    if opts.true_peak && opts.analysis_mode == AnalysisMode::Rg1 {
+        anyhow::bail!("--true-peak requires --rg2 or --r128");
     }
 
     // cmd.exe and PowerShell do not expand `*.mp3` for native programs.
@@ -690,6 +703,26 @@ mod tests {
     fn rg2_and_r128_are_mutually_exclusive() {
         assert!(parse_args(&args(&["--rg2", "--r128", "song.mp3"])).is_err());
         assert!(parse_args(&args(&["--r128", "--rg2", "song.mp3"])).is_err());
+    }
+
+    #[test]
+    fn true_peak_flag() {
+        let opts = parse_args(&args(&["-r", "--rg2", "--true-peak", "song.mp3"])).unwrap();
+        assert!(opts.true_peak);
+        assert_eq!(opts.analysis_mode, AnalysisMode::Rg2);
+
+        // Order-independent: --true-peak may precede the mode flag.
+        let opts = parse_args(&args(&["--true-peak", "--r128", "song.mp3"])).unwrap();
+        assert!(opts.true_peak);
+
+        let opts = parse_args(&args(&["--rg2", "song.mp3"])).unwrap();
+        assert!(!opts.true_peak);
+    }
+
+    #[test]
+    fn true_peak_requires_bs1770_mode() {
+        assert!(parse_args(&args(&["--true-peak", "song.mp3"])).is_err());
+        assert!(parse_args(&args(&["-r", "--true-peak", "song.mp3"])).is_err());
     }
 
     #[test]

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -30,6 +30,8 @@ pub fn print_usage() {
     println!("    -a          Apply Album gain (ReplayGain analysis)");
     println!("    --rg2       ReplayGain 2.0 analysis (BS.1770, -18 LUFS reference)");
     println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
+    println!("    --true-peak Measure true peak (BS.1770-4 Annex 2) for REPLAYGAIN_*_PEAK");
+    println!("                (requires --rg2 or --r128; default is sample peak)");
     println!("    -e          Skip album analysis (even with multiple files)");
     println!("    -i <n>      Specify which audio track to process (default: 0)");
     println!("    -u          Undo gain changes (restore from APEv2 tag)");

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -46,6 +46,7 @@ pub fn run_album_analysis(
             on_complete: parallel.then_some(&on_complete as _),
             cancel: None,
             mode: opts.analysis_mode,
+            true_peak: opts.true_peak,
         },
     );
 

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -38,11 +38,14 @@ pub fn analyze_track(
             pb.set_position(bytes);
         }
     });
-    replaygain::analyze_track_with_mode(
+    replaygain::analyze_track_with_options(
         file,
-        opts.track_index,
-        opts.analysis_mode,
-        on_progress.as_ref().map(|cb| cb as &dyn Fn(u64, u64)),
+        &replaygain::TrackAnalysisOptions {
+            track_index: opts.track_index,
+            mode: opts.analysis_mode,
+            true_peak: opts.true_peak,
+            on_progress: on_progress.as_ref().map(|cb| cb as &dyn Fn(u64, u64)),
+        },
     )
 }
 

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -159,6 +159,10 @@ pub struct ReplayGainResult {
     file_type: AudioFileType,
     #[cfg_attr(feature = "serde", serde(default))]
     analysis_mode: AnalysisMode,
+    /// Whether `peak` is a BS.1770-4 Annex 2 true peak rather than the
+    /// decoded sample peak (issue #292).
+    #[cfg_attr(feature = "serde", serde(default))]
+    true_peak: bool,
 }
 
 impl ReplayGainResult {
@@ -178,6 +182,7 @@ impl ReplayGainResult {
             sample_rate,
             file_type,
             analysis_mode,
+            true_peak: false,
         }
     }
 
@@ -200,6 +205,13 @@ impl ReplayGainResult {
     }
     pub fn analysis_mode(&self) -> AnalysisMode {
         self.analysis_mode
+    }
+
+    /// `true` when [`peak`](Self::peak) is a BS.1770-4 Annex 2 true peak
+    /// (measured with [`TrackAnalysisOptions::true_peak`] in a BS.1770
+    /// mode) rather than the decoded sample peak (issue #292).
+    pub fn is_true_peak(&self) -> bool {
+        self.true_peak
     }
 
     /// Integrated loudness in LUFS when measured with a BS.1770-based mode;
@@ -1140,6 +1152,7 @@ fn analyze_track_internal(
     track_index: Option<u32>,
     progress: Option<&dyn Fn(u64, u64)>,
     mode: AnalysisMode,
+    true_peak: bool,
 ) -> Result<TrackAnalysisInternal> {
     // Detect file type
     let file_type = detect_file_type(file_path);
@@ -1245,6 +1258,12 @@ fn analyze_track_internal(
                 analyzer: ReplayGainAnalyzer::new(sample_rate),
             }
         }
+        // True peak is only defined for the BS.1770 modes — RG1's peak is
+        // mp3gain's MAX_AMPLITUDE semantics and must stay bit-compatible,
+        // so the flag is ignored there (issue #292).
+        _ if true_peak => TrackAnalyzer::Bs1770 {
+            analyzer: crate::bs1770::Bs1770Analyzer::new_with_true_peak(sample_rate, channels),
+        },
         _ => TrackAnalyzer::Bs1770 {
             analyzer: crate::bs1770::Bs1770Analyzer::new(sample_rate, channels),
         },
@@ -1291,6 +1310,7 @@ fn analyze_track_internal(
     }
 
     // Finish analysis and calculate loudness and gain
+    let mut is_true_peak = false;
     let (loudness_db, gain_db, state) = match track_analyzer {
         TrackAnalyzer::Rg1 { mut analyzer, .. } => {
             // Finish any remaining samples in the last window
@@ -1303,13 +1323,22 @@ fn analyze_track_internal(
             )
         }
         TrackAnalyzer::Bs1770 { analyzer, .. } => {
+            // The interpolator's passthrough phase makes the true peak
+            // ≥ sample peak by construction; the max() is a guard against
+            // rounding at the very margin.
+            if let Some(tp) = analyzer.true_peak() {
+                peak = peak.max(tp);
+                is_true_peak = true;
+            }
             let blocks = analyzer.into_blocks();
             let (loudness_db, gain_db) = lufs_loudness_and_gain(blocks.integrated_lufs(), mode);
             (loudness_db, gain_db, LoudnessState::Bs1770(blocks))
         }
     };
 
-    let result = ReplayGainResult::new(loudness_db, gain_db, peak, sample_rate, file_type, mode);
+    let mut result =
+        ReplayGainResult::new(loudness_db, gain_db, peak, sample_rate, file_type, mode);
+    result.true_peak = is_true_peak;
 
     Ok(TrackAnalysisInternal { result, state })
 }
@@ -1342,7 +1371,51 @@ pub fn analyze_track_with_mode(
     mode: AnalysisMode,
     on_progress: Option<&dyn Fn(u64, u64)>,
 ) -> Result<ReplayGainResult> {
-    let internal = analyze_track_internal(file_path, track_index, on_progress, mode)?;
+    analyze_track_with_options(
+        file_path,
+        &TrackAnalysisOptions {
+            track_index,
+            mode,
+            on_progress,
+            ..Default::default()
+        },
+    )
+}
+
+/// Options for [`analyze_track_with_options`].
+///
+/// `Default` is a strict RG1 analysis of the first audio track with no
+/// callbacks — the same behavior as [`analyze_track`].
+#[derive(Default)]
+pub struct TrackAnalysisOptions<'a> {
+    /// Which audio track to analyze in multi-track containers (default: first).
+    pub track_index: Option<u32>,
+    /// Loudness measurement algorithm (issue #269).
+    pub mode: AnalysisMode,
+    /// Measure BS.1770-4 Annex 2 true peak instead of the decoded sample
+    /// peak in the BS.1770 modes (issue #292). True peak estimates
+    /// inter-sample peaks by oversampling, so values above 1.0 are expected
+    /// and correct. Ignored in [`AnalysisMode::Rg1`], whose peak is
+    /// mp3gain's `MAX_AMPLITUDE` semantics and must stay bit-compatible.
+    pub true_peak: bool,
+    /// Byte-level progress callback, as in [`analyze_track_with_progress`].
+    pub on_progress: Option<&'a dyn Fn(u64, u64)>,
+}
+
+/// Analyze a single track with the full option set (issue #292). The other
+/// `analyze_track_*` functions are conveniences over this one.
+#[cfg(feature = "replaygain")]
+pub fn analyze_track_with_options(
+    file_path: &Path,
+    opts: &TrackAnalysisOptions,
+) -> Result<ReplayGainResult> {
+    let internal = analyze_track_internal(
+        file_path,
+        opts.track_index,
+        opts.on_progress,
+        opts.mode,
+        opts.true_peak,
+    )?;
     Ok(internal.result)
 }
 
@@ -1587,6 +1660,10 @@ pub struct AlbumAnalysisOptions<'a> {
     /// Loudness measurement algorithm (issue #269). Defaults to
     /// [`AnalysisMode::Rg1`], the mp3gain-compatible algorithm.
     pub mode: AnalysisMode,
+    /// Measure BS.1770-4 Annex 2 true peak instead of sample peak in the
+    /// BS.1770 modes (issue #292); see [`TrackAnalysisOptions::true_peak`].
+    /// Ignored in [`AnalysisMode::Rg1`].
+    pub true_peak: bool,
 }
 
 /// Analyze multiple tracks for album gain (strict, serial, no callbacks).
@@ -1630,6 +1707,7 @@ fn analyze_album_serial(
         skip_errors,
         cancel,
         mode,
+        true_peak,
         ..
     } = *opts;
     let mut track_results = Vec::with_capacity(files.len());
@@ -1648,7 +1726,8 @@ fn analyze_album_serial(
             on_progress.map(|cb| Box::new(move |bytes, total| cb(i, bytes, total)) as _);
 
         // Analyze each track and get its loudness state
-        let track = analyze_track_internal(file, track_index, file_progress.as_deref(), mode);
+        let track =
+            analyze_track_internal(file, track_index, file_progress.as_deref(), mode, true_peak);
         if let Some(cb) = on_complete {
             cb(i, file);
         }
@@ -1697,6 +1776,7 @@ fn analyze_album_parallel_internal(
         skip_errors,
         cancel,
         mode,
+        true_peak,
         ..
     } = *opts;
 
@@ -1718,7 +1798,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None, mode);
+                let r = analyze_track_internal(file, track_index, None, mode, true_peak);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -1749,7 +1829,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None, mode);
+                let r = analyze_track_internal(file, track_index, None, mode, true_peak);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -1807,6 +1887,17 @@ pub fn analyze_track_with_mode(
     _track_index: Option<u32>,
     _mode: AnalysisMode,
     _on_progress: Option<&dyn Fn(u64, u64)>,
+) -> Result<ReplayGainResult> {
+    Err(Error::FeatureNotAvailable {
+        feature: "ReplayGain analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn analyze_track_with_options(
+    _file_path: &Path,
+    _opts: &TrackAnalysisOptions,
 ) -> Result<ReplayGainResult> {
     Err(Error::FeatureNotAvailable {
         feature: "ReplayGain analysis",

--- a/tests/bs1770_integration.rs
+++ b/tests/bs1770_integration.rs
@@ -5,8 +5,9 @@
 #![cfg(feature = "replaygain")]
 
 use mp3rgain::replaygain::{
-    analyze_album_with_options, analyze_track, analyze_track_with_mode, AlbumAnalysisOptions,
-    AnalysisMode, R128_REFERENCE_LUFS, RG2_REFERENCE_LUFS,
+    analyze_album_with_options, analyze_track, analyze_track_with_mode, analyze_track_with_options,
+    AlbumAnalysisOptions, AnalysisMode, TrackAnalysisOptions, R128_REFERENCE_LUFS,
+    RG2_REFERENCE_LUFS,
 };
 use std::path::Path;
 
@@ -48,6 +49,86 @@ fn default_mode_is_unchanged_rg1() {
     let rg1 = analyze_track_with_mode(path, None, AnalysisMode::Rg1, None).unwrap();
     assert_eq!(default, rg1);
     assert_eq!(default.analysis_mode(), AnalysisMode::Rg1);
+}
+
+/// Issue #292: `--true-peak` measures a BS.1770-4 Annex 2 true peak. It can
+/// never read below the sample peak, must not change the loudness/gain
+/// measurement, and stays within a fraction of a dB of the sample peak on
+/// ordinary program material.
+#[test]
+fn true_peak_ge_sample_peak_and_loudness_unchanged() {
+    for file in ["test_mono.mp3", "test_joint_stereo.mp3", "test_vbr.mp3"] {
+        let path_string = format!("tests/fixtures/{}", file);
+        let path = Path::new(&path_string);
+        let sample = analyze_track_with_mode(path, None, AnalysisMode::Rg2, None).unwrap();
+        let tp = analyze_track_with_options(
+            path,
+            &TrackAnalysisOptions {
+                mode: AnalysisMode::Rg2,
+                true_peak: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(!sample.is_true_peak());
+        assert!(tp.is_true_peak());
+        assert!(tp.peak() >= sample.peak(), "{file}");
+        // Inter-sample overshoot on normal material is well under 3 dB.
+        assert!(tp.peak() < sample.peak() * 1.5, "{file}");
+        assert_eq!(tp.loudness_db(), sample.loudness_db(), "{file}");
+        assert_eq!(tp.gain_db(), sample.gain_db(), "{file}");
+    }
+}
+
+/// The flag is ignored in RG1 mode: peak stays mp3gain's MAX_AMPLITUDE
+/// semantics, bit-identical to a plain RG1 analysis.
+#[test]
+fn true_peak_ignored_in_rg1_mode() {
+    let path = Path::new("tests/fixtures/test_mono.mp3");
+    let plain = analyze_track(path).unwrap();
+    let flagged = analyze_track_with_options(
+        path,
+        &TrackAnalysisOptions {
+            true_peak: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(plain, flagged);
+    assert!(!flagged.is_true_peak());
+}
+
+#[test]
+fn album_analysis_with_true_peak() {
+    let mono = Path::new("tests/fixtures/test_mono.mp3");
+    let vbr = Path::new("tests/fixtures/test_vbr.mp3");
+    let sample = analyze_album_with_options(
+        &[mono, vbr],
+        &AlbumAnalysisOptions {
+            mode: AnalysisMode::Rg2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let tp = analyze_album_with_options(
+        &[mono, vbr],
+        &AlbumAnalysisOptions {
+            mode: AnalysisMode::Rg2,
+            true_peak: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(tp.album.album_peak() >= sample.album.album_peak());
+    assert_eq!(
+        tp.album.album_loudness_db(),
+        sample.album.album_loudness_db()
+    );
+    for track in tp.album.tracks() {
+        assert!(track.is_true_peak());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements BS.1770-4 Annex 2 true-peak measurement as an opt-in `--true-peak` flag for the BS.1770 modes, per the design settled in the issue after skamp's follow-up on the Hydrogenaudio thread (reply #43).

## Context from the issue discussion

- **Opt-in, not default**: sample peak has been the established default for lossy files across the ecosystem "since pretty much forever" — loudgain and rsgain measure true peak only as an opt-in (`-t` / custom mode). `--rg2` / `--r128` therefore keep sample peak by default; nothing changes within 3.x without the flag.
- **No capping at 1.0**: skamp's core complaint was rsgain Easy Mode capping the reported peak at 1.0. mp3rgain already reports the real measured value, and this PR preserves that for true peak too — `REPLAYGAIN_*_PEAK` values above 1.0 are written as-is (`format_rg_peak` has no clamp), which is expected and correct for lossy codecs that reconstruct above the sample grid.

## Implementation

- **`TruePeakMeter` in `src/bs1770.rs`**: polyphase FIR interpolator — 49-tap Hann-windowed sinc (the libebur128 design), 4× oversampling at common rates, 2× at ≥ 88.2 kHz. Fed the raw normalized samples per channel *before* K-weighting via `Bs1770Analyzer::new_with_true_peak`. The center tap lands on one polyphase phase, so the reported peak is always ≥ the sample peak by construction.
- **Analysis plumbing**: new `TrackAnalysisOptions` + `analyze_track_with_options` (existing `analyze_track_*` functions become conveniences over it); `AlbumAnalysisOptions` gains a `true_peak` field. `ReplayGainResult` records whether its peak is a true peak (`is_true_peak()`), so post-apply re-analysis (`compute_rg_residual`) reuses the same peak kind.
- **CLI**: `--true-peak` flag, order-independent validation — using it without `--rg2` / `--r128` is an error.
- **Clipping / `-k`**: the clip check compares `track.peak()` × gain against 1.0, so with `--true-peak` it automatically uses the (slightly more conservative) true peak — design decision 2.
- **AAC/M4A**: shares the analyzer, so it inherits the flag with no tag-format change — design decision 4.

## Non-goals honored

- RG1 analysis, `MAX_AMPLITUDE`, and all mp3gain-compatible output are untouched (the flag is ignored in RG1 inside the library and rejected by the CLI).
- Default `--rg2`/`--r128` peak semantics unchanged; no true-peak limiting.

## Tests

- Unit: fs/4 sine at 45° phase (sample peak 0.707, true peak 1.0) reads ~0 dBTP within EBU Tech 3341 tolerance at 44.1/48 kHz; true peak ≥ sample peak invariant; 2× path at 96 kHz; silence.
- Integration: true peak ≥ sample peak with identical loudness/gain on the MP3 fixtures; flag ignored (bit-identical result) in RG1; album analysis with true peak.
- CLI: flag parsing incl. order independence and the requires-BS.1770-mode error.

Closes #292
