### PR TITLE
gui: make panics visible with a log-first panic hook

### DIFF
--- a/mp3rgui/src/main.rs
+++ b/mp3rgui/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod panic_hook;
 mod startup;
 mod ui;
 mod worker;
@@ -8,6 +9,8 @@ mod worker;
 use app::Mp3rgainApp;
 
 fn main() {
+    panic_hook::install();
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([900.0, 650.0])

--- a/mp3rgui/src/panic_hook.rs
+++ b/mp3rgui/src/panic_hook.rs
@@ -1,0 +1,102 @@
+//! Panic hook for the windowed build (issue #297).
+//!
+//! On Windows the GUI has no console (`windows_subsystem = "windows"`), so a
+//! panic anywhere — winit/wgpu during startup, the render loop, our own
+//! `update()` — kills the process with nothing the user can see. The hook
+//! makes that failure visible and reportable: log first (stderr plus a
+//! `panic.log` in the eframe data dir), dialog last, and only on the main
+//! thread. A modal for a worker-thread panic would turn a survivable glitch
+//! into a scary popup, and a dialog from a panicking event loop is
+//! best-effort anyway — if the platform state is too broken to show it, we
+//! are no worse off than today.
+
+use std::io::Write as _;
+use std::panic::PanicHookInfo;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Where panics are recorded: next to eframe's own `app.ron`, so a portable
+/// install leaves no new directory behind. `None` if eframe has no data dir.
+fn log_path() -> Option<PathBuf> {
+    eframe::storage_dir("mp3rgain").map(|dir| dir.join("panic.log"))
+}
+
+/// Appends normally; a log past this size is truncated first so repeated
+/// crashes cannot grow the file without bound.
+const MAX_LOG_BYTES: u64 = 64 * 1024;
+
+pub fn install() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // The default hook prints message + location (and a backtrace with
+        // RUST_BACKTRACE) to stderr, for anyone running from a terminal.
+        default_hook(info);
+
+        // A panic inside this hook must not recurse into it.
+        static IN_HOOK: AtomicBool = AtomicBool::new(false);
+        if IN_HOOK.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let message = describe(info);
+        let logged = write_log(&message);
+
+        if std::thread::current().name() == Some("main") {
+            let where_to = match &logged {
+                Some(path) => format!("This was written to:\n{}\n\n", path.display()),
+                None => String::new(),
+            };
+            let text = format!(
+                "{message}\n\n{where_to}Please report it at https://github.com/M-Igashi/mp3rgain/issues"
+            );
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rfd::MessageDialog::new()
+                    .set_title("mp3rgain crashed")
+                    .set_description(&text)
+                    .set_level(rfd::MessageLevel::Error)
+                    .show();
+            }));
+        }
+
+        IN_HOOK.store(false, Ordering::SeqCst);
+    }));
+}
+
+fn describe(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    let msg = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<non-string panic payload>");
+    let location = info
+        .location()
+        .map(|l| l.to_string())
+        .unwrap_or_else(|| "<unknown location>".to_string());
+    let thread = std::thread::current();
+    format!(
+        "mp3rgui {} panicked on thread '{}' at {location}:\n{msg}",
+        env!("CARGO_PKG_VERSION"),
+        thread.name().unwrap_or("<unnamed>"),
+    )
+}
+
+/// Best-effort: any I/O failure just means no log file, never a panic.
+fn write_log(message: &str) -> Option<PathBuf> {
+    let path = log_path()?;
+    std::fs::create_dir_all(path.parent()?).ok()?;
+    let truncate = std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_LOG_BYTES);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(!truncate)
+        .truncate(truncate)
+        .open(&path)
+        .ok()?;
+    let unix_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    writeln!(file, "[unix {unix_secs}] {message}\n").ok()?;
+    Some(path)
+}


### PR DESCRIPTION
Closes #297

## Summary

Installs a panic hook in `mp3rgui` so a panic is no longer a silent death on the windowed build (no console under `windows_subsystem = "windows"`). Implements the scope agreed in #297:

- **Log first**: the default hook still prints to stderr for terminal users, then the message, location, thread, and version are appended to `panic.log` in the eframe data dir (next to `app.ron`, so a portable install leaves no new directory behind). The file is truncated once it passes 64 KiB.
- **Dialog last, main thread only**: an `rfd` error dialog with the panic text, the log path, and a pointer to the issue tracker. Worker-thread panics (which the app survives) log without a dialog. The dialog is wrapped in `catch_unwind` and treated as best-effort; if the platform state is too broken to show it, behavior is no worse than today.
- **Re-entrancy guard**: a panic inside the hook cannot recurse into it.

No new dependencies; `rfd` was already used for the startup-error dialog.

## Verification

- `cargo fmt`, `cargo clippy`, `cargo test` clean on the `mp3rgui` manifest.
- Smoke-tested on macOS with a temporary forced worker-thread panic: the default stderr output appears and `panic.log` is written with version, thread, location, and message; no dialog for the non-main thread, as intended.
- The main-thread dialog path reuses the same `rfd::MessageDialog` shape as the existing startup-error dialog from #282.