### PR TITLE
Undo before deleting tags with -u -s d

### DIFF
--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -111,7 +111,7 @@ Stored tag handling mode:
 Check/show stored tag information.
 .TP
 .B d
-Delete stored tag information.
+Delete stored tag information. Combined with \fB\-u\fR, the frame-level gain is undone first, then the remaining tags are deleted; deleting alone would destroy the undo information.
 .TP
 .B s
 Skip (ignore) stored tag information.

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -38,7 +38,7 @@ pub fn print_usage() {
     println!("    -x          Only find max amplitude of file");
     println!("    -s <mode>   Stored tag handling:");
     println!("                  c = check/show stored tag info");
-    println!("                  d = delete stored tag info");
+    println!("                  d = delete stored tag info (with -u: undo gain first)");
     println!("                  s = skip (don't write) stored tag info");
     println!("                  r = force recalculation (default; kept for compatibility)");
     println!("                  R = reuse stored ReplayGain tags with -r/-a, re-analyzing");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,7 +82,9 @@ pub fn run(mut opts: Options) -> Result<()> {
     }
 
     if opts.stored_tag_mode == StoredTagMode::Delete {
-        // -s d: delete stored tag info
+        // -s d: delete stored tag info. With -u, cmd_delete_tags undoes the
+        // frame-level gain first: deleting first would destroy MP3GAIN_UNDO
+        // and make the applied gain permanently irreversible (issue #305).
         return cmd_delete_tags(&opts.files, &opts);
     }
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -95,15 +95,17 @@ pub fn cmd_delete_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
     let dry_run_prefix = opts.dry_run_prefix();
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
+        let action = match (opts.dry_run, opts.undo) {
+            (true, true) => "Would undo gain changes and delete",
+            (true, false) => "Would delete",
+            (false, true) => "Undoing gain changes and deleting",
+            (false, false) => "Deleting",
+        };
         println!(
             "{}{} {} ReplayGain tags from {} file(s)",
             dry_run_prefix,
             "mp3rgain".green().bold(),
-            if opts.dry_run {
-                "Would delete"
-            } else {
-                "Deleting"
-            },
+            action,
             files.len()
         );
         println!();
@@ -123,12 +125,12 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
 
     if opts.dry_run {
         if opts.output_format == OutputFormat::Text && !opts.quiet {
-            writeln!(
-                out,
-                "  {} [DRY RUN] {} (would delete tags)",
-                "~".cyan(),
-                filename
-            )?;
+            let action = if opts.undo {
+                "would undo gain changes, then delete tags"
+            } else {
+                "would delete tags"
+            };
+            writeln!(out, "  {} [DRY RUN] {} ({})", "~".cyan(), filename, action)?;
         }
         return Ok((
             JsonFileResult {
@@ -143,6 +145,22 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
 
     let original_mtime = save_original_mtime(file, opts);
 
+    // -u -s d (issue #305): undo the frame-level gain before the tags,
+    // including MP3GAIN_UNDO, are destroyed. A file with nothing to undo
+    // falls through to the plain delete; any other undo failure skips the
+    // delete so the undo info survives for another attempt.
+    let mut undone_frames: Option<usize> = None;
+    if opts.undo {
+        use mp3rgain::Error as GainError;
+        match mp3rgain::undo_gain_auto(file, opts.tag_layout) {
+            Ok(frames) => undone_frames = Some(frames),
+            Err(GainError::NoApeTag | GainError::NoUndoTag | GainError::NoId3v2UndoTag) => {
+                undone_frames = Some(0);
+            }
+            Err(e) => return Ok((report_file_error(file, filename, e, opts), out)),
+        }
+    }
+
     let delete_result = mp3rgain::delete_gain_tags_auto(file, opts.tag_layout);
 
     match delete_result {
@@ -152,12 +170,20 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
             }
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
-                writeln!(out, "  {} {} (tags deleted)", "v".green(), filename)?;
+                let note = match undone_frames {
+                    Some(frames) if frames > 0 => {
+                        format!("{} frames restored, tags deleted", frames)
+                    }
+                    Some(_) => "no changes to undo, tags deleted".to_string(),
+                    None => "tags deleted".to_string(),
+                };
+                writeln!(out, "  {} {} ({})", "v".green(), filename, note)?;
             }
             Ok((
                 JsonFileResult {
                     file: file.display().to_string(),
                     status: Some(FileStatus::Success),
+                    frames: undone_frames,
                     ..Default::default()
                 },
                 out,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -308,3 +308,57 @@ fn track_at_zero_steps_still_writes_replaygain_tags() {
         "an already-normalized track should keep its ReplayGain tags"
     );
 }
+
+/// Issue #305: `-u -s d` must undo the frame-level gain before deleting the
+/// tags. The old dispatch deleted first, destroying MP3GAIN_UNDO and making
+/// the applied gain permanently irreversible.
+#[test]
+fn undo_with_delete_tags_undoes_before_deleting() {
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+    let original_avg = mp3rgain::analyze(file).unwrap().avg_gain();
+
+    // Apply -2 steps, which records MP3GAIN_UNDO. (Negative, because the
+    // fixture's global_gain values sit at the 255 ceiling, where a positive
+    // apply saturates into a no-op.)
+    let out = run(&["-g", "-2", file.to_str().unwrap()]);
+    assert!(out.status.success(), "apply failed: {:?}", out);
+    assert_ne!(
+        mp3rgain::analyze(file).unwrap().avg_gain(),
+        original_avg,
+        "setup: apply should have changed the gain"
+    );
+
+    let out = run(&["-u", "-s", "d", file.to_str().unwrap()]);
+    assert!(out.status.success(), "undo+delete failed: {:?}", out);
+
+    assert_eq!(
+        mp3rgain::analyze(file).unwrap().avg_gain(),
+        original_avg,
+        "-u -s d did not undo the frame-level gain"
+    );
+    assert!(
+        read_ape_tag_from_file(file).unwrap().is_none()
+            || read_ape_tag_from_file(file)
+                .unwrap()
+                .is_some_and(|t| t.get(TAG_MP3GAIN_UNDO).is_none()),
+        "tags were not deleted"
+    );
+}
+
+/// Issue #305: `-u -s d` on a file that has no undo info must still delete
+/// the tags instead of failing.
+#[test]
+fn undo_with_delete_tags_without_undo_info_still_deletes() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let file = &album.files[0];
+
+    let out = run(&["-u", "-s", "d", file.to_str().unwrap()]);
+    assert!(out.status.success(), "undo+delete failed: {:?}", out);
+    let text = stdout_of(&out);
+    assert!(
+        text.contains("no changes to undo, tags deleted"),
+        "unexpected output: {}",
+        text
+    );
+}


### PR DESCRIPTION
Closes #305

`mp3rgain -u -s d` only deleted the tags and never undid the frame-level gain: the dispatch in `src/commands/mod.rs` checks `StoredTagMode::Delete` before `opts.undo`, so `-s d` returned early and `-u` was silently ignored. Since the deleted tags include `MP3GAIN_UNDO`, the applied gain became permanently impossible to undo.

## Fix

`cmd_delete_tags` now handles the combination itself, per file:

1. With `-u`, run `undo_gain_auto` first. `NoApeTag` / `NoUndoTag` / `NoId3v2UndoTag` are treated as "nothing to undo" and fall through to the delete; any other undo failure reports the error and skips the delete, so the undo info survives for another attempt.
2. Then delete the remaining gain tags as before.

Output makes both steps visible: the header reads `Undoing gain changes and deleting ReplayGain tags from N file(s)`, per-file lines read `(39 frames restored, tags deleted)` or `(no changes to undo, tags deleted)`, and dry-run (`-n`) prints `(would undo gain changes, then delete tags)`. JSON output carries the undone frame count in the existing `frames` field.

Help text (`-s d` line) and the man page document the combination.

## Verification

- Two new CLI tests: `-g -2` then `-u -s d` restores the original `avg_gain` and leaves no tags; `-u -s d` on a file with no undo info still deletes and reports `no changes to undo`. (The apply uses a negative gain because the fixtures' `global_gain` values sit at the 255 ceiling, where a positive apply saturates into a no-op.)
- Manual check of the reported repro: after `-g` + `-u -s d`, the audio is restored and `-s c` shows no tags, instead of the old `tags deleted` with no undo.
- `cargo test`: 169 tests pass; `cargo fmt -- --check` clean; `cargo clippy --all-targets`: no new warnings.

Reported by skamp on the HydrogenAudio thread (Reply #47).

Note: #306 extends what undo itself cleans up; the two changes are independent and merge cleanly in either order.