### PR TITLE
Retry temp file ops on Windows sharing violations

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -652,20 +652,49 @@ fn temp_sibling_path(file: &Path, ext: &str) -> std::path::PathBuf {
     ))
 }
 
+/// Retry `op` on transient Windows sharing violations (issue #303).
+///
+/// On SMB shares an antivirus scanner, Windows Search, or the SMB
+/// redirector's handle caching can briefly hold the temp file between our
+/// close and the next open, failing it with `ERROR_SHARING_VIOLATION` (32)
+/// or `ERROR_LOCK_VIOLATION` (33). Back off and retry; any other error is
+/// returned immediately. No-op wrapper on non-Windows.
+#[cfg(windows)]
+fn retry_sharing_violation<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    let mut delay = std::time::Duration::from_millis(10);
+    for _ in 0..8 {
+        match op() {
+            Err(e) if matches!(e.raw_os_error(), Some(32) | Some(33)) => {
+                std::thread::sleep(delay);
+                delay *= 2;
+            }
+            other => return other,
+        }
+    }
+    op()
+}
+
+#[cfg(not(windows))]
+fn retry_sharing_violation<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    op()
+}
+
 /// Copy `original`'s permissions onto `temp`, fsync it, and rename it over
 /// `original` (issue #227).
 fn persist_temp(original: &Path, temp: &Path) -> Result<()> {
     let finish = || -> std::io::Result<()> {
         // fsync needs a writable handle on Windows, and must happen before
         // the permission copy in case the original mode is read-only.
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(temp)?
-            .sync_all()?;
+        retry_sharing_violation(|| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(temp)?
+                .sync_all()
+        })?;
         if let Ok(meta) = std::fs::metadata(original) {
-            std::fs::set_permissions(temp, meta.permissions())?;
+            retry_sharing_violation(|| std::fs::set_permissions(temp, meta.permissions()))?;
         }
-        std::fs::rename(temp, original)
+        retry_sharing_violation(|| std::fs::rename(temp, original))
     };
     finish().map_err(|e| Error::io_write(original, e))
 }
@@ -693,7 +722,7 @@ where
         Ok(value)
     });
     if result.is_err() {
-        let _ = std::fs::remove_file(&temp_path);
+        let _ = retry_sharing_violation(|| std::fs::remove_file(&temp_path));
     }
     result
 }


### PR DESCRIPTION
Fixes #303

## Problem

On SMB shares, an antivirus scanner, Windows Search, or the SMB redirector's handle caching can briefly hold the `.mp3rgain_temp_*` file between our close and the next open. The fsync reopen or rename in `persist_temp` then fails with `ERROR_SHARING_VIOLATION`, and the cleanup delete fails too (`CANNOT DELETE`), leaving the temp file behind. This is timing-dependent, which matches the reported symptom: a random single file fails occasionally and a retry always succeeds.

## Fix

Add `retry_sharing_violation`, a small helper that retries an I/O operation with exponential backoff (10ms doubling, 8 retries, ~2.5s total) when it fails with `ERROR_SHARING_VIOLATION` (32) or `ERROR_LOCK_VIOLATION` (33). Applied to the fsync reopen, permission copy, rename, and the cleanup `remove_file` in `with_temp_file`. On non-Windows platforms the helper is a pass-through.

## Verification

- `cargo build --release`, `cargo test` (167 tests): all pass on macOS
- `cargo check --target x86_64-pc-windows-msvc`: passes, so the `#[cfg(windows)]` branch type-checks
- The actual SMB race is environment-dependent and not reproducible in CI; the retry pattern is the standard mitigation for this class of transient failure on Windows

Diagnosis was based on the Process Monitor log provided by @boydfields in #303; credited as co-author.