### PR TITLE
Skip AAC files in write_album_minmax

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -753,16 +753,25 @@ pub fn read_mtime(path: &Path) -> Option<SystemTime> {
 ///
 /// Each file is paired with the `(max, min)` range from
 /// [`ApplyReport::gain_range`] so the apply pass's scan is reused instead of
-/// re-analyzing every file (issue #232); files without one (AAC members,
-/// zero-frame applies, failed applies) fall back to a fresh `analyze()`.
+/// re-analyzing every file (issue #232); files without one (zero-frame
+/// applies, failed applies) fall back to a fresh `analyze()`.
 ///
-/// AAC members are skipped — the MP3 analyzer rejects them and mp3gain has no
-/// AAC. Best-effort: a failed scan or tag write on one file is ignored so a
+/// AAC members are filtered out up front (issue #307): `MP3GAIN_ALBUM_MINMAX`
+/// is an MP3/APEv2 concept, and the `analyze()` fallback is the raw MP3 frame
+/// scanner, which can false-sync on MP4 bytes and "succeed" with garbage
+/// values, skewing the album range and appending an APEv2 tag after the MP4
+/// data. Best-effort: a failed scan or tag write on one file is ignored so a
 /// metadata hiccup never fails the album operation. Intended for the default
 /// APEv2 path; skip the call when writing ID3v2 (`-s i`) or when stored-tag
 /// writing is disabled.
 pub fn write_album_minmax(files: &[(&Path, Option<(u8, u8)>)]) {
     use rayon::prelude::*;
+
+    let files: Vec<(&Path, Option<(u8, u8)>)> = files
+        .iter()
+        .copied()
+        .filter(|&(file, _)| !mp4meta::is_aac_file(file))
+        .collect();
 
     // The fallback analyze() is a full-file frame walk, so run the range
     // collection in parallel like the apply pass that precedes it (#252).


### PR DESCRIPTION
Closes #307

`write_album_minmax` had no file-type filter. AAC members never carry a gain range from the apply report, so the function fell back to `crate::analyze()`, the raw MP3 frame scanner. When the MP4 byte stream happens to contain MP3-syncable patterns, the scan "succeeds" with garbage values, which had two consequences: an APEv2 `MP3GAIN_ALBUM_MINMAX` tag appended after the MP4 data (invalid MP4 structure), and a garbage min/max polluting the album-wide range written to every MP3 in the same album.

## Fix

Filter on `mp4meta::is_aac_file` at the top of `write_album_minmax` itself, as proposed in the issue. AAC members are excluded from both the range collection and the tag write, and since the filter lives inside the function, the unfiltered call sites in the CLI (`src/commands/replaygain.rs`) and the GUI (`mp3rgui/src/worker.rs`) are both covered without changes.

The `mp3rgain_undo` / `mp3rgain_minmax` freeform entries in the MP4 metadata are intended behavior and unaffected; only the APEv2 append is removed.

## Verification

- `cargo build` / `cargo test`: 167 tests pass
- `cargo clippy --all-targets`: no new warnings (two pre-existing ones in bs1770/replaygain test code from a newer clippy, untouched)
- `cargo fmt -- --check`: clean

Reported by skamp on the HydrogenAudio thread (Reply #46).