### PR TITLE
Add --tags-only: write ReplayGain tags without touching the audio

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -294,6 +294,16 @@ Note that this is not an either/or for mp3rgain users: applying gain also writes
 so a tag-aware player and a tag-blind one converge on the same loudness. `-s s` skips the tags if
 you want the bitstream change alone.
 
+The other end of that trade-off is available too: `--tags-only` runs the same analysis
+but writes full `REPLAYGAIN_*` values without modifying a single frame, matching what `loudgain` and
+`rsgain` produce. Use it when the listener should keep the choice of switching ReplayGain off in
+their player; use the default apply when the playback device ignores tags entirely.
+
+```bash
+mp3rgain -a --tags-only *.mp3   # tags only, audio byte-identical
+mp3rgain -a *.mp3               # gain baked into global_gain, plus residual tags
+```
+
 ## Security
 
 See [Security Documentation](security.md) for detailed CVE analysis.

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -86,6 +86,38 @@ but normalizes to the EBU R128 broadcast target of \-23 LUFS.
 Mutually exclusive with
 .BR \-\-rg2 .
 .TP
+.B \-\-tags\-only
+Write the analysis to \fBREPLAYGAIN_*\fR tags and leave the audio untouched, the way
+.BR loudgain (1)
+and
+.BR rsgain (1)
+work. The frame-level
+.I global_gain
+fields are not modified, so a listener can still turn ReplayGain off in their player.
+The tag holds the full gain rather than a residual, and no
+\fBMP3GAIN_UNDO\fR, \fBMP3GAIN_MINMAX\fR or \fBMP3GAIN_ALBUM_MINMAX\fR is written since
+there is no gain change to undo or describe.
+Requires
+.BR \-r ,
+.B \-a
+or
+.BR \-e ,
+and cannot be combined with
+.BR \-g ,
+.BR \-l ,
+.BR \-u ,
+.BR \-w ,
+.B \-x
+or
+.BR "\-s c" / "\-s d" / "\-s s" .
+.B \-d
+and
+.B \-m
+shift the written value instead of the applied gain, and apply exactly (no 1.5 dB
+step rounding, since a tag holds a float).
+.B \-k
+caps the written value at the file's headroom so a player applying the tag cannot clip.
+.TP
 .B \-e
 Skip album analysis even when processing multiple files.
 Apply track gain only.
@@ -198,6 +230,9 @@ Analyze and apply track gain (ReplayGain).
 .TP
 .B mp3rgain \-a *.mp3
 Analyze and apply album gain to all MP3 files.
+.TP
+.B mp3rgain \-a \-\-tags\-only *.mp3
+Write album and track ReplayGain tags without modifying the audio.
 .TP
 .B mp3rgain \-u song.mp3
 Undo previous gain changes.

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -88,6 +88,7 @@ are worth knowing:
 | `-s i` | Put *every* tag in ID3v2 `TXXX`, undo included. Since 3.2.0 the default already writes `REPLAYGAIN_*` to ID3v2, so this is only needed when you want `MP3GAIN_UNDO` there too |
 | `-j <n>` / `--threads <n>` | Worker threads for ReplayGain analysis (default: auto). `MP3RGAIN_THREADS` env var also honored. `-j 1` reproduces mp3gain's serial behavior. See [docs/perf-parallel.md](perf-parallel.md). |
 | `--skip-errors` | Keep album analysis (`-a`) going past unreadable files; failed files are reported and excluded from the album gain |
