### PR TITLE
Remove stale gain tags on undo

### DIFF
--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1426,7 +1426,11 @@ pub fn undo_aac_gain(file_path: &Path) -> Result<usize> {
     let analysis = analyze_aac_gains_from_data(&data)?;
     let modified = apply_aac_gain_to_data(&mut data, &analysis, -undo_gain);
 
-    let final_data = mp4meta::update_mp4_undo_metadata(&data, &mp4meta::UndoTags::default())?;
+    let no_undo = mp4meta::update_mp4_undo_metadata(&data, &mp4meta::UndoTags::default())?;
+    // Issue #306: the REPLAYGAIN_* freeform values were written as residuals
+    // of the gained audio, so after the rollback they are stale; drop them
+    // before the single atomic write.
+    let final_data = mp4meta::update_mp4_metadata(&no_undo, &mp4meta::ReplayGainTags::default())?;
     crate::apply::atomic_write(file_path, &final_data)?;
 
     Ok(modified)

--- a/src/ape.rs
+++ b/src/ape.rs
@@ -516,6 +516,24 @@ pub(crate) fn remove_ape_replaygain(file_path: &Path) -> Result<()> {
     rewrite_ape_tail(file_path, |tag| tag.remove_replaygain())
 }
 
+/// Post-undo cleanup for cross-container layouts (issue #306): drop the
+/// `REPLAYGAIN_*` items and `MP3GAIN_ALBUM_MINMAX`, all of which described
+/// the pre-undo audio, but keep any `MP3GAIN_UNDO` / `MP3GAIN_MINMAX`. Files
+/// carrying none of them are left untouched rather than rewritten.
+pub(crate) fn remove_ape_undone_gain_values(file_path: &Path) -> Result<()> {
+    let has_stale = read_ape_tag_from_file(file_path)?.is_some_and(|tag| {
+        REPLAYGAIN_KEYS.iter().any(|k| tag.get(k).is_some())
+            || tag.get(TAG_MP3GAIN_ALBUM_MINMAX).is_some()
+    });
+    if !has_stale {
+        return Ok(());
+    }
+    rewrite_ape_tail(file_path, |tag| {
+        tag.remove_replaygain();
+        tag.remove(TAG_MP3GAIN_ALBUM_MINMAX);
+    })
+}
+
 /// Add (or replace) the `MP3GAIN_ALBUM_MINMAX` item in `file_path`'s APEv2
 /// tag, preserving all other items. mp3gain writes this album-wide
 /// post-apply `global_gain` range (`min,max`) in album (`-a`) mode (issue

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,7 +1,7 @@
 use crate::analysis::{analyze_data, ChannelMode};
 use crate::ape::{
     parse_undo_values, parse_undo_wrap, read_ape_tag, replace_ape_tag, ApeReplayGain,
-    TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
+    TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
 use crate::frame::{apply_gain_to_data, scan_gain_range, GainMode, SaturationStats};
@@ -314,6 +314,11 @@ pub fn undo_gain(file_path: &Path) -> Result<usize> {
 
     tag.remove(TAG_MP3GAIN_UNDO);
     tag.remove(TAG_MP3GAIN_MINMAX);
+    // Issue #306: the album range and the REPLAYGAIN_* residuals described
+    // the gained audio; after the rollback they are simply wrong, so drop
+    // them in the same write.
+    tag.remove(TAG_MP3GAIN_ALBUM_MINMAX);
+    tag.remove_replaygain();
 
     let new_data = replace_ape_tag(&data, &tag);
     crate::apply::atomic_write(file_path, &new_data)?;

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -28,6 +28,15 @@ const ALL_RG_DESCRIPTIONS: &[&str] = &[
     TAG_REPLAYGAIN_ALGORITHM,
 ];
 
+/// The `REPLAYGAIN_*` value descriptions only (no undo/minmax).
+const RG_VALUE_DESCRIPTIONS: &[&str] = &[
+    TAG_REPLAYGAIN_TRACK_GAIN,
+    TAG_REPLAYGAIN_TRACK_PEAK,
+    TAG_REPLAYGAIN_ALBUM_GAIN,
+    TAG_REPLAYGAIN_ALBUM_PEAK,
+    TAG_REPLAYGAIN_ALGORITHM,
+];
+
 /// ReplayGain and undo data stored in ID3v2 TXXX frames
 #[derive(Debug, Clone, Default)]
 pub struct Id3v2ReplayGain {
@@ -212,11 +221,35 @@ pub fn undo_gain_id3v2(path: &Path) -> Result<usize> {
     crate::apply::with_temp_file(path, |original, temp| {
         std::fs::write(temp, &data).map_err(|e| Error::io_write(original, e))?;
         let mut tag = read_tag(temp)?;
-        remove_txxx_ci(&mut tag, TAG_MP3GAIN_UNDO);
-        remove_txxx_ci(&mut tag, TAG_MP3GAIN_MINMAX);
+        // Issue #306: everything mp3rgain stored (undo, minmax, and the
+        // REPLAYGAIN_* residuals) described the gained audio, so strip it
+        // all in the same write.
+        for desc in ALL_RG_DESCRIPTIONS {
+            remove_txxx_ci(&mut tag, desc);
+        }
         write_tag_direct(temp, &mut tag)
     })?;
     Ok(frames)
+}
+
+/// Post-undo cleanup for cross-container layouts (issue #306): drop only the
+/// `REPLAYGAIN_*` TXXX frames, leaving any `MP3GAIN_UNDO` / `MP3GAIN_MINMAX`
+/// alone. Files without ReplayGain frames are left untouched rather than
+/// rewritten.
+pub(crate) fn remove_id3v2_rg_values(path: &Path) -> Result<()> {
+    let mut tag = read_tag(path)?;
+    let has_rg = tag.extended_texts().any(|t| {
+        RG_VALUE_DESCRIPTIONS
+            .iter()
+            .any(|d| t.description.eq_ignore_ascii_case(d))
+    });
+    if !has_rg {
+        return Ok(());
+    }
+    for desc in RG_VALUE_DESCRIPTIONS {
+        remove_txxx_ci(&mut tag, desc);
+    }
+    write_tag(path, &mut tag)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,16 +210,31 @@ pub fn undo_gain_auto(file_path: &Path, layout: TagLayout) -> Result<usize> {
             .is_some_and(|rg| rg.undo.is_some())
     };
 
-    if layout.mp3gain_in_id3v2() {
-        if id3v2_has_undo() || !ape_has_undo() {
-            return id3v2::undo_gain_id3v2(file_path);
+    let use_id3v2 = if layout.mp3gain_in_id3v2() {
+        id3v2_has_undo() || !ape_has_undo()
+    } else {
+        !ape_has_undo() && id3v2_has_undo()
+    };
+
+    let frames = if use_id3v2 {
+        id3v2::undo_gain_id3v2(file_path)?
+    } else {
+        gain::undo_gain(file_path)?
+    };
+
+    // Issue #306: under the split layout the REPLAYGAIN_* values live in the
+    // container that did not hold the undo tag, and they described the
+    // pre-undo audio. Strip stale copies there too. Best-effort: the rollback
+    // already succeeded, so a metadata hiccup here must not turn the undo
+    // into an error.
+    if frames > 0 {
+        if use_id3v2 {
+            let _ = ape::remove_ape_undone_gain_values(file_path);
+        } else {
+            let _ = id3v2::remove_id3v2_rg_values(file_path);
         }
-        return gain::undo_gain(file_path);
     }
-    if ape_has_undo() || !id3v2_has_undo() {
-        return gain::undo_gain(file_path);
-    }
-    id3v2::undo_gain_id3v2(file_path)
+    Ok(frames)
 }
 
 /// Delete ReplayGain / undo tags, auto-dispatching by file format and tag mode.

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -654,7 +654,7 @@ pub fn write_replaygain_tags(file_path: &Path, tags: &ReplayGainTags) -> Result<
 }
 
 /// Update MP4 metadata with new ReplayGain tags
-fn update_mp4_metadata(data: &[u8], tags: &ReplayGainTags) -> Result<Vec<u8>> {
+pub(crate) fn update_mp4_metadata(data: &[u8], tags: &ReplayGainTags) -> Result<Vec<u8>> {
     let make_ilst = |existing: &[u8]| create_ilst_box(tags, existing);
     rebuild_mp4_with_ilst(data, make_ilst)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -667,3 +667,107 @@ fn test_apply_album_gain_writes_ape_album_replaygain_tags() {
 
     cleanup(&path);
 }
+
+/// Issue #306: undoing must also drop `MP3GAIN_ALBUM_MINMAX` and the
+/// `REPLAYGAIN_*` residuals from the APEv2 tag; they described the gained
+/// audio and are wrong once it is rolled back.
+#[test]
+fn test_undo_removes_album_minmax_and_replaygain_ape() {
+    use mp3rgain::apply::{apply_with_options, ApplyOptions};
+    use mp3rgain::{
+        ape, replaygain, TagLayout, TAG_MP3GAIN_ALBUM_MINMAX, TAG_REPLAYGAIN_TRACK_GAIN,
+        TAG_REPLAYGAIN_TRACK_PEAK,
+    };
+
+    let path = copy_test_file("test_stereo.mp3");
+    let result = replaygain::analyze_track_with_index(&path, None).unwrap();
+    let mut opts = ApplyOptions::new(2);
+    opts.track_result = Some(result);
+    opts.write_replaygain_tags = true;
+    opts.tag_layout = TagLayout::Ape;
+    apply_with_options(&path, &opts).unwrap();
+    ape::write_ape_album_minmax(&path, 10, 200).unwrap();
+
+    let frames = undo_gain(&path).unwrap();
+    assert!(frames > 0, "undo should have modified frames");
+
+    if let Some(tag) = read_ape_tag_from_file(&path).unwrap() {
+        assert!(tag.get(TAG_MP3GAIN_UNDO).is_none(), "undo tag left behind");
+        assert!(
+            tag.get(TAG_MP3GAIN_ALBUM_MINMAX).is_none(),
+            "MP3GAIN_ALBUM_MINMAX left behind"
+        );
+        assert!(
+            tag.get(TAG_REPLAYGAIN_TRACK_GAIN).is_none(),
+            "stale REPLAYGAIN_TRACK_GAIN left behind"
+        );
+        assert!(
+            tag.get(TAG_REPLAYGAIN_TRACK_PEAK).is_none(),
+            "stale REPLAYGAIN_TRACK_PEAK left behind"
+        );
+    }
+    cleanup(&path);
+}
+
+/// Issue #306, split layout: the `REPLAYGAIN_*` values live in ID3v2 while
+/// the undo tag lives in APEv2. Undoing via the APE path must also strip the
+/// now-stale ID3v2 values.
+#[test]
+fn test_undo_auto_removes_stale_id3v2_replaygain_in_split_layout() {
+    use mp3rgain::apply::{apply_with_options, ApplyOptions};
+    use mp3rgain::{read_id3v2_replaygain, replaygain, undo_gain_auto, TagLayout};
+
+    let path = copy_test_file("test_stereo.mp3");
+    let result = replaygain::analyze_track_with_index(&path, None).unwrap();
+    let mut opts = ApplyOptions::new(2);
+    opts.track_result = Some(result);
+    opts.write_replaygain_tags = true;
+    opts.tag_layout = TagLayout::Split;
+    apply_with_options(&path, &opts).unwrap();
+
+    let rg = read_id3v2_replaygain(&path).unwrap();
+    assert!(rg.track_gain.is_some(), "setup: ID3v2 RG values expected");
+
+    let frames = undo_gain_auto(&path, TagLayout::Split).unwrap();
+    assert!(frames > 0, "undo should have modified frames");
+
+    let rg = read_id3v2_replaygain(&path).unwrap();
+    assert!(
+        rg.track_gain.is_none() && rg.track_peak.is_none(),
+        "stale ID3v2 REPLAYGAIN_* left behind"
+    );
+    if let Some(tag) = read_ape_tag_from_file(&path).unwrap() {
+        assert!(tag.get(TAG_MP3GAIN_UNDO).is_none(), "undo tag left behind");
+    }
+    cleanup(&path);
+}
+
+/// Issue #306, all-ID3v2 layout: the ID3v2 undo path must strip the
+/// `REPLAYGAIN_*` TXXX frames along with undo/minmax.
+#[test]
+fn test_undo_removes_stale_replaygain_in_id3v2_layout() {
+    use mp3rgain::apply::{apply_with_options, ApplyOptions};
+    use mp3rgain::{read_id3v2_replaygain, replaygain, undo_gain_auto, TagLayout};
+
+    let path = copy_test_file("test_stereo.mp3");
+    let result = replaygain::analyze_track_with_index(&path, None).unwrap();
+    let mut opts = ApplyOptions::new(2);
+    opts.track_result = Some(result);
+    opts.write_replaygain_tags = true;
+    opts.tag_layout = TagLayout::Id3v2;
+    apply_with_options(&path, &opts).unwrap();
+
+    let frames = undo_gain_auto(&path, TagLayout::Id3v2).unwrap();
+    assert!(frames > 0, "undo should have modified frames");
+
+    let rg = read_id3v2_replaygain(&path).unwrap();
+    assert!(
+        rg.undo.is_none() && rg.minmax.is_none(),
+        "ID3v2 undo/minmax left behind"
+    );
+    assert!(
+        rg.track_gain.is_none() && rg.track_peak.is_none(),
+        "stale ID3v2 REPLAYGAIN_* left behind"
+    );
+    cleanup(&path);
+}


### PR DESCRIPTION
Closes #306

`mp3rgain -u` restored the audio but only removed `MP3GAIN_UNDO` and `MP3GAIN_MINMAX`, leaving behind `MP3GAIN_ALBUM_MINMAX` (APEv2) and all `REPLAYGAIN_*` values (APEv2, ID3v2 TXXX, and MP4 freeform). mp3rgain writes `REPLAYGAIN_*` as the residual relative to the gained audio, so once the audio is rolled back those values are simply wrong: after undoing a large apply, the file still claimed values like `REPLAYGAIN_TRACK_GAIN: +0.52 dB`.

## Fix

All three undo paths now drop the stale values in the same write that removes the undo tag:

- **APEv2** (`gain::undo_gain`): also removes `MP3GAIN_ALBUM_MINMAX` and the `REPLAYGAIN_*` items.
- **ID3v2** (`id3v2::undo_gain_id3v2`): removes all mp3rgain TXXX descriptions (undo, minmax, and the `REPLAYGAIN_*` frames).
- **AAC** (`aac::undo_aac_gain`): clears the `REPLAYGAIN_*` freeform values alongside the undo/minmax entries, still in a single atomic write.

Under the split layout (default), the `REPLAYGAIN_*` values live in ID3v2 while the undo tag lives in APEv2, so a container-local fix would not cover the reported case. `undo_gain_auto` now also strips stale values from the container that did not hold the undo tag: `REPLAYGAIN_*` TXXX frames after an APE-path undo, and `REPLAYGAIN_*` + `MP3GAIN_ALBUM_MINMAX` APE items after an ID3v2-path undo. This cross-container pass is best-effort (the rollback already succeeded, so a metadata hiccup must not turn the undo into an error), skips files where nothing is present rather than rewriting them, and never touches `MP3GAIN_UNDO`/`MP3GAIN_MINMAX` in the other container.

Zero-delta undos (`Ok(0)`) keep their early-return behavior and do not touch any tags, since the audio and the stored values are still in agreement. Tags from other tools that mp3rgain never wrote are untouched, per the issue scope.

## Verification

- Three new integration tests cover the APEv2 layout (`MP3GAIN_ALBUM_MINMAX` + `REPLAYGAIN_*` gone after undo), the split layout (stale ID3v2 values stripped after an APE-path undo), and the all-ID3v2 layout.
- Manual check of the reported repro: `-r -c` then `-u` then `-s c` now prints `(no gain tags found)`.
- `cargo test`: 170 tests pass; `cargo fmt -- --check` clean; `cargo clippy --all-targets`: no new warnings.

Reported by skamp on the HydrogenAudio thread (Reply #46).