### PR TITLE
Fix AAC tag writing under -s i, undo sign in the GUI, and tag-loss ordering

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -792,7 +792,7 @@ impl Mp3rgainApp {
                     track_result: Some(ReplayGainResult::from_stored_tags(
                         gain_db,
                         peak,
-                        stored_file_type(&f.path),
+                        AudioFileType::from_path(&f.path),
                         AnalysisMode::Rg1,
                     )),
                     album_info: None,
@@ -1213,7 +1213,7 @@ impl Mp3rgainApp {
                                 track_result: Some(ReplayGainResult::from_stored_tags(
                                     tags.track_gain,
                                     tags.track_peak,
-                                    stored_file_type(&f.path),
+                                    AudioFileType::from_path(&f.path),
                                     AnalysisMode::Rg1,
                                 )),
                                 album_info: Some(info),
@@ -1711,16 +1711,6 @@ fn trusted_album_tags(file: &FileEntry) -> Option<StoredAlbumTags> {
         album_gain: view.album_gain.as_deref().and_then(parse_rg_gain)?,
         album_peak: view.album_peak.as_deref().and_then(parse_rg_peak)?,
     })
-}
-
-/// File type for a tag-derived result, mirroring the dispatch in
-/// `mp3rgain::read_gain_tags_auto` (same as the CLI's -s R path).
-fn stored_file_type(path: &Path) -> AudioFileType {
-    if mp3rgain::mp4meta::is_aac_file(path) {
-        AudioFileType::Aac
-    } else {
-        AudioFileType::Mp3
-    }
 }
 
 /// Display pair for a ReplayGain value, mode-aware (issue #272).

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -20,12 +20,24 @@ fn render_stored_tags_cell(ui: &mut egui::Ui, tags: Option<&StoredTagsView>) {
         ui.label(format!("Container: {}", view.format.unwrap_or("?")));
         ui.separator();
         for (name, value) in [
-            ("REPLAYGAIN_TRACK_GAIN", view.track_gain.as_deref()),
-            ("REPLAYGAIN_TRACK_PEAK", view.track_peak.as_deref()),
-            ("REPLAYGAIN_ALBUM_GAIN", view.album_gain.as_deref()),
-            ("REPLAYGAIN_ALBUM_PEAK", view.album_peak.as_deref()),
-            ("MP3GAIN_UNDO", view.undo.as_deref()),
-            ("MP3GAIN_MINMAX", view.minmax.as_deref()),
+            (
+                mp3rgain::TAG_REPLAYGAIN_TRACK_GAIN,
+                view.track_gain.as_deref(),
+            ),
+            (
+                mp3rgain::TAG_REPLAYGAIN_TRACK_PEAK,
+                view.track_peak.as_deref(),
+            ),
+            (
+                mp3rgain::TAG_REPLAYGAIN_ALBUM_GAIN,
+                view.album_gain.as_deref(),
+            ),
+            (
+                mp3rgain::TAG_REPLAYGAIN_ALBUM_PEAK,
+                view.album_peak.as_deref(),
+            ),
+            (mp3rgain::TAG_MP3GAIN_UNDO, view.undo.as_deref()),
+            (mp3rgain::TAG_MP3GAIN_MINMAX, view.minmax.as_deref()),
         ] {
             if let Some(v) = value {
                 ui.label(format!("{}: {}", name, v));

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -377,10 +377,7 @@ pub fn spawn_album_analysis(
                         .iter()
                         .map(|(pos, msg)| (original_indices[*pos], msg.clone()))
                         .collect();
-                    let album_info = AacAlbumInfo {
-                        album_gain_db: report.album.album_gain_db(),
-                        album_peak: report.album.album_peak(),
-                    };
+                    let album_info = AacAlbumInfo::from(&report.album);
                     analyzed_total += successful.len();
                     skipped_total += failures.len();
 
@@ -852,8 +849,11 @@ pub fn spawn_find_max_amplitude(ctx: egui::Context, files: Vec<(usize, PathBuf)>
     WorkerHandle { rx, cancel }
 }
 
-/// Spawn the stored-tag scanner. Iterates files serially (tag reads are
-/// I/O-light) and emits `StoredTagsRead` for each.
+/// Spawn the stored-tag scanner, emitting `StoredTagsRead` per file.
+///
+/// Runs through [`run_job_pool`] like the other workers: an MP3 tag read is
+/// I/O-light, but an AAC one parses the whole `moov` box, so importing a large
+/// library from network storage was noticeably serial.
 ///
 /// Dispatch is shared with the CLI via `mp3rgain::read_gain_tags_auto`:
 ///   - AAC: MP4 freeform RG + undo
@@ -870,18 +870,24 @@ pub fn spawn_check_stored_tags(
 
     thread::spawn(move || {
         let total = jobs.len();
-        for job in jobs {
-            if cancel_w.load(Ordering::Relaxed) {
-                send(&tx, &ctx, WorkerEvent::Cancelled);
-                return;
-            }
-            send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
-            let view = read_stored_tags(&job.path, layout);
-            send(
-                &tx,
-                &ctx,
-                WorkerEvent::StoredTagsRead { idx: job.idx, view },
-            );
+
+        {
+            let tx = tx.clone();
+            let ctx = ctx.clone();
+            run_job_pool(jobs, &cancel_w, move |job: CheckTagsJob| {
+                send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
+                let view = read_stored_tags(&job.path, layout);
+                send(
+                    &tx,
+                    &ctx,
+                    WorkerEvent::StoredTagsRead { idx: job.idx, view },
+                );
+            });
+        }
+
+        if cancel_w.load(Ordering::Relaxed) {
+            send(&tx, &ctx, WorkerEvent::Cancelled);
+            return;
         }
 
         send(

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -52,6 +52,15 @@ pub struct AacAlbumInfo {
     pub album_peak: f64,
 }
 
+impl From<&crate::replaygain::AlbumGainResult> for AacAlbumInfo {
+    fn from(album: &crate::replaygain::AlbumGainResult) -> Self {
+        Self {
+            album_gain_db: album.album_gain_db(),
+            album_peak: album.album_peak(),
+        }
+    }
+}
+
 /// Driver configuration for [`apply_with_options`].
 ///
 /// Construct via [`ApplyOptions::new`] and tweak fields directly — this
@@ -250,33 +259,34 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     // 3) Remaining ReplayGain tag writes.
     //
     // AAC writes to mp4 freeform metadata (always arithmetic — AAC clamps
-    // internally, and mp3gain has no AAC, so it is interop-neutral). The MP3
-    // paths were handled in step 2, except: under saturation or `-w` wrap the
-    // loudness shift is not uniform, so the modified file is re-analyzed for
-    // the true post-apply residual and the APE items rewritten; channel
-    // applies keep the legacy separate write.
-    if opts.write_replaygain_tags && !opts.tag_layout.mp3gain_in_id3v2() {
+    // internally, and mp3gain has no AAC, so it is interop-neutral).
+    // `tag_layout` selects a *container for MP3 tags*, so it must not gate
+    // the AAC branch — doing so silently skipped the mp4 ReplayGain tags for
+    // an `.m4a` processed under `-s i`, leaving stale values for players to
+    // double-apply. MP3 under `-s i` was already handled in step 2; the other
+    // MP3 layouts land below, where saturation or `-w` wrap means the loudness
+    // shift is not uniform, so the modified file is re-analyzed for the true
+    // post-apply residual and the APE items rewritten. Channel applies keep
+    // the legacy separate write.
+    if opts.write_replaygain_tags {
         let needs_reanalysis =
             !is_aac && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
         if is_aac {
             if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, false) {
-                let mut tags = mp4meta::ReplayGainTags::default();
-                tags.set_track(res.track_gain_db, res.track_peak);
-                if let Some((album_gain, album_peak)) = res.album {
-                    tags.set_album(album_gain, album_peak);
-                }
-                tags.set_algorithm(res.mode);
-                mp4meta::write_replaygain_tags(file_path, &tags)?;
+                mp4meta::write_replaygain_tags(file_path, &res.to_mp4())?;
             }
+        } else if opts.tag_layout.mp3gain_in_id3v2() {
+            // Folded into the step-2 temp file by apply_mp3_id3v2_bytes.
         } else if opts.tag_layout == TagLayout::Split {
-            // Clear any APEv2 ReplayGain first: mp3gain or an earlier `-s a`
-            // run may have left values there, and they would now disagree
-            // with the authoritative ID3v2 ones.
-            ape::remove_ape_replaygain(file_path)?;
+            // Write the authoritative ID3v2 values *before* dropping the
+            // APEv2 copies mp3gain or an earlier `-s a` run may have left:
+            // removing them first means a failed ID3v2 write (ENOSPC, a
+            // locked file) leaves the file with no ReplayGain values at all.
             if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
             {
                 id3v2::write_id3v2_replaygain(file_path, &res.to_id3v2())?;
             }
+            ape::remove_ape_replaygain(file_path)?;
         } else if !ape_rg_folded || needs_reanalysis {
             if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
             {
@@ -483,6 +493,16 @@ impl RgResidual {
             ..Default::default()
         }
     }
+
+    fn to_mp4(&self) -> mp4meta::ReplayGainTags {
+        let mut tags = mp4meta::ReplayGainTags::default();
+        tags.set_track(self.track_gain_db, self.track_peak);
+        if let Some((album_gain, album_peak)) = self.album {
+            tags.set_album(album_gain, album_peak);
+        }
+        tags.set_algorithm(self.mode);
+        tags
+    }
 }
 
 /// Compute the residual track/album ReplayGain after applying `actual_steps`.
@@ -601,23 +621,31 @@ fn apply_mp3_id3v2_bytes(
             // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue
             // #210): applying `+delta` makes the stored undo `-delta`,
             // accumulating by subtraction onto any prior undo value.
-            rg.undo = Some(ape::format_undo_value(
-                existing_left - delta_left,
-                existing_right - delta_right,
-                opts.wrap,
-            ));
+            let (undo_left, undo_right) =
+                (existing_left - delta_left, existing_right - delta_right);
+            // A zero undo delta describes nothing to roll back. Writing it
+            // anyway (as an already-on-target `-r -s i` track would) leaves a
+            // permanent `+000,+000` tag: both undo paths early-return on 0,0
+            // without removing anything, so it can never be cleaned up again.
+            // Only keep a 0,0 value when one is already stored, so an
+            // existing tag is still updated rather than left stale.
+            if (undo_left, undo_right) != (0, 0) || existing.undo.is_some() {
+                rg.undo = Some(ape::format_undo_value(undo_left, undo_right, opts.wrap));
 
-            // MP3GAIN_MINMAX is the *post-apply* global_gain range (mp3gain
-            // convention). A full apply already tracked it in the saturation
-            // stats (issue #231); channel and zero-step applies only touch a
-            // subset (or nothing), so scan the modified temp file instead.
-            let (min, max) = if opts.channel.is_none() && stats.frames > 0 {
-                (stats.min_gain, stats.max_gain)
-            } else {
-                let post = crate::analyze(w)?;
-                (post.min_gain(), post.max_gain())
-            };
-            rg.minmax = Some(ape::format_minmax(min, max));
+                // MP3GAIN_MINMAX is the *post-apply* global_gain range
+                // (mp3gain convention). A full apply already tracked it in the
+                // saturation stats (issue #231); channel applies only touch a
+                // subset, so scan the modified temp file instead. Written
+                // alongside the undo value, never on its own: on a file with
+                // no gain applied it would claim an apply that never happened.
+                let (min, max) = if opts.channel.is_none() && stats.frames > 0 {
+                    (stats.min_gain, stats.max_gain)
+                } else {
+                    let post = crate::analyze(w)?;
+                    (post.min_gain(), post.max_gain())
+                };
+                rg.minmax = Some(ape::format_minmax(min, max));
+            }
         }
 
         if opts.write_replaygain_tags {
@@ -803,21 +831,17 @@ pub fn write_replaygain_tags_only(file_path: &Path, opts: &TagsOnlyOptions) -> R
     };
 
     if mp4meta::is_aac_file(file_path) {
-        let mut tags = mp4meta::ReplayGainTags::default();
-        tags.set_track(values.track_gain_db, values.track_peak);
-        if let Some((album_gain, album_peak)) = values.album {
-            tags.set_album(album_gain, album_peak);
-        }
-        tags.set_algorithm(values.mode);
-        mp4meta::write_replaygain_tags(file_path, &tags)?;
+        mp4meta::write_replaygain_tags(file_path, &values.to_mp4())?;
     } else {
         match opts.tag_layout {
             // Split keeps the authoritative values in ID3v2, so an APEv2 copy
             // from mp3gain or an earlier `-s a` run has to go, the same rule
-            // the apply path follows.
+            // the apply path follows — and in the same order, writing the new
+            // values before dropping the old ones so a failed write cannot
+            // leave the file with no ReplayGain tags at all.
             TagLayout::Split => {
-                ape::remove_ape_replaygain(file_path)?;
                 id3v2::write_id3v2_replaygain(file_path, &values.to_id3v2())?;
+                ape::remove_ape_replaygain(file_path)?;
             }
             TagLayout::Id3v2 => id3v2::write_id3v2_replaygain(file_path, &values.to_id3v2())?,
             TagLayout::Ape => ape::write_ape_replaygain(file_path, &values.to_ape())?,

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -230,8 +230,14 @@ pub struct TruePeakMeter {
     /// coefficients each. `phases[p][k]` multiplies the input from `k`
     /// samples ago.
     phases: Vec<Vec<f64>>,
-    /// Per-channel input history, most recent first.
+    /// Per-channel input history, as a ring buffer indexed through
+    /// [`Self::pos`].
     history: Vec<Vec<f64>>,
+    /// Ring write position; steps backwards per frame so the sample written
+    /// `k` frames ago lives at `(pos + k) % len`. Replaces the per-sample
+    /// `rotate_right(1)` memmove the history used to pay on every frame of
+    /// every channel, the same trick `EqualLoudnessFilter` uses (issue #255).
+    pos: usize,
     peak: f64,
 }
 
@@ -257,6 +263,7 @@ impl TruePeakMeter {
         Self {
             phases,
             history: vec![vec![0.0; history_len]; channels.max(1)],
+            pos: 0,
             peak: 0.0,
         }
     }
@@ -266,13 +273,24 @@ impl TruePeakMeter {
     /// ignored.
     #[inline]
     pub fn add_frame(&mut self, frame: &[f64]) {
+        let len = self.history.first().map_or(0, Vec::len);
+        if len == 0 {
+            return;
+        }
+        // Step the write position backwards so index `k` ahead of it is the
+        // sample from `k` frames ago, matching `phases[p][k]`'s meaning.
+        self.pos = (self.pos + len - 1) % len;
+        let pos = self.pos;
         for (history, &sample) in self.history.iter_mut().zip(frame) {
-            history.rotate_right(1);
-            history[0] = sample;
+            history[pos] = sample;
             for phase in &self.phases {
                 let mut acc = 0.0;
-                for (&c, &x) in phase.iter().zip(history.iter()) {
-                    acc += c * x;
+                for (k, &c) in phase.iter().enumerate() {
+                    // `phase.len() <= len`, so one conditional subtraction
+                    // wraps the index.
+                    let idx = pos + k;
+                    let idx = if idx >= len { idx - len } else { idx };
+                    acc += c * history[idx];
                 }
                 self.peak = self.peak.max(acc.abs());
             }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -12,14 +12,13 @@ use std::path::{Path, PathBuf};
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
-    create_json_summary, exit_if_failed, finish_with_summary, for_each_file_with_analysis_bar,
-    print_dry_run_notice, run_album_analysis, update_counters,
+    create_json_summary, exit_if_failed, finish_with_album_summary, finish_with_summary,
+    for_each_file_with_analysis_bar, run_album_analysis, update_counters,
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{
     capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
 };
-use crate::processors::utils::stored_file_type;
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
 
@@ -128,7 +127,7 @@ fn stored_album_report(files: &[PathBuf], opts: &Options) -> Option<AlbumAnalysi
         tracks.push(ReplayGainResult::from_stored_tags(
             gain_db,
             peak,
-            stored_file_type(file),
+            AudioFileType::from_path(file),
             opts.analysis_mode,
         ));
     }
@@ -247,10 +246,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 peak: album_result.album_peak(),
             };
 
-            let album_info = AacAlbumInfo {
-                album_gain_db: album_result.album_gain_db(),
-                album_peak: album_result.album_peak(),
-            };
+            let album_info = AacAlbumInfo::from(&album_result);
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 println!();
@@ -318,19 +314,16 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                             ),
                         })
                         .collect();
-
-                    let output = JsonOutput {
-                        files: Some(json_results),
-                        album: Some(json_album),
-                        summary: Some(create_json_summary(
-                            files.len(),
-                            0,
-                            failure_count,
-                            opts.dry_run,
-                        )),
-                    };
-                    println!("{}", serde_json::to_string_pretty(&output)?);
-                } else if !opts.quiet {
+                    return finish_with_album_summary(
+                        files.len(),
+                        json_results,
+                        Some(json_album),
+                        0,
+                        failure_count,
+                        opts,
+                    );
+                }
+                if !opts.quiet {
                     println!("  {} No adjustment needed", ".".cyan());
                 }
                 exit_if_failed(failure_count);
@@ -468,22 +461,14 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 mp3rgain::write_album_minmax(&album_files);
             }
 
-            if opts.output_format == OutputFormat::Json {
-                let output = JsonOutput {
-                    files: Some(json_results),
-                    album: Some(json_album),
-                    summary: Some(create_json_summary(
-                        files.len(),
-                        successful,
-                        failed,
-                        opts.dry_run,
-                    )),
-                };
-                println!("{}", serde_json::to_string_pretty(&output)?);
-            } else {
-                print_dry_run_notice(opts);
-            }
-            exit_if_failed(failed);
+            finish_with_album_summary(
+                files.len(),
+                json_results,
+                Some(json_album),
+                successful,
+                failed,
+                opts,
+            )?;
         }
         Err(e) => {
             if opts.output_format == OutputFormat::Json {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::threading::effective_threads;
-use crate::json_output::{FileStatus, JsonFileResult, JsonOutput, JsonSummary};
+use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput, JsonSummary};
 use crate::progress::{
     album_progress_callbacks, create_album_progress_pb_in, create_analysis_progress_bar,
     create_file_count_pb_in, create_progress_bar, progress_finish, progress_inc,
@@ -197,10 +197,23 @@ pub fn finish_with_summary(
     failed: usize,
     opts: &Options,
 ) -> Result<()> {
+    finish_with_album_summary(total_files, json_results, None, successful, failed, opts)
+}
+
+/// [`finish_with_summary`] carrying an album block, for the `-a` paths whose
+/// JSON output has one.
+pub fn finish_with_album_summary(
+    total_files: usize,
+    json_results: Vec<JsonFileResult>,
+    album: Option<JsonAlbumResult>,
+    successful: usize,
+    failed: usize,
+    opts: &Options,
+) -> Result<()> {
     if opts.output_format == OutputFormat::Json {
         let output = JsonOutput {
             files: Some(json_results),
-            album: None,
+            album,
             summary: Some(create_json_summary(
                 total_files,
                 successful,

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -5,7 +5,7 @@
 //! subsumed by a broader rewrite of this module.
 
 use crate::ape::{
-    parse_undo_values, parse_undo_wrap, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
+    parse_undo_values, parse_undo_wrap, REPLAYGAIN_KEYS, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
     TAG_REPLAYGAIN_ALBUM_GAIN, TAG_REPLAYGAIN_ALBUM_PEAK, TAG_REPLAYGAIN_ALGORITHM,
     TAG_REPLAYGAIN_TRACK_GAIN, TAG_REPLAYGAIN_TRACK_PEAK,
 };
@@ -17,19 +17,14 @@ use std::path::Path;
 
 const TARGET_VERSION: id3::Version = id3::Version::Id3v24;
 
-/// All known mp3gain/ReplayGain TXXX descriptions
+/// The `REPLAYGAIN_*` value descriptions only (no undo/minmax). Same set as
+/// the APEv2 keys — the two containers store identical names.
+const RG_VALUE_DESCRIPTIONS: &[&str] = &REPLAYGAIN_KEYS;
+
+/// All known mp3gain/ReplayGain TXXX descriptions.
 const ALL_RG_DESCRIPTIONS: &[&str] = &[
     TAG_MP3GAIN_UNDO,
     TAG_MP3GAIN_MINMAX,
-    TAG_REPLAYGAIN_TRACK_GAIN,
-    TAG_REPLAYGAIN_TRACK_PEAK,
-    TAG_REPLAYGAIN_ALBUM_GAIN,
-    TAG_REPLAYGAIN_ALBUM_PEAK,
-    TAG_REPLAYGAIN_ALGORITHM,
-];
-
-/// The `REPLAYGAIN_*` value descriptions only (no undo/minmax).
-const RG_VALUE_DESCRIPTIONS: &[&str] = &[
     TAG_REPLAYGAIN_TRACK_GAIN,
     TAG_REPLAYGAIN_TRACK_PEAK,
     TAG_REPLAYGAIN_ALBUM_GAIN,
@@ -95,12 +90,29 @@ fn is_frame_encodable(frame: &id3::Frame) -> bool {
 ///
 /// Takes `&mut` so the unencodable frames can be filtered in place: cloning the
 /// tag first would copy every frame, including multi-megabyte embedded art.
+///
+/// The whole tag is probed once first, and the per-frame filter only runs when
+/// that fails. `is_frame_encodable` clones each frame it inspects, so screening
+/// every frame up front made a tag with embedded cover art clone and encode
+/// those megabytes on every write — for the rare malformed frame the filter
+/// actually exists to catch.
 fn write_tag_direct(path: &Path, tag: &mut id3::Tag) -> Result<()> {
-    tag.frames_vec_mut().retain(is_frame_encodable);
+    if !is_tag_encodable(tag) {
+        tag.frames_vec_mut().retain(is_frame_encodable);
+    }
     tag.write_to_path(path, TARGET_VERSION)
         .map_err(|e| Error::Id3v2Error {
             message: e.to_string(),
         })
+}
+
+/// Whether `tag` encodes cleanly as [`TARGET_VERSION`] as a whole.
+fn is_tag_encodable(tag: &id3::Tag) -> bool {
+    let mut buf: Vec<u8> = Vec::new();
+    id3::Encoder::new()
+        .version(TARGET_VERSION)
+        .encode(tag, &mut buf)
+        .is_ok()
 }
 
 /// Rewrite the tag atomically: copy the file to a sibling temp, write the tag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,30 +430,39 @@ pub fn read_gain_tags_auto(file_path: &Path, layout: TagLayout) -> Result<Stored
     }
 }
 
-/// Read the left-channel undo step count without modifying the file.
+/// Read the cumulative *applied* left-channel gain, in steps, without
+/// modifying the file — i.e. how much louder the file currently is than its
+/// original, which an undo would roll back.
 ///
-/// Mirrors [`undo_gain_auto`]'s dispatch so the returned value matches what
-/// `undo_gain_auto` would roll back. Returns `None` if the tag is absent or
-/// unreadable.
+/// The on-disk sign convention differs by container (MP3 stores the undo
+/// delta, AAC the applied gain — see [`ape::format_undo_value`]), so the MP3
+/// values are negated here and the returned number means the same thing for
+/// every format. Mirrors [`undo_gain_auto`]'s container dispatch, so the value
+/// matches what `undo_gain_auto` would actually reverse. Returns `None` if the
+/// tag is absent or unreadable.
 pub fn read_undo_steps(file_path: &Path, layout: TagLayout) -> Option<i32> {
     #[cfg(feature = "aac")]
     {
         if mp4meta::is_aac_file(file_path) {
             let undo_tags = mp4meta::read_undo_tags(file_path).ok()?;
+            // AAC already stores the applied gain.
             return Some(ape::parse_undo_values(undo_tags.undo()).0);
         }
     }
+    // MP3 stores the undo delta (the value to re-add to restore the
+    // original), so the applied gain is its negation.
     let from_ape = || {
         ape::read_ape_tag_from_file(file_path)
             .ok()
             .flatten()
             .and_then(|t| t.get_undo_gain())
+            .map(i32::wrapping_neg)
     };
     let from_id3v2 = || {
         let rg = id3v2::read_id3v2_replaygain(file_path).ok()?;
         rg.undo
             .as_deref()
-            .map(|u| ape::parse_undo_values(Some(u)).0)
+            .map(|u| ape::parse_undo_values(Some(u)).0.wrapping_neg())
     };
     // Same fallback order as undo_gain_auto, so the reported value matches
     // what an undo would actually roll back.
@@ -479,6 +488,60 @@ fn collect_audio_files_into(dir: &Path, recursive: bool, result: &mut Vec<PathBu
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod undo_steps_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(name: &str, data: &[u8]) -> PathBuf {
+        let dir = std::env::temp_dir().join("mp3rgain_undo_steps_tests");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join(name);
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(data)
+            .unwrap();
+        path
+    }
+
+    /// `read_undo_steps` must report the cumulative *applied* gain, whichever
+    /// container the tag came from. MP3 stores the undo delta (the negation of
+    /// the applied gain), so a file that had +4 steps applied carries
+    /// `-004,-004` and must read back as `+4`.
+    ///
+    /// The GUI reverses its displayed volume / gain columns by this value
+    /// after an undo, so a sign flip here silently doubled the error instead
+    /// of cancelling it, and left the cached peak wrong for the next
+    /// prevent-clipping check.
+    #[test]
+    fn read_undo_steps_reports_applied_gain_for_mp3() {
+        let mut tag = ape::ApeTag::new();
+        // What an apply of +4 steps records.
+        tag.set_undo_gain(-4, -4, false);
+        let data = ape::replace_ape_tag(&vec![0u8; 8_000], &tag);
+        let path = write_temp("applied_plus4.mp3", &data);
+
+        for layout in [TagLayout::Split, TagLayout::Ape] {
+            assert_eq!(
+                read_undo_steps(&path, layout),
+                Some(4),
+                "{layout:?} should report the applied gain, not the stored delta"
+            );
+        }
+
+        // An attenuating apply reads back negative.
+        let mut tag = ape::ApeTag::new();
+        tag.set_undo_gain(3, 3, false);
+        let data = ape::replace_ape_tag(&vec![0u8; 8_000], &tag);
+        let path = write_temp("applied_minus3.mp3", &data);
+        assert_eq!(read_undo_steps(&path, TagLayout::Split), Some(-3));
+
+        // No tag at all stays None rather than reading as 0.
+        let path = write_temp("untagged.mp3", &vec![0u8; 8_000]);
+        assert_eq!(read_undo_steps(&path, TagLayout::Split), None);
+    }
 }
 
 #[cfg(all(test, feature = "aac"))]

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -32,6 +32,16 @@ pub const RG_ALBUM_GAIN: &str = "replaygain_album_gain";
 pub const RG_ALBUM_PEAK: &str = "replaygain_album_peak";
 pub const RG_ALGORITHM: &str = "replaygain_algorithm";
 
+/// Every ReplayGain freeform name mp3rgain writes, for the paths that treat
+/// them as a set.
+const RG_FREEFORM_NAMES: [&str; 5] = [
+    RG_TRACK_GAIN,
+    RG_TRACK_PEAK,
+    RG_ALBUM_GAIN,
+    RG_ALBUM_PEAK,
+    RG_ALGORITHM,
+];
+
 /// Undo tag keys (iTunes freeform format, same namespace)
 pub const UNDO_TAG: &str = "mp3rgain_undo";
 pub const MINMAX_TAG: &str = "mp3rgain_minmax";
@@ -934,11 +944,9 @@ fn is_freeform_matching(
 /// Check if a box at the given position is a ReplayGain freeform tag
 fn is_replaygain_freeform(data: &[u8], pos: usize, header: &BoxHeader) -> bool {
     is_freeform_matching(data, pos, header, |name| {
-        name.eq_ignore_ascii_case(RG_TRACK_GAIN)
-            || name.eq_ignore_ascii_case(RG_TRACK_PEAK)
-            || name.eq_ignore_ascii_case(RG_ALBUM_GAIN)
-            || name.eq_ignore_ascii_case(RG_ALBUM_PEAK)
-            || name.eq_ignore_ascii_case(RG_ALGORITHM)
+        RG_FREEFORM_NAMES
+            .iter()
+            .any(|n| name.eq_ignore_ascii_case(n))
     })
 }
 

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -2,7 +2,7 @@ use colored::*;
 use indicatif::ProgressBar;
 use mp3rgain::apply::ClippingDetection;
 use mp3rgain::mp4meta;
-use mp3rgain::replaygain::{self, ReplayGainResult};
+use mp3rgain::replaygain::{self, AudioFileType, ReplayGainResult};
 use std::path::Path;
 use std::time::SystemTime;
 
@@ -67,19 +67,9 @@ pub fn stored_track_result(file: &Path, opts: &Options) -> Option<ReplayGainResu
     Some(ReplayGainResult::from_stored_tags(
         gain_db,
         peak,
-        stored_file_type(file),
+        AudioFileType::from_path(file),
         opts.analysis_mode,
     ))
-}
-
-/// File type for a tag-derived result, mirroring the dispatch in
-/// [`mp3rgain::read_gain_tags_auto`].
-pub fn stored_file_type(file: &Path) -> mp3rgain::replaygain::AudioFileType {
-    if mp4meta::is_aac_file(file) {
-        mp3rgain::replaygain::AudioFileType::Aac
-    } else {
-        mp3rgain::replaygain::AudioFileType::Mp3
-    }
 }
 
 pub fn save_original_mtime(file: &Path, opts: &Options) -> Option<SystemTime> {

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -16,8 +16,6 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
 #[cfg(feature = "replaygain")]
-use crate::mp4meta;
-#[cfg(feature = "replaygain")]
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "replaygain")]
 use std::sync::Arc;
@@ -136,6 +134,18 @@ pub enum AudioFileType {
     Mp3,
     /// AAC/M4A file
     Aac,
+}
+
+impl AudioFileType {
+    /// Classify `path` by container, matching the dispatch every apply / tag
+    /// path uses (AAC for an MP4 carrying AAC audio, MP3 otherwise).
+    pub fn from_path(path: &Path) -> Self {
+        if crate::mp4meta::is_aac_file(path) {
+            AudioFileType::Aac
+        } else {
+            AudioFileType::Mp3
+        }
+    }
 }
 
 impl std::fmt::Display for AudioFileType {
@@ -1064,11 +1074,7 @@ impl ReplayGainAnalyzer {
 /// Detect file type from path
 #[cfg(feature = "replaygain")]
 fn detect_file_type(file_path: &Path) -> AudioFileType {
-    if mp4meta::is_aac_file(file_path) {
-        AudioFileType::Aac
-    } else {
-        AudioFileType::Mp3
-    }
+    AudioFileType::from_path(file_path)
 }
 
 // =============================================================================


### PR DESCRIPTION
Found while reviewing the whole codebase for reuse, quality, and efficiency ahead of 3.5.0.

## Correctness

- **`read_undo_steps` mixed two sign conventions.** MP3 stores the undo delta in `MP3GAIN_UNDO` (the value to re-add to restore the original), AAC stores the cumulative applied gain. The function returned whichever was on disk, and the GUI treats it as an applied gain — so undoing an MP3 shifted the Volume / Gain columns in the wrong direction (doubling the error instead of cancelling it) and rewrote the cached peak upward, which then made "Prevent clipping" cap gains that would not clip. It now reports the applied gain for every container, with a regression test covering both the boost and attenuation cases.
- **AAC ReplayGain tags were skipped under `-s i`.** `apply_with_options` gated all of step 3 on `!tag_layout.mp3gain_in_id3v2()`, and the AAC branch sat inside that gate. An `.m4a` processed with the GUI's "All in ID3v2" setting got its bitstream gain and undo tag but never had its mp4 `replaygain_track_*` tags written or refreshed, leaving stale values for a ReplayGain-aware player to double-apply. `tag_layout` selects a container for *MP3* tags, so it no longer gates the AAC path.
- **Split layout could lose ReplayGain tags from both containers.** Both the apply path and `--tags-only` deleted the APEv2 copies before writing the authoritative ID3v2 values, so a failed ID3v2 write (ENOSPC, a locked file on a Windows share) left the file with no ReplayGain values at all. The new values are written first; a stale APE copy after a failure is recoverable, deleted data is not.
- **Zero-step `-s i` applies left an uncleanable undo tag.** An already-on-target track processed with `-r -s i` takes the apply path (RG tags still get written) and recorded `+000,+000,N`. Both undo paths early-return on a 0,0 value without removing anything, so the tag persisted forever reporting "no changes to undo". It is now only written when there is something to undo, or when a value is already stored. `MP3GAIN_MINMAX` follows the same condition rather than claiming an apply that never happened.

## Efficiency

- ID3v2 writes probe the whole tag once and only fall back to the per-frame encodability filter when that fails. The filter clones each frame it inspects, so a tag with embedded cover art cloned and encoded those megabytes on every write — to screen for the rare malformed frame the filter exists to catch.
- `TruePeakMeter` keeps its input history in a ring buffer instead of a `rotate_right(1)` memmove per sample per channel, the same approach `EqualLoudnessFilter` already uses (#255). Only affects `--true-peak`.
- The GUI stored-tag scan (also used for the automatic import scan) runs through the shared job pool like every other worker. An MP3 tag read is light, but an AAC one parses the whole `moov` box.

## Reuse

`AudioFileType::from_path`, `AacAlbumInfo::from(&AlbumGainResult)`, `RgResidual::to_mp4()` and a shared `finish_with_album_summary` replace hand-written copies across the CLI and GUI, and the `REPLAYGAIN_*` key lists are now declared once per container instead of three times.

## Verification

`cargo test` (both crates, 182 tests) passes, `cargo fmt --check` and `cargo clippy -- -D warnings` are clean for `mp3rgain` and `mp3rgui`.