+| `--tags-only` | Write `REPLAYGAIN_*` tags and leave the audio untouched, the way `loudgain` / `rsgain` do, so the listener can still turn ReplayGain off in their player ([#308](https://github.com/M-Igashi/mp3rgain/issues/308)). The tag holds the full gain instead of mp3gain's residual, and no `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` is written since there is no gain change to reverse. Requires `-r`/`-a`/`-e`; rejected with `-g`, `-l`, `-u`, `-w`, `-x` and `-s c`/`-s d`/`-s s`. Here `-d`/`-m` shift the written value (exactly, with no 1.5 dB step rounding) and `-k` caps it at the file's headroom |
 
 For the full list run `mp3rgain --help`.
 

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -742,6 +742,94 @@ pub fn read_mtime(path: &Path) -> Option<SystemTime> {
     std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
 }
 
+/// Values written by [`write_replaygain_tags_only`].
+///
+/// Unlike the apply path these are *absolute*: no gain is baked into the
+/// audio, so the tag carries the full gain a player should apply.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TagsOnlyOptions {
+    /// `REPLAYGAIN_TRACK_GAIN` in dB.
+    pub track_gain_db: f64,
+    /// `REPLAYGAIN_TRACK_PEAK` as a linear peak.
+    pub track_peak: f64,
+    /// `(gain_db, peak)` for the `REPLAYGAIN_ALBUM_*` pair, when the caller
+    /// analyzed an album.
+    pub album: Option<(f64, f64)>,
+    /// Measurement mode, recorded as `REPLAYGAIN_ALGORITHM` in the BS.1770
+    /// modes.
+    pub mode: crate::replaygain::AnalysisMode,
+    /// MP3 only: which container the values go in.
+    pub tag_layout: TagLayout,
+    /// Restore the file's mtime after writing.
+    pub preserve_timestamp: bool,
+}
+
+impl TagsOnlyOptions {
+    /// Construct with the track values; album stays unset and the layout
+    /// defaults to [`TagLayout::Split`].
+    pub fn new(track_gain_db: f64, track_peak: f64, mode: crate::replaygain::AnalysisMode) -> Self {
+        Self {
+            track_gain_db,
+            track_peak,
+            album: None,
+            mode,
+            tag_layout: TagLayout::default(),
+            preserve_timestamp: false,
+        }
+    }
+}
+
+/// Tags-only mode (issue #308): record ReplayGain metadata without touching a
+/// single audio frame, the way `loudgain` / `rsgain` work.
+///
+/// The audio is left byte-identical, so the listener keeps the choice of
+/// enabling or disabling ReplayGain in their player. Nothing that describes a
+/// gain change is written: no `MP3GAIN_UNDO`, no `MP3GAIN_MINMAX`, no
+/// `MP3GAIN_ALBUM_MINMAX`. Any that a previous real apply left behind stay
+/// untouched: they still describe the audio as it currently is.
+pub fn write_replaygain_tags_only(file_path: &Path, opts: &TagsOnlyOptions) -> Result<()> {
+    let original_mtime = if opts.preserve_timestamp {
+        read_mtime(file_path)
+    } else {
+        None
+    };
+
+    let values = RgResidual {
+        track_gain_db: opts.track_gain_db,
+        track_peak: opts.track_peak,
+        album: opts.album,
+        mode: opts.mode,
+    };
+
+    if mp4meta::is_aac_file(file_path) {
+        let mut tags = mp4meta::ReplayGainTags::default();
+        tags.set_track(values.track_gain_db, values.track_peak);
+        if let Some((album_gain, album_peak)) = values.album {
+            tags.set_album(album_gain, album_peak);
+        }
+        tags.set_algorithm(values.mode);
+        mp4meta::write_replaygain_tags(file_path, &tags)?;
+    } else {
+        match opts.tag_layout {
+            // Split keeps the authoritative values in ID3v2, so an APEv2 copy
+            // from mp3gain or an earlier `-s a` run has to go, the same rule
+            // the apply path follows.
+            TagLayout::Split => {
+                ape::remove_ape_replaygain(file_path)?;
+                id3v2::write_id3v2_replaygain(file_path, &values.to_id3v2())?;
+            }
+            TagLayout::Id3v2 => id3v2::write_id3v2_replaygain(file_path, &values.to_id3v2())?,
+            TagLayout::Ape => ape::write_ape_replaygain(file_path, &values.to_ape())?,
+        }
+    }
+
+    if let Some(mtime) = original_mtime {
+        restore_timestamp(file_path, mtime);
+    }
+    Ok(())
+}
+
 /// Aggregate the post-apply `global_gain` range across an album's MP3 files
 /// and write `MP3GAIN_ALBUM_MINMAX` (`min,max`) to each, matching mp3gain's
 /// album (`-a`) mode (issue #210).

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -46,6 +46,10 @@ pub struct Options {
     // --true-peak: BS.1770-4 Annex 2 true peak for REPLAYGAIN_*_PEAK in the
     // BS.1770 modes (issue #292). Requires --rg2 or --r128.
     pub true_peak: bool,
+    // --tags-only: analyze as usual but write absolute REPLAYGAIN_* values
+    // without modifying a single audio frame (issue #308), the loudgain /
+    // rsgain workflow. Requires -r / -a / -e.
+    pub tags_only: bool,
     pub skip_album: bool,         // -e: skip album analysis
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files
@@ -88,7 +92,7 @@ impl Options {
         self.use_stored_tags
             && !self.force_recalc
             && self.analysis_mode == AnalysisMode::Rg1
-            && self.gain_modifier_steps() == 0
+            && self.target_offset_db() == 0.0
     }
 
     /// Combined `-m` (steps) and `-d` (dB) modifier expressed as mp3 gain steps.
@@ -96,5 +100,20 @@ impl Options {
     /// round to zero, matching mp3gain's quantized step model.
     pub fn gain_modifier_steps(&self) -> i32 {
         self.gain_modifier + mp3rgain::db_to_steps(self.gain_modifier_db)
+    }
+
+    /// How far `-d` / `-m` shift the target, in dB.
+    ///
+    /// Normally this is [`Self::gain_modifier_steps`] converted back to dB,
+    /// because the shift has to land on a whole `global_gain` step. In
+    /// `--tags-only` mode nothing is quantized, since the shift only moves a
+    /// float in a tag, so `-d` applies exactly and `-m` contributes its steps
+    /// (issue #308).
+    pub fn target_offset_db(&self) -> f64 {
+        if self.tags_only {
+            self.gain_modifier_db + mp3rgain::steps_to_db(self.gain_modifier)
+        } else {
+            mp3rgain::steps_to_db(self.gain_modifier_steps())
+        }
     }
 }

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -56,6 +56,12 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
             continue;
         }
 
+        if arg == "--tags-only" {
+            opts.tags_only = true;
+            i += 1;
+            continue;
+        }
+
         if arg == "--help" {
             print_usage();
             std::process::exit(0);
@@ -320,6 +326,38 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         anyhow::bail!("--true-peak requires --rg2 or --r128");
     }
 
+    // --tags-only (issue #308) writes ReplayGain metadata and nothing else, so
+    // it needs an analysis to write and must not be paired with a flag that
+    // would modify the audio or suppress the tag write. Rejected rather than
+    // silently ignored: a user who asked for both meant one of them, and
+    // guessing wrong here rewrites their files.
+    if opts.tags_only {
+        if !(opts.track_gain || opts.album_gain || opts.skip_album) {
+            anyhow::bail!("--tags-only requires -r, -a or -e (there is no analysis to write)");
+        }
+        let conflict = if opts.gain_steps.is_some() {
+            Some("-g")
+        } else if opts.channel_gain.is_some() {
+            Some("-l")
+        } else if opts.undo {
+            Some("-u")
+        } else if opts.wrap_gain {
+            Some("-w")
+        } else if opts.max_amplitude_only {
+            Some("-x")
+        } else {
+            match opts.stored_tag_mode {
+                StoredTagMode::Check => Some("-s c"),
+                StoredTagMode::Delete => Some("-s d"),
+                StoredTagMode::Skip => Some("-s s"),
+                StoredTagMode::None => None,
+            }
+        };
+        if let Some(flag) = conflict {
+            anyhow::bail!("--tags-only cannot be combined with {}", flag);
+        }
+    }
+
     // cmd.exe and PowerShell do not expand `*.mp3` for native programs.
     #[cfg(windows)]
     {
@@ -354,6 +392,81 @@ mod tests {
 
     fn args(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tags_only_requires_an_analysis_flag() {
+        // Issue #308: --tags-only writes what an analysis produced, so on its
+        // own there is nothing to write.
+        assert!(parse_args(&args(&["--tags-only", "a.mp3"])).is_err());
+        for flag in ["-r", "-a", "-e"] {
+            let opts = parse_args(&args(&["--tags-only", flag, "a.mp3"])).unwrap();
+            assert!(opts.tags_only, "{} should enable tags-only", flag);
+        }
+    }
+
+    #[test]
+    fn tags_only_rejects_flags_that_would_modify_audio() {
+        // Rejected rather than silently ignored: guessing which half of the
+        // request the user meant would rewrite their files.
+        for conflicting in [
+            vec!["-r", "-g", "2"],
+            vec!["-r", "-l", "0", "2"],
+            vec!["-r", "-u"],
+            vec!["-r", "-w"],
+            vec!["-r", "-x"],
+            vec!["-r", "-s", "s"],
+            vec!["-r", "-s", "d"],
+            vec!["-r", "-s", "c"],
+        ] {
+            let mut argv = vec!["--tags-only"];
+            argv.extend_from_slice(&conflicting);
+            argv.push("a.mp3");
+            assert!(
+                parse_args(&args(&argv)).is_err(),
+                "--tags-only {:?} should be rejected",
+                conflicting
+            );
+        }
+    }
+
+    #[test]
+    fn tags_only_accepts_tag_layout_and_analysis_flags() {
+        for compatible in [
+            vec!["-s", "a"],
+            vec!["-s", "i"],
+            vec!["-s", "R"],
+            vec!["--rg2"],
+            vec!["-k"],
+            vec!["-d", "2"],
+            vec!["-m", "1"],
+            vec!["-p"],
+            vec!["-n"],
+        ] {
+            let mut argv = vec!["--tags-only", "-r"];
+            argv.extend_from_slice(&compatible);
+            argv.push("a.mp3");
+            assert!(
+                parse_args(&args(&argv)).is_ok(),
+                "--tags-only {:?} should be accepted",
+                compatible
+            );
+        }
+    }
+
+    #[test]
+    fn tags_only_target_offset_is_not_step_quantized() {
+        // The apply path has to land on a whole 1.5 dB step, so -d 0.4 rounds
+        // away; a tag holds a float, so it must survive (issue #308).
+        let applied = parse_args(&args(&["-r", "-d", "0.4", "a.mp3"])).unwrap();
+        assert_eq!(applied.target_offset_db(), 0.0);
+
+        let tagged = parse_args(&args(&["-r", "--tags-only", "-d", "0.4", "a.mp3"])).unwrap();
+        assert!((tagged.target_offset_db() - 0.4).abs() < f64::EPSILON);
+
+        // -m still contributes whole steps, converted to dB.
+        let steps = parse_args(&args(&["-r", "--tags-only", "-m", "2", "a.mp3"])).unwrap();
+        assert!((steps.target_offset_db() - mp3rgain::steps_to_db(2)).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -32,6 +32,9 @@ pub fn print_usage() {
     println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
     println!("    --true-peak Measure true peak (BS.1770-4 Annex 2) for REPLAYGAIN_*_PEAK");
     println!("                (requires --rg2 or --r128; default is sample peak)");
+    println!("    --tags-only Write REPLAYGAIN_* tags without changing the audio, so the");
+    println!("                listener can still turn ReplayGain off in their player.");
+    println!("                Needs -r/-a; no undo tag is written (nothing to undo)");
     println!("    -e          Skip album analysis (even with multiple files)");
     println!("    -i <n>      Specify which audio track to process (default: 0)");
     println!("    -u          Undo gain changes (restore from APEv2 tag)");
@@ -70,6 +73,8 @@ pub fn print_usage() {
     println!("    mp3rgain -r -d 4.5 song.mp3    Apply track gain, target +4.5 dB louder");
     println!("    mp3rgain -r song.mp3           Analyze and apply track gain");
     println!("    mp3rgain -a *.mp3              Analyze and apply album gain");
+    println!("    mp3rgain -r --tags-only *.mp3  Tag with track gain, leave audio alone");
+    println!("    mp3rgain -a --tags-only *.mp3  Tag with album+track gain (loudgain style)");
     println!("    mp3rgain -r --rg2 song.mp3     Track gain via ReplayGain 2.0 (BS.1770)");
     println!("    mp3rgain -a --r128 *.mp3       Album gain to the EBU R128 target");
     println!("    mp3rgain -r -m 2 *.mp3         Apply track gain + 2 steps");

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -4,7 +4,7 @@ use mp3rgain::replaygain::{
     self, AlbumAnalysisReport, AlbumGainResult, AudioFileType, ReplayGainResult,
     REPLAYGAIN_REFERENCE_DB,
 };
-use mp3rgain::{steps_to_db, AacAlbumInfo};
+use mp3rgain::AacAlbumInfo;
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -16,7 +16,9 @@ use crate::commands::utils::{
     print_dry_run_notice, run_album_analysis, update_counters,
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
-use crate::processors::replaygain::{process_apply_replaygain_with_album, process_track_gain};
+use crate::processors::replaygain::{
+    capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
+};
 use crate::processors::utils::stored_file_type;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
@@ -24,9 +26,10 @@ use crate::util::get_filename;
 fn print_target_with_modifier(opts: &Options) {
     let mode = opts.analysis_mode;
     let target = mode.target_lufs().unwrap_or(REPLAYGAIN_REFERENCE_DB);
-    let modifier_steps = opts.gain_modifier_steps();
-    if modifier_steps != 0 {
-        let modifier_db = steps_to_db(modifier_steps);
+    // `-d`/`-m` land on whole gain steps when frames are modified, but shift
+    // the tag value exactly in --tags-only mode (issue #308).
+    let modifier_db = opts.target_offset_db();
+    if modifier_db != 0.0 {
         println!(
             "  Target: {:.1} {} ({} {} {} {:+.1} dB modifier)",
             target + modifier_db,
@@ -58,17 +61,31 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     let dry_run_prefix = opts.dry_run_prefix();
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
-        println!(
-            "{}{} Analyzing and {} track gain to {} file(s)",
-            dry_run_prefix,
-            "mp3rgain".green().bold(),
-            if opts.dry_run {
-                "would apply"
-            } else {
-                "applying"
-            },
-            files.len()
-        );
+        if opts.tags_only {
+            println!(
+                "{}{} Analyzing and {} track ReplayGain tags for {} file(s) (audio unchanged)",
+                dry_run_prefix,
+                "mp3rgain".green().bold(),
+                if opts.dry_run {
+                    "would write"
+                } else {
+                    "writing"
+                },
+                files.len()
+            );
+        } else {
+            println!(
+                "{}{} Analyzing and {} track gain to {} file(s)",
+                dry_run_prefix,
+                "mp3rgain".green().bold(),
+                if opts.dry_run {
+                    "would apply"
+                } else {
+                    "applying"
+                },
+                files.len()
+            );
+        }
         print_target_with_modifier(opts);
         println!();
     }
@@ -134,10 +151,15 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         println!(
-            "{}{} Analyzing album gain for {} file(s)",
+            "{}{} Analyzing album gain for {} file(s){}",
             dry_run_prefix,
             "mp3rgain".green().bold(),
-            files.len()
+            files.len(),
+            if opts.tags_only {
+                " (tags only, audio unchanged)"
+            } else {
+                ""
+            }
         );
         print_target_with_modifier(opts);
         println!();
@@ -198,13 +220,30 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let modifier_steps = opts.gain_modifier_steps();
             let modified_gain_steps = album_result.album_gain_steps() + modifier_steps;
 
+            // --tags-only writes the album gain into the tag instead of the
+            // frames, capped at the album peak's headroom under `-k` so every
+            // file in the set still carries the same value (issue #308).
+            let album_tag_gain_db = opts.tags_only.then(|| {
+                capped_tag_gain(
+                    album_result.album_gain_db() + opts.target_offset_db(),
+                    album_result.album_peak(),
+                    opts.prevent_clipping,
+                )
+            });
+
             let is_lufs = opts.analysis_mode.target_lufs().is_some();
             let json_album = JsonAlbumResult {
                 loudness_db: album_result.album_loudness_db(),
                 loudness_lufs: is_lufs.then(|| album_result.album_loudness_db()),
                 analysis_mode: Some(opts.analysis_mode.name()),
                 gain_db: album_result.album_gain_db(),
-                gain_steps: modified_gain_steps,
+                // Nothing is applied to the audio in --tags-only mode.
+                gain_steps: if opts.tags_only {
+                    0
+                } else {
+                    modified_gain_steps
+                },
+                tag_gain_db: album_tag_gain_db,
                 peak: album_result.album_peak(),
             };
 
@@ -220,16 +259,22 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                     album_result.album_loudness_db(),
                     opts.analysis_mode.unit()
                 );
-                println!(
-                    "  Album gain:     {:+.1} dB ({} steps{})",
-                    album_result.album_gain_db(),
-                    album_result.album_gain_steps(),
-                    if modifier_steps != 0 {
-                        format!(" + {} = {}", modifier_steps, modified_gain_steps)
-                    } else {
-                        String::new()
-                    }
-                );
+                match album_tag_gain_db {
+                    Some(tag_gain) => println!(
+                        "  Album gain:     {:+.2} dB (tag value, audio unchanged)",
+                        tag_gain
+                    ),
+                    None => println!(
+                        "  Album gain:     {:+.1} dB ({} steps{})",
+                        album_result.album_gain_db(),
+                        album_result.album_gain_steps(),
+                        if modifier_steps != 0 {
+                            format!(" + {} = {}", modifier_steps, modified_gain_steps)
+                        } else {
+                            String::new()
+                        }
+                    ),
+                }
                 println!("  Album peak:     {:.4}", album_result.album_peak());
                 println!();
             }
@@ -251,7 +296,8 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let clip_prevention_applies =
                 opts.prevent_clipping && album_result.tracks().iter().any(|t| t.peak() > 1.0);
 
-            if steps == 0 && !writes_rg_tags && !clip_prevention_applies {
+            // --tags-only always has a tag to write (issue #308).
+            if !opts.tags_only && steps == 0 && !writes_rg_tags && !clip_prevention_applies {
                 if opts.output_format == OutputFormat::Json {
                     let json_results: Vec<JsonFileResult> = files
                         .iter()
@@ -407,7 +453,11 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             // MP3 file after all gain is applied (the range is only known once the
             // whole album is done). APEv2 only — mp3gain has no AAC, and `-s i`
             // uses ID3v2; best-effort, so a tag hiccup never fails the album.
+            // Skipped entirely in --tags-only mode: MP3GAIN_ALBUM_MINMAX
+            // describes a global_gain range that a gain apply produced, and
+            // no apply happened (issue #308).
             if !opts.dry_run
+                && !opts.tags_only
                 && opts.stored_tag_mode != StoredTagMode::Skip
                 && !opts.tag_layout.mp3gain_in_id3v2()
             {

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -48,6 +48,11 @@ pub struct JsonFileResult {
     pub gain_applied_steps: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gain_applied_db: Option<f64>,
+    /// `--tags-only` (issue #308): the absolute `REPLAYGAIN_TRACK_GAIN` value
+    /// written, which `-k` may have capped below the measured gain. Absent in
+    /// every other mode, where the tag holds a residual instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_gain_db: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub loudness_db: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,6 +107,9 @@ pub struct JsonAlbumResult {
     pub analysis_mode: Option<&'static str>,
     pub gain_db: f64,
     pub gain_steps: i32,
+    /// `--tags-only`: the absolute `REPLAYGAIN_ALBUM_GAIN` value written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_gain_db: Option<f64>,
     pub peak: f64,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ pub use ape::{
     TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
 pub use apply::{
-    apply_with_options, predict_apply, write_album_minmax, AacAlbumInfo, ApplyOptions, ApplyReport,
-    ClippingDetection,
+    apply_with_options, predict_apply, write_album_minmax, write_replaygain_tags_only,
+    AacAlbumInfo, ApplyOptions, ApplyReport, ClippingDetection, TagsOnlyOptions,
 };
 pub use error::{Error, Result};
 pub use gain::{

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
 use colored::*;
 use indicatif::ProgressBar;
-use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions};
+use mp3rgain::apply::{
+    apply_with_options, predict_apply, write_replaygain_tags_only, ApplyOptions, TagsOnlyOptions,
+};
 use mp3rgain::replaygain::{AudioFileType, ReplayGainResult};
-use mp3rgain::{apply_gain_to_peak, mp4meta, steps_to_db, AacAlbumInfo};
+use mp3rgain::{apply_gain_to_peak, mp4meta, peak_to_headroom_db, steps_to_db, AacAlbumInfo};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -67,20 +69,39 @@ fn process_track_gain_into(
             let modified_steps = base_steps + modifier_steps;
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
-                writeln!(
-                    out,
-                    "      Loudness: {:.1} {}, Gain: {:+.1} dB ({} steps{}), Peak: {:.4}",
-                    result.loudness_db(),
-                    result.analysis_mode().unit(),
-                    result.gain_db(),
-                    base_steps,
-                    if modifier_steps != 0 {
-                        format!(" + {} = {}", modifier_steps, modified_steps)
-                    } else {
-                        String::new()
-                    },
-                    result.peak()
-                )?;
+                if opts.tags_only {
+                    // No frames are touched, so there are no gain steps to
+                    // report, only the dB value headed for the tag.
+                    let offset_db = opts.target_offset_db();
+                    writeln!(
+                        out,
+                        "      Loudness: {:.1} {}, Tag gain: {:+.2} dB{}, Peak: {:.4}",
+                        result.loudness_db(),
+                        result.analysis_mode().unit(),
+                        result.gain_db(),
+                        if offset_db != 0.0 {
+                            format!(" {:+.2} = {:+.2}", offset_db, result.gain_db() + offset_db)
+                        } else {
+                            String::new()
+                        },
+                        result.peak()
+                    )?;
+                } else {
+                    writeln!(
+                        out,
+                        "      Loudness: {:.1} {}, Gain: {:+.1} dB ({} steps{}), Peak: {:.4}",
+                        result.loudness_db(),
+                        result.analysis_mode().unit(),
+                        result.gain_db(),
+                        base_steps,
+                        if modifier_steps != 0 {
+                            format!(" + {} = {}", modifier_steps, modified_steps)
+                        } else {
+                            String::new()
+                        },
+                        result.peak()
+                    )?;
+                }
             }
 
             // A net 0-step adjustment still has work to do when (issue #206):
@@ -97,7 +118,10 @@ fn process_track_gain_into(
             let writes_rg_tags = result.file_type() == AudioFileType::Aac
                 || opts.stored_tag_mode != StoredTagMode::Skip;
             let clip_prevention_applies = opts.prevent_clipping && result.peak() > 1.0;
-            if modified_steps == 0 && !writes_rg_tags && !clip_prevention_applies {
+            // --tags-only always has a tag to write, so it never takes the
+            // "nothing to do" shortcut (issue #308).
+            if !opts.tags_only && modified_steps == 0 && !writes_rg_tags && !clip_prevention_applies
+            {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {
                     writeln!(out, "  {} {} (no adjustment needed)", ".".cyan(), filename)?;
                 }
@@ -145,6 +169,13 @@ fn apply_replaygain_with_album_into(
 ) -> Result<(JsonFileResult, Option<(u8, u8)>)> {
     let filename = get_filename(file);
     let is_aac = result.file_type() == AudioFileType::Aac;
+
+    // --tags-only: record the analysis and leave every frame alone
+    // (issue #308). `steps` is deliberately ignored: the target shift lives
+    // in the tag value instead.
+    if opts.tags_only {
+        return write_tags_only_into(file, result, opts, album_info, out).map(|r| (r, None));
+    }
 
     // Dry run: don't actually modify. Clipping prevention still needs to
     // be reflected in the "would apply N steps" message, so drive the same
@@ -232,6 +263,189 @@ fn apply_replaygain_with_album_into(
             ))
         }
         Err(e) => Ok((report_file_error(file, filename, e, opts), None)),
+    }
+}
+
+/// The gain a player should apply in `--tags-only` mode, capped at the file's
+/// exact headroom when `-k` is on so applying the tag cannot push playback
+/// past unity (issue #308). Pure, so the album summary can report the same
+/// number the per-file writer stores.
+pub fn capped_tag_gain(gain_db: f64, peak: f64, prevent_clipping: bool) -> f64 {
+    if !prevent_clipping || apply_gain_to_peak(peak, gain_db) <= 1.0 {
+        return gain_db;
+    }
+    // `None` only for a peak of 0 (digital silence), which cannot clip.
+    peak_to_headroom_db(peak).unwrap_or(gain_db)
+}
+
+/// Clipping check for `--tags-only` (issue #308).
+///
+/// No gain is baked into the audio, so nothing can clip on disk; the only
+/// risk is the *player* driving the file past unity when it applies the tag.
+/// `-k` therefore caps the written value at the file's exact headroom, with no
+/// 1.5 dB step rounding, because a tag holds a float, not a `global_gain`
+/// field. Without `-k` the usual warning is emitted unless `-c` / `-q`
+/// silence it.
+fn cap_tag_gain(
+    gain_db: f64,
+    peak: f64,
+    label: &str,
+    filename: &str,
+    opts: &Options,
+) -> (f64, Option<String>) {
+    let player_peak = apply_gain_to_peak(peak, gain_db);
+    if player_peak <= 1.0 {
+        return (gain_db, None);
+    }
+    let dry_run_prefix = opts.dry_run_prefix();
+
+    let capped = capped_tag_gain(gain_db, peak, opts.prevent_clipping);
+    if capped != gain_db {
+        let msg = format!(
+            "{} gain reduced from {:+.2} to {:+.2} dB to prevent clipping (peak: {:.4})",
+            label, gain_db, capped, peak
+        );
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            eprintln!(
+                "  {} {}{} - {}",
+                "!".yellow(),
+                dry_run_prefix,
+                filename,
+                msg
+            );
+        }
+        return (capped, Some(msg));
+    }
+
+    if opts.ignore_clipping || opts.quiet {
+        return (gain_db, None);
+    }
+    let msg = format!(
+        "clipping warning: a player applying the {} gain of {:+.2} dB would peak at {:.2} (>1.00)",
+        label, gain_db, player_peak
+    );
+    if opts.output_format == OutputFormat::Text {
+        eprintln!(
+            "  {} {}{} - {}",
+            "!".yellow(),
+            dry_run_prefix,
+            filename,
+            msg
+        );
+        eprintln!("      Use -c to ignore clipping warnings or -k to cap the written gain");
+    }
+    (gain_db, Some(msg))
+}
+
+/// `--tags-only` (issue #308): write the absolute `REPLAYGAIN_*` values and
+/// leave the audio byte-identical, the way `loudgain` / `rsgain` work.
+///
+/// Unlike the apply path the tag is not a residual, so `-d` / `-m` shift the
+/// written value rather than the gain baked into the frames, and no
+/// `MP3GAIN_UNDO` / `MP3GAIN_MINMAX` is written, since there is nothing to undo.
+fn write_tags_only_into(
+    file: &Path,
+    result: &ReplayGainResult,
+    opts: &Options,
+    album_info: Option<&AacAlbumInfo>,
+    out: &mut String,
+) -> Result<JsonFileResult> {
+    let filename = get_filename(file);
+    let offset_db = opts.target_offset_db();
+
+    if result.file_type() == AudioFileType::Aac {
+        warn_aac_multi_track(file, filename, opts, opts.dry_run_prefix());
+    }
+
+    let mut warnings: Vec<String> = Vec::new();
+    let (track_gain_db, warning) = cap_tag_gain(
+        result.gain_db() + offset_db,
+        result.peak(),
+        "track",
+        filename,
+        opts,
+    );
+    warnings.extend(warning);
+
+    // The album peak is the loudest across the set, so capping against it
+    // keeps the album value identical on every file, which is the whole
+    // point of an album tag.
+    let album = album_info.map(|a| {
+        let (gain, warning) = cap_tag_gain(
+            a.album_gain_db + offset_db,
+            a.album_peak,
+            "album",
+            filename,
+            opts,
+        );
+        warnings.extend(warning);
+        (gain, a.album_peak)
+    });
+
+    let tag_type = if album.is_some() {
+        "track+album tags"
+    } else {
+        "tags"
+    };
+    let values = match album {
+        Some((album_gain, _)) => format!(
+            "track {:+.2} dB, album {:+.2} dB",
+            track_gain_db, album_gain
+        ),
+        None => format!("{:+.2} dB", track_gain_db),
+    };
+    let warning = (!warnings.is_empty()).then(|| warnings.join("; "));
+
+    let base = JsonFileResult {
+        // Nothing was applied to the audio; the gain lives in the tag.
+        gain_applied_steps: Some(0),
+        gain_applied_db: Some(0.0),
+        tag_gain_db: Some(track_gain_db),
+        warning,
+        ..JsonFileResult::from_analysis(file, result)
+    };
+
+    if opts.dry_run {
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            writeln!(
+                out,
+                "  {} [DRY RUN] {} (would write {}, {})",
+                "~".cyan(),
+                filename,
+                tag_type,
+                values
+            )?;
+        }
+        return Ok(JsonFileResult {
+            status: Some(FileStatus::DryRun),
+            dry_run: Some(true),
+            ..base
+        });
+    }
+
+    let mut tag_opts = TagsOnlyOptions::new(track_gain_db, result.peak(), result.analysis_mode());
+    tag_opts.album = album;
+    tag_opts.tag_layout = opts.tag_layout;
+    tag_opts.preserve_timestamp = opts.preserve_timestamp;
+
+    match write_replaygain_tags_only(file, &tag_opts) {
+        Ok(()) => {
+            if opts.output_format == OutputFormat::Text && !opts.quiet {
+                writeln!(
+                    out,
+                    "  {} {} ({} written, {})",
+                    "v".green(),
+                    filename,
+                    tag_type,
+                    values
+                )?;
+            }
+            Ok(JsonFileResult {
+                status: Some(FileStatus::Success),
+                ..base
+            })
+        }
+        Err(e) => Ok(report_file_error(file, filename, e, opts)),
     }
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -362,3 +362,205 @@ fn undo_with_delete_tags_without_undo_info_still_deletes() {
         text
     );
 }
+
+/// Track gain in dB parsed from wherever the tag was stored.
+fn track_gain_db(file: &Path) -> Option<f64> {
+    track_gain_tag(file).and_then(|s| mp3rgain::ape::parse_rg_gain(&s))
+}
+
+/// `(min_gain, max_gain)` global_gain range, the cheapest proof that the
+/// audio frames were or were not rewritten.
+fn gain_range(file: &Path) -> (u8, u8) {
+    let info = mp3rgain::analyze(file).expect("analyze should succeed");
+    (info.min_gain(), info.max_gain())
+}
+
+/// mp3gain-style suggested track gain in dB, from the TSV report.
+fn suggested_gain_db(file: &Path) -> f64 {
+    let out = run(&["-o", "tsv", file.to_str().unwrap()]);
+    let text = stdout_of(&out);
+    let row = text
+        .lines()
+        .nth(1)
+        .expect("TSV output should carry a data row");
+    row.split('\t')
+        .nth(2)
+        .expect("dB gain column")
+        .parse()
+        .expect("dB gain should parse")
+}
+
+fn json_of(output: &Output) -> serde_json::Value {
+    serde_json::from_str(&stdout_of(output)).expect("output should be JSON")
+}
+
+/// Issue #308: `--tags-only` writes the full ReplayGain value and leaves every
+/// audio frame alone, so the listener can still switch ReplayGain off in their
+/// player.
+#[test]
+fn tags_only_writes_absolute_gain_without_touching_audio() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let file = &album.files[0];
+    let before = gain_range(file);
+
+    let out = run(&[
+        "-r",
+        "--tags-only",
+        "-c",
+        "-o",
+        "json",
+        file.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "tags-only run failed: {:?}", out);
+    let json = json_of(&out);
+    let entry = &json["files"][0];
+
+    // Nothing was applied to the frames...
+    assert_eq!(entry["gain_applied_steps"].as_i64(), Some(0));
+    assert_eq!(gain_range(file), before, "audio frames were rewritten");
+
+    // ...so the tag holds the *full* suggested gain rather than the residual
+    // the apply path leaves behind. Contrast with a real -r run on an
+    // identical copy, which bakes the gain into the frames and tags only
+    // what is left over.
+    let tag_gain = entry["tag_gain_db"].as_f64().expect("tag_gain_db");
+    let written = track_gain_db(file).expect("REPLAYGAIN_TRACK_GAIN should be written");
+    assert!((written - tag_gain).abs() < 0.01, "written {}", written);
+
+    let applied = TempAlbum::new(&["test_mono.mp3"]);
+    let applied_file = &applied.files[0];
+    let suggested = suggested_gain_db(applied_file);
+    assert!(
+        (written - suggested).abs() < 0.01,
+        "tags-only wrote {} but the analysis suggests {}",
+        written,
+        suggested
+    );
+    let out = run(&["-r", "-c", applied_file.to_str().unwrap()]);
+    assert!(out.status.success(), "apply run failed: {:?}", out);
+    let residual = track_gain_db(applied_file).expect("residual gain");
+    assert_ne!(
+        gain_range(applied_file),
+        before,
+        "the apply path should have rewritten the frames"
+    );
+    assert!(
+        residual.abs() < written.abs(),
+        "residual {} should be smaller than the absolute {}",
+        residual,
+        written
+    );
+
+    // No gain change happened, so nothing describes one.
+    if let Some(tag) = read_ape_tag_from_file(file).unwrap() {
+        assert!(
+            tag.get(TAG_MP3GAIN_UNDO).is_none(),
+            "--tags-only wrote an undo tag"
+        );
+    }
+}
+
+/// Issue #308, album mode: every file gets the same album value, and no
+/// `MP3GAIN_ALBUM_MINMAX` is written since no apply produced a gain range.
+#[test]
+fn tags_only_album_writes_shared_album_tag_and_no_minmax() {
+    let album = TempAlbum::new(&["test_stereo.mp3", "test_mono.mp3"]);
+    let files = album.args();
+    let before: Vec<(u8, u8)> = album.files.iter().map(|f| gain_range(f)).collect();
+
+    let mut args = vec!["-a", "--tags-only", "-c"];
+    args.extend_from_slice(&files);
+    let out = run(&args);
+    assert!(
+        out.status.success(),
+        "album tags-only run failed: {:?}",
+        out
+    );
+
+    let mut album_gains = Vec::new();
+    for (file, before) in album.files.iter().zip(&before) {
+        assert_eq!(gain_range(file), *before, "audio frames were rewritten");
+        let rg = mp3rgain::read_id3v2_replaygain(file).expect("ID3v2 read");
+        album_gains.push(
+            rg.album_gain
+                .as_deref()
+                .and_then(mp3rgain::ape::parse_rg_gain)
+                .expect("REPLAYGAIN_ALBUM_GAIN should be written"),
+        );
+        // MP3GAIN_ALBUM_MINMAX is an APEv2 item describing a post-apply
+        // global_gain range; there was no apply, so nothing should have been
+        // appended at all.
+        assert!(
+            read_ape_tag_from_file(file).unwrap().is_none(),
+            "--tags-only appended an APEv2 tag in the default split layout"
+        );
+    }
+    assert_eq!(
+        album_gains[0], album_gains[1],
+        "album gain must be identical across the album"
+    );
+}
+
+/// Issue #308: `-d` shifts the written value exactly. A sub-step value like
+/// 0.4 dB rounds to zero steps in the apply path, but a tag holds a float, so
+/// here it has to land verbatim.
+#[test]
+fn tags_only_d_modifier_shifts_written_value_exactly() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let file = &album.files[0];
+
+    let out = run(&["-r", "--tags-only", "-c", file.to_str().unwrap()]);
+    assert!(out.status.success(), "baseline run failed: {:?}", out);
+    let base = track_gain_db(file).expect("baseline gain");
+
+    let out = run(&[
+        "-r",
+        "--tags-only",
+        "-d",
+        "0.4",
+        "-c",
+        file.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "-d run failed: {:?}", out);
+    let shifted = track_gain_db(file).expect("shifted gain");
+    assert!(
+        (shifted - (base + 0.4)).abs() < 0.001,
+        "expected {} + 0.4, got {}",
+        base,
+        shifted
+    );
+}
+
+/// Issue #308: `-k` caps the written value at the file's headroom so a player
+/// applying the tag cannot push the signal past unity.
+#[test]
+fn tags_only_k_caps_written_gain_at_headroom() {
+    // The stereo fixture's peak is far above unity, so any positive tag gain
+    // would clip on playback.
+    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let file = &album.files[0];
+
+    let out = run(&[
+        "-r",
+        "--tags-only",
+        "-k",
+        "-o",
+        "json",
+        file.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "-k run failed: {:?}", out);
+    let json = json_of(&out);
+    let entry = &json["files"][0];
+    let peak = entry["peak"].as_f64().expect("peak");
+    let tag_gain = entry["tag_gain_db"].as_f64().expect("tag_gain_db");
+
+    assert!(peak > 1.0, "fixture should already clip for this test");
+    let played_peak = peak * 10f64.powf(tag_gain / 20.0);
+    assert!(
+        played_peak <= 1.0 + 1e-9,
+        "capped tag gain still clips: peak {} * gain {} dB = {}",
+        peak,
+        tag_gain,
+        played_peak
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -394,6 +394,15 @@ fn json_of(output: &Output) -> serde_json::Value {
     serde_json::from_str(&stdout_of(output)).expect("output should be JSON")
 }
 
+/// Run `args` against `file` in JSON mode and return the single file record.
+fn json_file_record(args: &[&str], file: &Path) -> serde_json::Value {
+    let mut argv = args.to_vec();
+    argv.extend_from_slice(&["-o", "json", file.to_str().unwrap()]);
+    let out = run(&argv);
+    assert!(out.status.success(), "run {:?} failed: {:?}", args, out);
+    json_of(&out)["files"][0].clone()
+}
+
 /// Issue #308: `--tags-only` writes the full ReplayGain value and leaves every
 /// audio frame alone, so the listener can still switch ReplayGain off in their
 /// player.
@@ -436,19 +445,19 @@ fn tags_only_writes_absolute_gain_without_touching_audio() {
         written,
         suggested
     );
-    let out = run(&["-r", "-c", applied_file.to_str().unwrap()]);
-    assert!(out.status.success(), "apply run failed: {:?}", out);
+
+    // The apply path tags what is left over after baking gain into the
+    // frames, so its value is the same measurement minus whatever it applied.
+    let record = json_file_record(&["-r", "-c"], applied_file);
+    let applied_db = record["gain_applied_db"].as_f64().expect("gain_applied_db");
     let residual = track_gain_db(applied_file).expect("residual gain");
-    assert_ne!(
-        gain_range(applied_file),
-        before,
-        "the apply path should have rewritten the frames"
-    );
     assert!(
-        residual.abs() < written.abs(),
-        "residual {} should be smaller than the absolute {}",
+        (residual - (suggested - applied_db)).abs() < 0.05,
+        "apply wrote {} but the residual of {} after {} dB is {}",
         residual,
-        written
+        suggested,
+        applied_db,
+        suggested - applied_db
     );
 
     // No gain change happened, so nothing describes one.
@@ -535,32 +544,36 @@ fn tags_only_d_modifier_shifts_written_value_exactly() {
 /// applying the tag cannot push the signal past unity.
 #[test]
 fn tags_only_k_caps_written_gain_at_headroom() {
-    // The stereo fixture's peak is far above unity, so any positive tag gain
-    // would clip on playback.
-    let album = TempAlbum::new(&["test_stereo.mp3"]);
+    let album = TempAlbum::new(&["test_mono.mp3"]);
     let file = &album.files[0];
 
-    let out = run(&[
-        "-r",
-        "--tags-only",
-        "-k",
-        "-o",
-        "json",
-        file.to_str().unwrap(),
-    ]);
-    assert!(out.status.success(), "-k run failed: {:?}", out);
-    let json = json_of(&out);
-    let entry = &json["files"][0];
-    let peak = entry["peak"].as_f64().expect("peak");
-    let tag_gain = entry["tag_gain_db"].as_f64().expect("tag_gain_db");
+    // +60 dB of pregain is past any real file's headroom, so the written value
+    // would clip on playback whatever the fixture happens to measure.
+    let uncapped = json_file_record(&["-r", "--tags-only", "-d", "60", "-c"], file);
+    let peak = uncapped["peak"].as_f64().expect("peak");
+    let wanted = uncapped["tag_gain_db"].as_f64().expect("tag_gain_db");
+    assert!(peak > 0.0, "fixture should not be digital silence");
+    assert!(
+        peak * 10f64.powf(wanted / 20.0) > 1.0,
+        "setup: the uncapped value should clip on playback"
+    );
 
-    assert!(peak > 1.0, "fixture should already clip for this test");
-    let played_peak = peak * 10f64.powf(tag_gain / 20.0);
+    let capped = json_file_record(&["-r", "--tags-only", "-d", "60", "-k"], file);
+    let got = capped["tag_gain_db"].as_f64().expect("tag_gain_db");
+    assert!(
+        got < wanted,
+        "-k left the written gain at {} instead of capping it",
+        got
+    );
+    let played_peak = peak * 10f64.powf(got / 20.0);
     assert!(
         played_peak <= 1.0 + 1e-9,
         "capped tag gain still clips: peak {} * gain {} dB = {}",
         peak,
-        tag_gain,
+        got,
         played_peak
     );
+    // The tag must actually carry the capped value, not just report it.
+    let written = track_gain_db(file).expect("REPLAYGAIN_TRACK_GAIN");
+    assert!((written - got).abs() < 0.01, "written {}", written);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -771,3 +771,46 @@ fn test_undo_removes_stale_replaygain_in_id3v2_layout() {
     );
     cleanup(&path);
 }
+
+/// Issue #308: the tags-only library entry point records ReplayGain metadata
+/// without touching a frame, and leaves any MP3GAIN_* items from a previous
+/// real apply alone: those still describe the audio as it currently is.
+#[test]
+fn write_replaygain_tags_only_preserves_audio_and_mp3gain_tags() {
+    use mp3rgain::apply::{write_replaygain_tags_only, TagsOnlyOptions};
+    use mp3rgain::replaygain::AnalysisMode;
+    use mp3rgain::{TagLayout, TAG_MP3GAIN_MINMAX, TAG_REPLAYGAIN_TRACK_GAIN};
+
+    let path = copy_test_file("test_stereo.mp3");
+    // A real apply first, so the file carries MP3GAIN_UNDO / MP3GAIN_MINMAX.
+    GainOptions::new(-2).undo(true).apply(&path).unwrap();
+    let before = analyze(&path).unwrap();
+
+    let mut opts = TagsOnlyOptions::new(-3.25, 0.75, AnalysisMode::Rg1);
+    opts.album = Some((-4.5, 0.9));
+    opts.tag_layout = TagLayout::Ape;
+    write_replaygain_tags_only(&path, &opts).unwrap();
+
+    let after = analyze(&path).unwrap();
+    assert_eq!(
+        (before.min_gain(), before.max_gain()),
+        (after.min_gain(), after.max_gain()),
+        "tags-only must not rewrite the audio frames"
+    );
+
+    let tag = read_ape_tag_from_file(&path).unwrap().expect("APE tag");
+    assert_eq!(
+        tag.get(TAG_REPLAYGAIN_TRACK_GAIN).map(str::to_string),
+        Some("-3.250000 dB".to_string())
+    );
+    // The earlier apply's bookkeeping still describes the current audio.
+    assert!(
+        tag.get(TAG_MP3GAIN_UNDO).is_some(),
+        "MP3GAIN_UNDO from the earlier apply was dropped"
+    );
+    assert!(
+        tag.get(TAG_MP3GAIN_MINMAX).is_some(),
+        "MP3GAIN_MINMAX from the earlier apply was dropped"
+    );
+    cleanup(&path);
+}


### PR DESCRIPTION
Closes #308

mp3rgain, like mp3gain, always bakes gain into `global_gain` and tags only the residual, so a listener can no longer opt out by disabling ReplayGain in their player. `--tags-only` runs the normal analysis but skips the frame-level apply and writes the full absolute `REPLAYGAIN_*` values instead, which is the loudgain / rsgain workflow.

```console
$ mp3rgain -a --tags-only *.mp3
mp3rgain Analyzing album gain for 2 file(s) (tags only, audio unchanged)
  Album gain:     +3.70 dB (tag value, audio unchanged)
  v track01.mp3 (track+album tags written, track +3.70 dB, album +3.70 dB)
```

## Behavior

- **Audio is byte-identical.** No frame is rewritten; the `global_gain` range before and after is the same. Verified in tests by comparing `analyze()` output across the run.
- **Absolute, not residual.** The tag carries the full suggested gain rather than what is left over after an apply. Works with `--rg2` / `--r128` / `--true-peak` and all three tag layouts (default split, `-s a`, `-s i`); AAC writes the MP4 freeform values.
- **No gain-change bookkeeping.** `MP3GAIN_UNDO`, `MP3GAIN_MINMAX` and `MP3GAIN_ALBUM_MINMAX` are not written, since there is nothing to undo or describe. Any left behind by an earlier real apply is preserved untouched, because it still describes the audio as it currently is (and `-u` still rolls that apply back afterwards).
- **Album mode** writes the same album value to every file in the set.

## Open questions from the issue

- **`-d` / `-m`:** they shift the written value instead of the applied gain. Nothing is quantized to a whole 1.5 dB step here, so `-d` applies exactly (`-d 0.4` lands verbatim, where the apply path rounds it to zero steps) and `-m` contributes its steps converted to dB. The `Target:` line reports the exact dB.
- **`-k`:** kept meaningful rather than silently inert. It caps the written value at the file's exact headroom so a player applying the tag cannot push the signal past unity, which is what loudgain's `-k` does. The album value is capped against the album peak so it stays identical across the set. Without `-k` the usual clipping warning is emitted, and `-c` silences it.
- **GUI:** out of scope, as the issue allows. Only library API was added, so `mp3rgui` is unaffected and still builds.

## Command compatibility

`--tags-only` is a long flag, and mp3gain has no long options, so there is no namespace collision. The flag requires `-r`, `-a` or `-e`, and is **rejected** (not silently ignored) with `-g`, `-l`, `-u`, `-w`, `-x` and `-s c` / `-s d` / `-s s`: a user who passed both meant one of them, and guessing wrong rewrites their files. `-s a`, `-s i`, `-s R`, `-k`, `-c`, `-p`, `-n`, `-d`, `-m` and the analysis modes are all accepted.

Existing behavior is untouched. The only shared-path change is `stored_tags_usable()` switching from `gain_modifier_steps() == 0` to `target_offset_db() == 0.0`, which is exactly equivalent outside `--tags-only` (`steps_to_db(n) == 0.0` iff `n == 0`) and additionally forces a rescan when a sub-step `-d` would shift a reused tag value.

I checked this against a `master` build rather than by inspection: for 24 existing invocations (`-o tsv`, `-o json`, `-r`, `-a`, `-g`, `-l 0 2`, `-l 1 -2`, `-u`, `-s c`, `-s d`, `-u -s d`, `-x`, `-e`, `-Rpa`, `-s R`, `-s a`, `-s i`, `-s s`, `--rg2`, `--r128 --true-peak`, `-d`, `-m`, `-k`, combined short flags) both the stdout/stderr and the resulting files are identical between the two binaries. The `--help` diff is additions only.

## Verification

- 9 new tests: 4 end-to-end CLI (audio untouched + absolute-vs-residual contrast against a real `-r` run, album tag shared with no APEv2 append, exact `-d` shift, `-k` capping below unity), 4 parser unit tests (requires an analysis flag, rejects the conflicting set, accepts the compatible set, offset is not step-quantized), 1 library test (`write_replaygain_tags_only` preserves audio and pre-existing `MP3GAIN_*`).
- `cargo test`: 181 pass. `cargo fmt -- --check` clean on both crates. `cargo clippy --all-targets`: no new warnings (two pre-existing ones in `bs1770` / `replaygain` test code).
- Man page, `--help` and the migration / comparison docs updated.

Suggested by skamp on the HydrogenAudio thread (Reply #48).