### PR TITLE
Add -s R: reuse stored ReplayGain tags instead of rescanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A native GUI application (`mp3rgui`) is available for users who prefer a graphic
 | `-u` | Undo gain changes |
 | `-k` | Prevent clipping |
 | `-R` | Process directories recursively |
+| `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only when tags are missing (mp3gain's default behavior) |
 | `--skip-errors` | Keep album analysis (`-a`) going past unreadable files |
 | `-n` | Dry-run mode |
 | `-j <n>` / `--threads <n>` | Worker threads for analysis (default: auto, 0=auto, 1=serial) |

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -72,6 +72,7 @@ All options from the original mp3gain are fully implemented in mp3rgain:
 | Option | Description |
 |--------|-------------|
 | `-R` | Recursive directory processing |
+| `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only when tags are missing (mp3gain's *default* behavior, opt-in here) |
 | `-n` / `--dry-run` | Dry-run mode (preview changes without modifying files) |
 | `-o json` | JSON output format (for scripting and automation) |
 | `-o tsv` | Tab-separated output (database-friendly) |

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -117,7 +117,10 @@ Delete stored tag information.
 Skip (ignore) stored tag information.
 .TP
 .B r
-Force recalculation, ignoring stored tags.
+Force recalculation, ignoring stored tags (the default; kept for mp3gain compatibility).
+.TP
+.B R
+Reuse stored ReplayGain tags with \fB\-r\fR/\fB\-a\fR instead of re-analyzing, rescanning only files whose tags are missing. This is mp3gain's default behavior. Album mode requires a consistent set of album tags on every file; otherwise the whole album is rescanned. Ignored with \fB\-s r\fR, \fB\-d\fR/\fB\-m\fR modifiers, or \fB\-\-rg2\fR/\fB\-\-r128\fR.
 .TP
 .B i
 Use ID3v2 tags (not fully supported, falls back to APEv2).

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -69,7 +69,7 @@ flags are accepted with the same semantics; mp3rgain adds a few extensions.
 | `-f` | Assume MPEG2 Layer III | Accepted; no effect (mp3rgain auto-detects) |
 | `-q` | Quiet mode | |
 | `-R` | Process directories recursively | |
-| `-s c` / `-s d` / `-s s` / `-s r` / `-s a` | Stored-tag handling: check / delete / skip / recalc / all-APEv2 | Same modes as mp3gain. `-s a` pins every tag to APEv2, which is mp3gain's layout and was mp3rgain's default before 3.2.0 |
+| `-s c` / `-s d` / `-s s` / `-s r` / `-s a` | Stored-tag handling: check / delete / skip / recalc / all-APEv2 | Same modes as mp3gain. `-s a` pins every tag to APEv2, which is mp3gain's layout and was mp3rgain's default before 3.2.0. Note the default is inverted: mp3gain reuses stored tags unless you pass `-s r`, while mp3rgain re-analyzes unless you pass `-s R` (see below) |
 | `-o` (no argument) | TSV output | Default header matches mp3gain exactly (see [Output format](#output-format)) |
 
 ### mp3rgain extensions
@@ -84,6 +84,7 @@ are worth knowing:
 | `-w` | Wrap gain values instead of clamping |
 | `-n`, `--dry-run` | Preview changes without writing |
 | `-o text` / `-o json` / `-o tsv` | Explicit output format selection |
+| `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only files whose tags are missing. This restores mp3gain's default behavior as an opt-in ([#298](https://github.com/M-Igashi/mp3rgain/issues/298)). Album mode requires a consistent set of album tags on every file, otherwise the whole album is rescanned. Ignored with `-s r`, `-d`/`-m`, or `--rg2`/`--r128` |
 | `-s i` | Put *every* tag in ID3v2 `TXXX`, undo included. Since 3.2.0 the default already writes `REPLAYGAIN_*` to ID3v2, so this is only needed when you want `MP3GAIN_UNDO` there too |
 | `-j <n>` / `--threads <n>` | Worker threads for ReplayGain analysis (default: auto). `MP3RGAIN_THREADS` env var also honored. `-j 1` reproduces mp3gain's serial behavior. See [docs/perf-parallel.md](perf-parallel.md). |
 | `--skip-errors` | Keep album analysis (`-a`) going past unreadable files; failed files are reported and excluded from the album gain |

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -34,9 +34,12 @@ pub struct Options {
     // *where* they live (-s i: all ID3v2, -s a: all APEv2, default: split).
     pub stored_tag_mode: StoredTagMode,
     pub tag_layout: TagLayout, // -s i / -s a
-    pub force_recalc: bool,    // -s r: accepted for compatibility (always recalculates)
-    pub track_gain: bool,      // -r (apply track gain)
-    pub album_gain: bool,      // -a (apply album gain)
+    pub force_recalc: bool,    // -s r: accepted for compatibility (recalculation is the default)
+    // -s R: reuse stored REPLAYGAIN_* tags instead of re-analyzing, rescanning
+    // only files whose tags are missing (mp3gain's default behavior, issue #298).
+    pub use_stored_tags: bool,
+    pub track_gain: bool, // -r (apply track gain)
+    pub album_gain: bool, // -a (apply album gain)
     // --rg2 / --r128: opt-in BS.1770 loudness modes (issue #269).
     // Default Rg1 keeps mp3gain-identical values.
     pub analysis_mode: AnalysisMode,
@@ -75,6 +78,17 @@ impl Options {
         } else {
             ""
         }
+    }
+
+    /// Whether `-s R` may reuse stored tags at all. Stored values can't be
+    /// trusted when `-s r` forces recalculation, a `-d`/`-m` modifier shifts
+    /// the target, or a BS.1770 mode is selected (`REPLAYGAIN_ALGORITHM`
+    /// can't distinguish the RG2 and R128 targets), so those force a rescan.
+    pub fn stored_tags_usable(&self) -> bool {
+        self.use_stored_tags
+            && !self.force_recalc
+            && self.analysis_mode == AnalysisMode::Rg1
+            && self.gain_modifier_steps() == 0
     }
 
     /// Combined `-m` (steps) and `-d` (dB) modifier expressed as mp3 gain steps.

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -131,15 +131,17 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                         "c" => opts.stored_tag_mode = StoredTagMode::Check,
                         "d" => opts.stored_tag_mode = StoredTagMode::Delete,
                         "s" => opts.stored_tag_mode = StoredTagMode::Skip,
-                        // mp3gain compatibility: mp3rgain never reads stored
-                        // tags as an analysis cache, so "force recalculation"
-                        // is always in effect. Accepted with a notice (#253).
+                        // mp3gain compatibility: recalculation is mp3rgain's
+                        // default, so "force recalculation" only matters as an
+                        // override of -s R. Accepted with a notice (#253).
                         "r" => opts.force_recalc = true,
+                        // Reuse stored tags, rescan only when missing (#298).
+                        "R" => opts.use_stored_tags = true,
                         "i" => opts.tag_layout = TagLayout::Id3v2,
                         "a" => opts.tag_layout = TagLayout::Ape,
                         other => {
                             eprintln!(
-                                "{}: unknown -s mode '{}', use c/d/s/r/i/a",
+                                "{}: unknown -s mode '{}', use c/d/s/r/R/i/a",
                                 "error".red().bold(),
                                 other
                             );
@@ -521,6 +523,18 @@ mod tests {
         let opts = parse_args(&args(&["-s", "r"])).unwrap();
         assert!(opts.force_recalc);
         assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
+        // -s R reuses stored tags, orthogonal to the mode enum (#298)
+        let opts = parse_args(&args(&["-s", "R", "-a"])).unwrap();
+        assert!(opts.use_stored_tags);
+        assert!(opts.stored_tags_usable());
+        assert_eq!(opts.stored_tag_mode, StoredTagMode::None);
+        // -s r, -d/-m, and the BS.1770 modes all disable tag reuse
+        let opts = parse_args(&args(&["-s", "R", "-s", "r"])).unwrap();
+        assert!(!opts.stored_tags_usable());
+        let opts = parse_args(&args(&["-s", "R", "-d", "3.0"])).unwrap();
+        assert!(!opts.stored_tags_usable());
+        let opts = parse_args(&args(&["-s", "R", "--rg2"])).unwrap();
+        assert!(!opts.stored_tags_usable());
         // -s i / -s a toggle the tag format; last one wins
         let opts = parse_args(&args(&["-s", "i"])).unwrap();
         assert_eq!(opts.tag_layout, TagLayout::Id3v2);

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -40,7 +40,9 @@ pub fn print_usage() {
     println!("                  c = check/show stored tag info");
     println!("                  d = delete stored tag info");
     println!("                  s = skip (don't write) stored tag info");
-    println!("                  r = force recalculation (always on; kept for compatibility)");
+    println!("                  r = force recalculation (default; kept for compatibility)");
+    println!("                  R = reuse stored ReplayGain tags with -r/-a, re-analyzing");
+    println!("                      only when tags are missing (mp3gain's default behavior)");
     println!("                  i = put all tags in ID3v2");
     println!("                  a = put all tags in APEv2 (mp3gain-identical)");
     println!("    -p          Preserve original file timestamp");
@@ -74,6 +76,8 @@ pub fn print_usage() {
     println!("    mp3rgain -e *.mp3              Track gain only (skip album calc)");
     println!("    mp3rgain -u song.mp3           Undo previous gain changes");
     println!("    mp3rgain -x song.mp3           Show max amplitude only");
+    println!("    mp3rgain -s R -a *.mp3         Album gain from stored tags (rescan only");
+    println!("                                   if any file lacks them)");
     println!("    mp3rgain -s c *.mp3            Check stored tag info");
     println!("    mp3rgain -s d *.mp3            Delete stored tag info");
     println!("    mp3rgain -g 2 -p song.mp3      Apply gain, preserve timestamp");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,11 +49,28 @@ pub fn run(mut opts: Options) -> Result<()> {
         );
     }
 
-    // -s r warning: mp3rgain never reads stored tags as an analysis cache,
-    // so recalculation is always in effect (issue #253)
-    if opts.force_recalc && !opts.quiet && opts.output_format == OutputFormat::Text {
+    // -s r warning: recalculation is mp3rgain's default, so the flag only
+    // matters as an override of -s R (issues #253, #298)
+    if opts.force_recalc
+        && !opts.use_stored_tags
+        && !opts.quiet
+        && opts.output_format == OutputFormat::Text
+    {
         eprintln!(
-            "{}: -s r (force recalculation) is accepted for compatibility but has no effect (mp3rgain always recalculates)",
+            "{}: -s r (force recalculation) is accepted for compatibility but has no effect (recalculation is the default; use -s R to reuse stored tags)",
+            "note".cyan()
+        );
+    }
+
+    // -s R warning: tell the user up front when stored tags will be ignored
+    // (see Options::stored_tags_usable for the reasons)
+    if opts.use_stored_tags
+        && !opts.stored_tags_usable()
+        && !opts.quiet
+        && opts.output_format == OutputFormat::Text
+    {
+        eprintln!(
+            "{}: -s R is ignored with -s r, -d/-m modifiers, or --rg2/--r128; files will be re-analyzed",
             "note".cyan()
         );
     }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use colored::*;
-use mp3rgain::replaygain::{self, AlbumAnalysisReport, AudioFileType, REPLAYGAIN_REFERENCE_DB};
+use mp3rgain::replaygain::{
+    self, AlbumAnalysisReport, AlbumGainResult, AudioFileType, ReplayGainResult,
+    REPLAYGAIN_REFERENCE_DB,
+};
 use mp3rgain::{steps_to_db, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
@@ -14,6 +17,7 @@ use crate::commands::utils::{
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
+use crate::processors::utils::stored_file_type;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
@@ -77,6 +81,52 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     finish_with_summary(files.len(), json_results, successful, failed, opts)
 }
 
+/// `-s R` (issue #298): build an album report from stored tags. Requires
+/// every file to carry parseable `REPLAYGAIN_TRACK_*` and `REPLAYGAIN_ALBUM_*`
+/// values with no algorithm marker and a matching album gain. The stored
+/// values are residuals relative to each file's current loudness, so a
+/// partial or inconsistent set cannot be mixed with fresh analysis — any gap
+/// returns `None` and the whole album is rescanned.
+fn stored_album_report(files: &[PathBuf], opts: &Options) -> Option<AlbumAnalysisReport> {
+    if !opts.stored_tags_usable() {
+        return None;
+    }
+    let mut tracks = Vec::with_capacity(files.len());
+    let mut album_gain: Option<f64> = None;
+    let mut album_peak: f64 = 0.0;
+    for file in files {
+        let tags = mp3rgain::read_gain_tags_auto(file, opts.tag_layout).ok()?;
+        if tags.algorithm.is_some() {
+            return None;
+        }
+        let gain_db = tags.track_gain_db()?;
+        let peak = tags.track_peak_value()?;
+        let file_album_gain = tags.album_gain_db()?;
+        album_peak = album_peak.max(tags.album_peak_value()?);
+        match album_gain {
+            Some(g) if (g - file_album_gain).abs() > 0.05 => return None,
+            Some(_) => {}
+            None => album_gain = Some(file_album_gain),
+        }
+        tracks.push(ReplayGainResult::from_stored_tags(
+            gain_db,
+            peak,
+            stored_file_type(file),
+            opts.analysis_mode,
+        ));
+    }
+    Some(AlbumAnalysisReport {
+        album: AlbumGainResult::from_stored_tags(
+            tracks,
+            album_gain?,
+            album_peak,
+            opts.analysis_mode,
+        ),
+        failures: Vec::new(),
+        successful_indices: (0..files.len()).collect(),
+    })
+}
+
 pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
 
@@ -93,17 +143,27 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    // First, analyze all tracks
-    if opts.output_format == OutputFormat::Text && !opts.quiet {
-        println!("  {} Analyzing tracks...", "->".cyan());
-    }
-
     let file_refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
 
     let threads = effective_threads(opts);
     let parallel = threads > 1 && files.len() > 1;
 
-    let album_analysis = run_album_analysis(&file_refs, opts, threads, parallel, opts.skip_errors);
+    // -s R: reuse stored album tags when every file carries a consistent
+    // set; otherwise fall back to the full rescan (issue #298).
+    let album_analysis = match stored_album_report(files, opts) {
+        Some(report) => {
+            if opts.output_format == OutputFormat::Text && !opts.quiet {
+                println!("  {} Using stored tags (no rescan)", "->".cyan());
+            }
+            Ok(report)
+        }
+        None => {
+            if opts.output_format == OutputFormat::Text && !opts.quiet {
+                println!("  {} Analyzing tracks...", "->".cyan());
+            }
+            run_album_analysis(&file_refs, opts, threads, parallel, opts.skip_errors)
+        }
+    };
 
     match album_analysis {
         Ok(report) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,26 @@ impl StoredGainTags {
         }
     }
 
+    /// `REPLAYGAIN_TRACK_GAIN` parsed to dB, if present and well-formed.
+    pub fn track_gain_db(&self) -> Option<f64> {
+        self.track_gain.as_deref().and_then(ape::parse_rg_gain)
+    }
+
+    /// `REPLAYGAIN_TRACK_PEAK` parsed to a linear peak.
+    pub fn track_peak_value(&self) -> Option<f64> {
+        self.track_peak.as_deref().and_then(ape::parse_rg_peak)
+    }
+
+    /// `REPLAYGAIN_ALBUM_GAIN` parsed to dB.
+    pub fn album_gain_db(&self) -> Option<f64> {
+        self.album_gain.as_deref().and_then(ape::parse_rg_gain)
+    }
+
+    /// `REPLAYGAIN_ALBUM_PEAK` parsed to a linear peak.
+    pub fn album_peak_value(&self) -> Option<f64> {
+        self.album_peak.as_deref().and_then(ape::parse_rg_peak)
+    }
+
     /// True if at least one gain tag is present.
     pub fn has_any(&self) -> bool {
         self.track_gain.is_some()

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -13,7 +13,7 @@ use crate::util::get_filename;
 
 use super::utils::{
     analyze_track, emit_clipping_warning, report_file_error, restore_timestamp,
-    save_original_mtime, warn_aac_multi_track,
+    save_original_mtime, stored_track_result, warn_aac_multi_track,
 };
 
 pub fn process_track_gain(
@@ -35,17 +35,31 @@ fn process_track_gain_into(
     let filename = get_filename(file);
     let dry_run_prefix = opts.dry_run_prefix();
 
+    // -s R: reuse stored tags when present and trusted; otherwise fall
+    // through to a normal analysis of just this file (issue #298).
+    let stored = stored_track_result(file, opts);
+
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         writeln!(
             out,
-            "  {} {}Analyzing {}...",
+            "  {} {}{} {}...",
             "->".cyan(),
             dry_run_prefix,
+            if stored.is_some() {
+                "Using stored tags for"
+            } else {
+                "Analyzing"
+            },
             filename
         )?;
     }
 
-    match analyze_track(file, opts, analysis_pb) {
+    let analysis = match stored {
+        Some(result) => Ok(result),
+        None => analyze_track(file, opts, analysis_pb),
+    };
+
+    match analysis {
         Ok(result) => {
             // Apply gain modifier (-m steps + -d dB, combined into steps)
             let base_steps = result.gain_steps();

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -49,6 +49,39 @@ pub fn analyze_track(
     )
 }
 
+/// `-s R` (issue #298): build an analysis result from the file's stored
+/// `REPLAYGAIN_TRACK_*` tags, or `None` when the tags are absent, malformed,
+/// unreadable, or untrusted (see [`Options::stored_tags_usable`]) — the
+/// caller then falls back to a real analysis. A `REPLAYGAIN_ALGORITHM` tag
+/// marks BS.1770 values, which don't match the RG1 target this path trusts.
+pub fn stored_track_result(file: &Path, opts: &Options) -> Option<ReplayGainResult> {
+    if !opts.stored_tags_usable() {
+        return None;
+    }
+    let tags = mp3rgain::read_gain_tags_auto(file, opts.tag_layout).ok()?;
+    if tags.algorithm.is_some() {
+        return None;
+    }
+    let gain_db = tags.track_gain_db()?;
+    let peak = tags.track_peak_value()?;
+    Some(ReplayGainResult::from_stored_tags(
+        gain_db,
+        peak,
+        stored_file_type(file),
+        opts.analysis_mode,
+    ))
+}
+
+/// File type for a tag-derived result, mirroring the dispatch in
+/// [`mp3rgain::read_gain_tags_auto`].
+pub fn stored_file_type(file: &Path) -> mp3rgain::replaygain::AudioFileType {
+    if mp4meta::is_aac_file(file) {
+        mp3rgain::replaygain::AudioFileType::Aac
+    } else {
+        mp3rgain::replaygain::AudioFileType::Mp3
+    }
+}
+
 pub fn save_original_mtime(file: &Path, opts: &Options) -> Option<SystemTime> {
     if opts.preserve_timestamp && !opts.dry_run {
         mp3rgain::apply::read_mtime(file)

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -186,6 +186,29 @@ impl ReplayGainResult {
         }
     }
 
+    /// Build a result from stored `REPLAYGAIN_*` tags instead of analysis
+    /// (`-s R`, issue #298). Loudness is derived from the gain relative to
+    /// the mode's target; `sample_rate` is unknown and reported as 0.
+    pub fn from_stored_tags(
+        gain_db: f64,
+        peak: f64,
+        file_type: AudioFileType,
+        analysis_mode: AnalysisMode,
+    ) -> Self {
+        let target = analysis_mode
+            .target_lufs()
+            .unwrap_or(REPLAYGAIN_REFERENCE_DB);
+        Self {
+            loudness_db: target - gain_db,
+            gain_db,
+            peak,
+            sample_rate: 0,
+            file_type,
+            analysis_mode,
+            true_peak: false,
+        }
+    }
+
     /// Measured loudness: the RG1 histogram value in [`AnalysisMode::Rg1`],
     /// or the BS.1770 integrated loudness in LUFS in the other modes.
     pub fn loudness_db(&self) -> f64 {
@@ -265,6 +288,25 @@ impl AlbumGainResult {
         Self {
             tracks,
             album_loudness_db,
+            album_gain_db,
+            album_peak,
+        }
+    }
+
+    /// Build an album result from stored `REPLAYGAIN_ALBUM_*` tags instead of
+    /// analysis (`-s R`, issue #298). See [`ReplayGainResult::from_stored_tags`].
+    pub fn from_stored_tags(
+        tracks: Vec<ReplayGainResult>,
+        album_gain_db: f64,
+        album_peak: f64,
+        analysis_mode: AnalysisMode,
+    ) -> Self {
+        let target = analysis_mode
+            .target_lufs()
+            .unwrap_or(REPLAYGAIN_REFERENCE_DB);
+        Self {
+            tracks,
+            album_loudness_db: target - album_gain_db,
             album_gain_db,
             album_peak,
         }


### PR DESCRIPTION
Closes #298

## Summary

Adds `-s R`, which reuses stored `REPLAYGAIN_*` tags with `-r`/`-a` instead of re-analyzing, rescanning only files whose tags are missing. This is mp3gain's default behavior, offered here as an opt-in so existing usage is unchanged.

- **Track mode (`-r`)**: per-file decision. Files with parseable `REPLAYGAIN_TRACK_GAIN`/`_PEAK` are applied from tags; files without them are analyzed as before.
- **Album mode (`-a`)**: all-or-nothing. Stored album tags are reused only when every file carries a parseable, consistent set (track gain/peak + album gain/peak, album gains matching within 0.05 dB). Any gap rescans the whole album, since stored values are residuals relative to each file's current loudness and cannot be soundly mixed with fresh analysis.
- **Forced rescan** when stored values can't be trusted: `-s r`, `-d`/`-m` modifiers, or `--rg2`/`--r128` (the `REPLAYGAIN_ALGORITHM` tag cannot distinguish the RG2 and R128 targets). A note is printed so the fallback is visible.
- `ReplayGainResult::from_stored_tags` / `AlbumGainResult::from_stored_tags` constructors and parsed accessors on `StoredGainTags` are added to the library; the existing `read_gain_tags_auto` handles APEv2/ID3v2/MP4 uniformly, so the feature is format-agnostic.
- The `-s r` compatibility notice is reworded (recalculation is the default; `-s R` opts into tag reuse), and usage text, man page, README, COMPARISON.md, and migrating-from-mp3gain.md are updated.

## Verification

- `cargo fmt`, `cargo clippy`, `cargo test` (167 tests) all clean.
- Manual check on fixture MP3s: tagged album applies from tags with no rescan and converges (residual +0.5 dB rounds to 0 steps); an untagged file mixed into the album triggers a full rescan; `-s R -r` on an untagged file falls back to analysis; `-s R -d 3` prints the fallback note and re-analyzes. Clipping warnings from stored peaks match the rescan path.

Thanks to @ToxicFrog for the report and the design discussion (credited as co-author).