### PR TITLE
Fold every tag write into the single temp-file rewrite

### DIFF
--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -2,11 +2,12 @@ use crate::worker::{
     self, ApplyJob, ApplyOptionsUi, CheckTagsJob, DeleteTagsJob, StoredTagsView, UndoJob,
     WorkerEvent, WorkerHandle,
 };
-use mp3rgain::ape::{parse_rg_gain, parse_rg_peak};
 use mp3rgain::replaygain::{
     self, AnalysisMode, AudioFileType, ReplayGainResult, REPLAYGAIN_REFERENCE_DB,
 };
-use mp3rgain::{apply_gain_to_peak, db_to_steps, would_clip, AacAlbumInfo, Channel};
+use mp3rgain::{
+    apply_gain_to_peak, db_to_steps, would_clip, AacAlbumInfo, Channel, StoredAlbumValues,
+};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::TryRecvError;
@@ -860,26 +861,20 @@ impl Mp3rgainApp {
         self.use_stored_tags && self.analysis_mode == AnalysisMode::Rg1
     }
 
-    /// Group-level `-s R` check (issue #302), mirroring the CLI's
+    /// Group-level `-s R` check (issue #302), the same rule as the CLI's
     /// `stored_album_report`: every file must carry trusted, parseable track
-    /// and album tags and the album gains must agree within 0.05 dB. Stored
-    /// values are residuals of each file's current loudness, so a partial or
-    /// inconsistent set cannot be mixed with fresh analysis. Returns the
-    /// shared album gain and the max album peak.
+    /// and album tags, and the album gains must agree (see
+    /// `mp3rgain::consistent_album_gain`). Returns the shared album gain and
+    /// the max album peak.
     fn trusted_album_group(&self, group: &[(usize, PathBuf)]) -> Option<AacAlbumInfo> {
-        let mut album_gain: Option<f64> = None;
-        let mut album_peak: f64 = 0.0;
+        let mut values = Vec::with_capacity(group.len());
         for &(idx, _) in group {
             let tags = trusted_album_tags(self.files.get(idx)?)?;
-            album_peak = album_peak.max(tags.album_peak);
-            match album_gain {
-                Some(g) if (g - tags.album_gain).abs() > 0.05 => return None,
-                Some(_) => {}
-                None => album_gain = Some(tags.album_gain),
-            }
+            values.push((tags.album_gain_db, tags.album_peak));
         }
+        let (album_gain_db, album_peak) = mp3rgain::consistent_album_gain(values)?;
         Some(AacAlbumInfo {
-            album_gain_db: album_gain?,
+            album_gain_db,
             album_peak,
         })
     }
@@ -1211,7 +1206,7 @@ impl Mp3rgainApp {
                                 path: f.path.clone(),
                                 steps,
                                 track_result: Some(ReplayGainResult::from_stored_tags(
-                                    tags.track_gain,
+                                    tags.track_gain_db,
                                     tags.track_peak,
                                     AudioFileType::from_path(&f.path),
                                     AnalysisMode::Rg1,
@@ -1484,6 +1479,14 @@ impl Mp3rgainApp {
                     file.status = FileStatus::NoChangesToUndo;
                 }
             }
+            WorkerEvent::TagsDeleted { idx } => {
+                if let Some(file) = self.files.get_mut(idx) {
+                    file.status = FileStatus::Done;
+                    // Audio levels are unchanged, so the volume / gain columns
+                    // stay valid; only the tag snapshot is stale now.
+                    file.stored_tags = None;
+                }
+            }
             WorkerEvent::StoredTagsRead { idx, view } => {
                 let target = self.target_volume;
                 let mode = self.analysis_mode;
@@ -1593,22 +1596,22 @@ impl Mp3rgainApp {
             }
         };
         let mut found = false;
-        if let Some(track_gain_db) = view.track_gain.as_deref().and_then(parse_rg_gain) {
+        if let Some(track_gain_db) = view.tags.track_gain_db() {
             let (volume, gain) = display(track_gain_db);
             file.volume = volume;
             file.track_gain = Some(gain);
-            if let Some(peak) = view.track_peak.as_deref().and_then(parse_rg_peak) {
+            if let Some(peak) = view.tags.track_peak_value() {
                 file.clipping = peak >= 1.0;
                 file.track_clip = would_clip(peak, gain);
                 file.stored_track_peak = Some(peak);
             }
             found = true;
         }
-        if let Some(album_gain_db) = view.album_gain.as_deref().and_then(parse_rg_gain) {
+        if let Some(album_gain_db) = view.tags.album_gain_db() {
             let (album_volume, album_gain) = display(album_gain_db);
             file.album_volume = album_volume;
             file.album_gain = Some(album_gain);
-            if let Some(peak) = view.album_peak.as_deref().and_then(parse_rg_peak) {
+            if let Some(peak) = view.tags.album_peak_value() {
                 file.album_clip = would_clip(peak, album_gain);
                 file.stored_album_peak = Some(peak);
             }
@@ -1678,39 +1681,17 @@ impl Mp3rgainApp {
     }
 }
 
-/// Stored track tags parsed for `-s R`-style reuse (issue #302): gain and
-/// peak, or `None` when absent, malformed, not yet scanned, or marked with a
-/// `REPLAYGAIN_ALGORITHM` tag: that marker means BS.1770 values, which don't
-/// match the RG1 target this path trusts (same rule as the CLI).
+/// Stored track tags usable for `-s R`-style reuse (issue #302), or `None`
+/// when not yet scanned or the library's RG1 trust rule rejects them (absent,
+/// malformed, or marked with `REPLAYGAIN_ALGORITHM`). Same rule as the CLI.
 fn trusted_track_tags(file: &FileEntry) -> Option<(f64, f64)> {
-    let view = file.stored_tags.as_ref()?;
-    if view.algorithm.is_some() {
-        return None;
-    }
-    let gain = view.track_gain.as_deref().and_then(parse_rg_gain)?;
-    let peak = view.track_peak.as_deref().and_then(parse_rg_peak)?;
-    Some((gain, peak))
-}
-
-/// One file's parsed stored tags for album-mode reuse (issue #302).
-struct StoredAlbumTags {
-    track_gain: f64,
-    track_peak: f64,
-    album_gain: f64,
-    album_peak: f64,
+    file.stored_tags.as_ref()?.tags.rg1_track_values()
 }
 
 /// Album variant of [`trusted_track_tags`]: additionally requires the album
-/// gain/peak pair, mirroring the CLI's `stored_album_report` requirements.
-fn trusted_album_tags(file: &FileEntry) -> Option<StoredAlbumTags> {
-    let (track_gain, track_peak) = trusted_track_tags(file)?;
-    let view = file.stored_tags.as_ref()?;
-    Some(StoredAlbumTags {
-        track_gain,
-        track_peak,
-        album_gain: view.album_gain.as_deref().and_then(parse_rg_gain)?,
-        album_peak: view.album_peak.as_deref().and_then(parse_rg_peak)?,
-    })
+/// gain/peak pair, the CLI's `stored_album_report` requirements.
+fn trusted_album_tags(file: &FileEntry) -> Option<StoredAlbumValues> {
+    file.stored_tags.as_ref()?.tags.rg1_album_values()
 }
 
 /// Display pair for a ReplayGain value, mode-aware (issue #272).

--- a/mp3rgui/src/ui/mod.rs
+++ b/mp3rgui/src/ui/mod.rs
@@ -208,16 +208,7 @@ fn handle_dropped_files(app: &mut Mp3rgainApp, ctx: &egui::Context) {
     // Expand directories recursively so dropping a folder behaves like
     // "Add Folder (with subfolders)". `add_files` itself only keeps regular
     // files, so directories would silently disappear without this.
-    let mut paths = Vec::new();
-    for path in dropped {
-        if path.is_dir() {
-            if let Ok(found) = mp3rgain::collect_audio_files(&path, true) {
-                paths.extend(found);
-            }
-        } else {
-            paths.push(path);
-        }
-    }
+    let paths = mp3rgain::expand_audio_paths(&dropped).unwrap_or_default();
     app.add_files(paths);
 }
 

--- a/mp3rgui/src/ui/table.rs
+++ b/mp3rgui/src/ui/table.rs
@@ -9,35 +9,42 @@ use crate::worker::StoredTagsView;
 fn render_stored_tags_cell(ui: &mut egui::Ui, tags: Option<&StoredTagsView>) {
     let Some(view) = tags else { return };
     if view.is_empty() {
-        ui.weak("none").on_hover_text(format!(
-            "No stored tags found ({} container)",
-            view.format.unwrap_or("?")
-        ));
+        ui.weak("none")
+            .on_hover_text(format!("No stored tags found ({} container)", view.format));
         return;
     }
-    let label = view.track_gain.as_deref().unwrap_or("—");
+    let tags = &view.tags;
+    let label = tags.track_gain.as_deref().unwrap_or("—");
     ui.label(label).on_hover_ui(|ui| {
-        ui.label(format!("Container: {}", view.format.unwrap_or("?")));
+        ui.label(format!("Container: {}", view.format));
         ui.separator();
         for (name, value) in [
             (
                 mp3rgain::TAG_REPLAYGAIN_TRACK_GAIN,
-                view.track_gain.as_deref(),
+                tags.track_gain.as_deref(),
             ),
             (
                 mp3rgain::TAG_REPLAYGAIN_TRACK_PEAK,
-                view.track_peak.as_deref(),
+                tags.track_peak.as_deref(),
             ),
             (
                 mp3rgain::TAG_REPLAYGAIN_ALBUM_GAIN,
-                view.album_gain.as_deref(),
+                tags.album_gain.as_deref(),
             ),
             (
                 mp3rgain::TAG_REPLAYGAIN_ALBUM_PEAK,
-                view.album_peak.as_deref(),
+                tags.album_peak.as_deref(),
             ),
-            (mp3rgain::TAG_MP3GAIN_UNDO, view.undo.as_deref()),
-            (mp3rgain::TAG_MP3GAIN_MINMAX, view.minmax.as_deref()),
+            (
+                mp3rgain::TAG_REPLAYGAIN_ALGORITHM,
+                tags.algorithm.as_deref(),
+            ),
+            (mp3rgain::TAG_MP3GAIN_UNDO, tags.undo.as_deref()),
+            (mp3rgain::TAG_MP3GAIN_MINMAX, tags.minmax.as_deref()),
+            (
+                mp3rgain::TAG_MP3GAIN_ALBUM_MINMAX,
+                tags.album_minmax.as_deref(),
+            ),
         ] {
             if let Some(v) = value {
                 ui.label(format!("{}: {}", name, v));

--- a/mp3rgui/src/worker.rs
+++ b/mp3rgui/src/worker.rs
@@ -9,11 +9,13 @@
 //! `ctx.request_repaint()` so egui actually redraws.
 
 use mp3rgain::apply::{
-    apply_with_options, predict_apply, read_mtime, restore_timestamp, write_album_minmax,
+    apply_with_options, predict_apply, read_mtime_if, restore_timestamp, write_album_minmax,
     ApplyOptions,
 };
 use mp3rgain::replaygain::{self, AnalysisMode, ReplayGainResult};
-use mp3rgain::{read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource, TagLayout};
+use mp3rgain::{
+    read_gain_tags_auto, AacAlbumInfo, Channel, GainTagSource, StoredGainTags, TagLayout,
+};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -21,32 +23,18 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-/// Stored-tag snapshot for one file, populated by `spawn_check_stored_tags`.
-/// All fields are pre-formatted strings so the UI can render them verbatim.
-/// `None` means the tag was absent (not an error).
-#[derive(Default, Clone)]
+/// Stored-tag snapshot for one file, populated by `spawn_check_stored_tags`:
+/// the library's [`StoredGainTags`] (raw tag strings, `None` = absent) plus
+/// the container label the table shows.
+#[derive(Clone)]
 pub struct StoredTagsView {
-    pub format: Option<&'static str>,
-    pub track_gain: Option<String>,
-    pub track_peak: Option<String>,
-    pub album_gain: Option<String>,
-    pub album_peak: Option<String>,
-    /// `REPLAYGAIN_ALGORITHM`; only written by the BS.1770 modes. Not shown
-    /// in the table, but its presence disqualifies the tags from `-s R`-style
-    /// reuse in RG1 mode (issue #302).
-    pub algorithm: Option<String>,
-    pub undo: Option<String>,
-    pub minmax: Option<String>,
+    pub format: &'static str,
+    pub tags: StoredGainTags,
 }
 
 impl StoredTagsView {
     pub fn is_empty(&self) -> bool {
-        self.track_gain.is_none()
-            && self.track_peak.is_none()
-            && self.album_gain.is_none()
-            && self.album_peak.is_none()
-            && self.undo.is_none()
-            && self.minmax.is_none()
+        !self.tags.has_any()
     }
 }
 
@@ -99,12 +87,17 @@ pub enum WorkerEvent {
         message: String,
     },
 
-    /// Stored-tag scan completed for `idx`. `view` carries pre-formatted
-    /// strings; `view.is_empty()` distinguishes "no tags" from "all tags
-    /// read successfully and present".
+    /// Stored-tag scan completed for `idx`. `view.is_empty()` distinguishes
+    /// "no tags" from "all tags read successfully and present".
     StoredTagsRead {
         idx: usize,
         view: StoredTagsView,
+    },
+
+    /// Stored tags were deleted from `idx`. The audio is untouched, so the
+    /// row keeps its volume / gain columns; only the tag snapshot is stale.
+    TagsDeleted {
+        idx: usize,
     },
 
     /// `-x` Find Max Amplitude result for `idx`. Lighter than
@@ -619,7 +612,7 @@ pub fn spawn_undo(ctx: egui::Context, jobs: Vec<UndoJob>, ui_opts: ApplyOptionsU
             run_job_pool(jobs, &cancel_w, move |job: UndoJob| {
                 send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-                let original_mtime = saved_mtime(&job.path, ui_opts.preserve_timestamp);
+                let original_mtime = read_mtime_if(&job.path, ui_opts.preserve_timestamp);
 
                 // Peek at the undo tag before running undo, so we can tell the
                 // UI how many steps to reverse on the display. We can't read
@@ -718,7 +711,7 @@ pub fn spawn_delete_tags(
             run_job_pool(jobs, &cancel_w, move |job: DeleteTagsJob| {
                 send(&tx, &ctx, WorkerEvent::FileStart { idx: job.idx });
 
-                let original_mtime = saved_mtime(&job.path, preserve_timestamp);
+                let original_mtime = read_mtime_if(&job.path, preserve_timestamp);
 
                 let result = mp3rgain::delete_gain_tags_auto(&job.path, layout);
 
@@ -728,18 +721,7 @@ pub fn spawn_delete_tags(
                             restore_timestamp(&job.path, m);
                         }
                         deleted.fetch_add(1, Ordering::Relaxed);
-                        // Tag deletion doesn't change audio levels, so the row's
-                        // volume/gain columns stay valid — pass 0 steps so the UI
-                        // doesn't shift them.
-                        send(
-                            &tx,
-                            &ctx,
-                            WorkerEvent::FileApplied {
-                                idx: job.idx,
-                                actual_steps: 0,
-                                from_stored: false,
-                            },
-                        );
+                        send(&tx, &ctx, WorkerEvent::TagsDeleted { idx: job.idx });
                     }
                     Err(e) => {
                         errors.fetch_add(1, Ordering::Relaxed);
@@ -903,34 +885,23 @@ pub fn spawn_check_stored_tags(
 }
 
 fn read_stored_tags(path: &Path, layout: TagLayout) -> StoredTagsView {
-    match read_gain_tags_auto(path, layout) {
-        Ok(tags) => StoredTagsView {
-            format: Some(match tags.source {
-                GainTagSource::Aac => "MP4",
-                GainTagSource::Id3v2 => "ID3v2",
-                GainTagSource::Ape { .. } => "APE",
-                GainTagSource::Split => "ID3v2+APE",
-            }),
-            track_gain: tags.track_gain,
-            track_peak: tags.track_peak,
-            album_gain: tags.album_gain,
-            album_peak: tags.album_peak,
-            algorithm: tags.algorithm,
-            undo: tags.undo,
-            minmax: tags.minmax,
-        },
-        // Read error: render as an empty tag set, like the pre-unification
-        // fail-soft branches did. The AAC branch never errors, so the label
-        // follows the MP3 tag mode.
-        Err(_) => StoredTagsView {
-            format: Some(match layout {
-                TagLayout::Id3v2 => "ID3v2",
-                TagLayout::Ape => "APE",
-                TagLayout::Split => "ID3v2+APE",
-            }),
-            ..Default::default()
-        },
-    }
+    // A read error renders as an empty tag set, like the pre-unification
+    // fail-soft branches did. The AAC branch never errors, so the fallback
+    // source follows the MP3 tag layout.
+    let tags = read_gain_tags_auto(path, layout).unwrap_or_else(|_| {
+        StoredGainTags::empty(match layout {
+            TagLayout::Id3v2 => GainTagSource::Id3v2,
+            TagLayout::Ape => GainTagSource::Ape { tag_present: false },
+            TagLayout::Split => GainTagSource::Split,
+        })
+    });
+    let format = match tags.source {
+        GainTagSource::Aac => "MP4",
+        GainTagSource::Id3v2 => "ID3v2",
+        GainTagSource::Ape { .. } => "APE",
+        GainTagSource::Split => "ID3v2+APE",
+    };
+    StoredTagsView { format, tags }
 }
 
 /// Build the final `ApplyOptions` by combining always-on safety rails
@@ -963,15 +934,6 @@ fn available_threads() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1)
-}
-
-/// mtime snapshot to restore after a write when "preserve timestamp" is on.
-fn saved_mtime(path: &Path, preserve: bool) -> Option<std::time::SystemTime> {
-    if preserve {
-        read_mtime(path)
-    } else {
-        None
-    }
 }
 
 /// Drain `jobs` through a pool of `available_parallelism` scoped worker

--- a/src/aac.rs
+++ b/src/aac.rs
@@ -1092,13 +1092,22 @@ fn parse_ics(
 // Element parsers
 // =============================================================================
 
-fn parse_sce(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<AacGainLocation>> {
+fn parse_sce(
+    reader: &mut BitReader,
+    sample_rate: u32,
+    out: &mut Vec<AacGainLocation>,
+) -> Result<()> {
     let _tag = reader.read_bits(4)?;
     let (loc, _) = parse_ics(reader, 0, false, None, sample_rate)?;
-    Ok(vec![loc])
+    out.push(loc);
+    Ok(())
 }
 
-fn parse_cpe(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<AacGainLocation>> {
+fn parse_cpe(
+    reader: &mut BitReader,
+    sample_rate: u32,
+    out: &mut Vec<AacGainLocation>,
+) -> Result<()> {
     let _tag = reader.read_bits(4)?;
     let common_window = reader.read_bit()?;
 
@@ -1116,8 +1125,9 @@ fn parse_cpe(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<AacGainLoca
 
     let (loc1, _) = parse_ics(reader, 0, common_window, shared_info.as_ref(), sample_rate)?;
     let (loc2, _) = parse_ics(reader, 1, common_window, shared_info.as_ref(), sample_rate)?;
-
-    Ok(vec![loc1, loc2])
+    out.push(loc1);
+    out.push(loc2);
+    Ok(())
 }
 
 fn skip_dse(reader: &mut BitReader) -> Result<()> {
@@ -1201,9 +1211,15 @@ fn skip_pce(reader: &mut BitReader) -> Result<()> {
     Ok(())
 }
 
-fn parse_raw_data_block(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<AacGainLocation>> {
-    let mut locations = Vec::new();
-
+/// Parse one raw_data_block, appending its `global_gain` locations to
+/// `locations`. The caller owns and reuses the buffer: at ~43 samples per
+/// second of audio, allocating a fresh `Vec` per sample (and per element)
+/// was ~8k heap allocations per minute in the analyzer's hottest loop.
+fn parse_raw_data_block(
+    reader: &mut BitReader,
+    sample_rate: u32,
+    locations: &mut Vec<AacGainLocation>,
+) -> Result<()> {
     loop {
         if reader.bits_remaining() < 3 {
             break;
@@ -1211,14 +1227,8 @@ fn parse_raw_data_block(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<
         let id = reader.read_bits(3)?;
 
         match id {
-            ID_SCE | ID_LFE => {
-                let locs = parse_sce(reader, sample_rate)?;
-                locations.extend(locs);
-            }
-            ID_CPE => {
-                let locs = parse_cpe(reader, sample_rate)?;
-                locations.extend(locs);
-            }
+            ID_SCE | ID_LFE => parse_sce(reader, sample_rate, locations)?,
+            ID_CPE => parse_cpe(reader, sample_rate, locations)?,
             ID_CCE => {
                 // Coupling channel — complex interactions with other channels,
                 // skip this sample to avoid unintended effects
@@ -1238,7 +1248,7 @@ fn parse_raw_data_block(reader: &mut BitReader, sample_rate: u32) -> Result<Vec<
         }
     }
 
-    Ok(locations)
+    Ok(())
 }
 
 // =============================================================================
@@ -1295,7 +1305,19 @@ fn apply_aac_gain_to_data(data: &mut [u8], analysis: &AacAnalysis, gain_steps: i
 ///
 /// Returns the number of modified gain locations.
 pub fn apply_aac_gain_to_path(read_from: &Path, write_to: &Path, gain_steps: i32) -> Result<usize> {
-    apply_aac_gain_to_path_with_analysis(read_from, write_to, gain_steps, None)
+    apply_aac_gain_to_path_with_analysis(read_from, write_to, gain_steps, None, None)
+}
+
+/// Write the finished container. When the caller reads and writes the same
+/// path it gets the temp + rename treatment; a distinct `write_to` is already
+/// the caller's temp file (`apply_with_options`), so a plain write avoids a
+/// pointless temp-of-a-temp.
+fn write_container(read_from: &Path, write_to: &Path, data: &[u8]) -> Result<()> {
+    if read_from == write_to {
+        crate::apply::atomic_write(write_to, data)
+    } else {
+        std::fs::write(write_to, data).map_err(|e| Error::io_write(write_to, e))
+    }
 }
 
 /// [`apply_aac_gain_to_path`] with an optional pre-computed analysis of
@@ -1303,13 +1325,18 @@ pub fn apply_aac_gain_to_path(read_from: &Path, write_to: &Path, gain_steps: i32
 /// check in `apply_with_options`) don't pay for a second bitstream walk
 /// (issue #188). The caller guarantees the file is unchanged since the
 /// analysis — same contract as the MP3 `mp3_analysis` cache from #135.
+///
+/// `replaygain`, when given, is folded into the same container rewrite. A
+/// separate `write_replaygain_tags` afterwards re-read the file, rebuilt the
+/// whole container a second time, and wrote it again.
 pub(crate) fn apply_aac_gain_to_path_with_analysis(
     read_from: &Path,
     write_to: &Path,
     gain_steps: i32,
     analysis: Option<AacAnalysis>,
+    replaygain: Option<&mp4meta::ReplayGainTags>,
 ) -> Result<usize> {
-    if gain_steps == 0 {
+    if gain_steps == 0 && replaygain.is_none() {
         if read_from != write_to {
             std::fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
         }
@@ -1318,14 +1345,20 @@ pub(crate) fn apply_aac_gain_to_path_with_analysis(
 
     let mut data = std::fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
 
-    let analysis = match analysis {
-        Some(a) => a,
-        None => analyze_aac_gains_from_data(&data)?,
+    let modified = if gain_steps == 0 {
+        0
+    } else {
+        let analysis = match analysis {
+            Some(a) => a,
+            None => analyze_aac_gains_from_data(&data)?,
+        };
+        apply_aac_gain_to_data(&mut data, &analysis, gain_steps)
     };
 
-    let modified = apply_aac_gain_to_data(&mut data, &analysis, gain_steps);
-
-    std::fs::write(write_to, &data).map_err(|e| Error::io_write(write_to, e))?;
+    if let Some(rg) = replaygain {
+        data = mp4meta::update_mp4_metadata(&data, rg)?;
+    }
+    write_container(read_from, write_to, &data)?;
 
     Ok(modified)
 }
@@ -1349,12 +1382,12 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
     write_to: &Path,
     gain_steps: i32,
     analysis: Option<AacAnalysis>,
+    replaygain: Option<&mp4meta::ReplayGainTags>,
 ) -> Result<usize> {
     if gain_steps == 0 {
-        if read_from != write_to {
-            std::fs::copy(read_from, write_to).map_err(|e| Error::io_write(write_to, e))?;
-        }
-        return Ok(0);
+        // Nothing to undo, so no undo tag; the ReplayGain tags (if any) are
+        // the only write left.
+        return apply_aac_gain_to_path_with_analysis(read_from, write_to, 0, None, replaygain);
     }
 
     let mut data = std::fs::read(read_from).map_err(|e| Error::io_read(read_from, e))?;
@@ -1391,8 +1424,11 @@ pub(crate) fn apply_aac_gain_with_undo_to_path_with_analysis(
         minmax,
     );
 
-    let final_data = mp4meta::update_mp4_undo_metadata(&data, &undo_tags)?;
-    crate::apply::atomic_write(write_to, &final_data)?;
+    let mut final_data = mp4meta::update_mp4_undo_metadata(&data, &undo_tags)?;
+    if let Some(rg) = replaygain {
+        final_data = mp4meta::update_mp4_metadata(&final_data, rg)?;
+    }
+    write_container(read_from, write_to, &final_data)?;
 
     Ok(modified)
 }
@@ -1458,6 +1494,7 @@ pub(crate) fn analyze_aac_gains_from_data(data: &[u8]) -> Result<AacAnalysis> {
 
     let sample_count = sample_table.len() as u32;
     let mut all_locations = Vec::new();
+    let mut sample_locations = Vec::with_capacity(8);
     let mut parse_warnings = 0u32;
     let mut min_gain = 255u8;
     let mut max_gain = 0u8;
@@ -1475,9 +1512,10 @@ pub(crate) fn analyze_aac_gains_from_data(data: &[u8]) -> Result<AacAnalysis> {
         let sample_data = &data[sample_start..sample_end];
         let mut reader = BitReader::new(sample_data);
 
-        match parse_raw_data_block(&mut reader, sample_rate) {
-            Ok(locations) => {
-                for mut loc in locations {
+        sample_locations.clear();
+        match parse_raw_data_block(&mut reader, sample_rate, &mut sample_locations) {
+            Ok(()) => {
+                for mut loc in sample_locations.drain(..) {
                     loc.sample_index = idx as u32;
                     loc.file_offset = entry.file_offset + loc.sample_byte_offset as u64;
                     min_gain = min_gain.min(loc.original_gain);

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::frame::{iterate_frames, read_gain_at, scan_gain_range};
+use crate::frame::{first_frame_header, iterate_frames, read_gain_at, scan_gain_range, skip_id3v2};
 use crate::gain::{steps_to_db, MAX_GAIN};
 
 use std::fs;
@@ -250,14 +250,18 @@ pub fn analyze_data(data: &[u8]) -> Result<Mp3Analysis> {
 /// `global_gain` headroom (MP3 only) — AAC inputs return an error in
 /// that build.
 ///
+/// The file is read from disk once: the same buffer feeds the gain-range
+/// scan and the decoder (previously each did its own full read).
+///
 /// Note: The max_amplitude is normalized (0.0 to 1.0+), where values > 1.0 indicate clipping.
 /// To get the value in 16-bit PCM scale (like mp3gain), multiply by 32768.
 #[cfg(feature = "replaygain")]
 pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
     use crate::replaygain;
 
-    let peak_result = replaygain::find_peak_amplitude(file_path)?;
-    let (min_gain, max_gain) = read_gain_range(file_path)?;
+    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+    let (min_gain, max_gain) = gain_range_of(&data)?;
+    let peak_result = replaygain::find_peak_amplitude_in_data(file_path, data)?;
 
     Ok(MaxAmplitudeResult::new(
         peak_result.peak(),
@@ -269,7 +273,8 @@ pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
 /// Find maximum amplitude in an MP3 file (fallback without replaygain feature)
 #[cfg(not(feature = "replaygain"))]
 pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
-    let (min_gain, max_gain) = read_gain_range(file_path)?;
+    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
+    let (min_gain, max_gain) = gain_range_of(&data)?;
 
     let headroom_steps = (MAX_GAIN - max_gain) as i32;
     let headroom_db = steps_to_db(headroom_steps);
@@ -278,14 +283,14 @@ pub fn find_max_amplitude(file_path: &Path) -> Result<MaxAmplitudeResult> {
     Ok(MaxAmplitudeResult::new(max_amplitude, max_gain, min_gain))
 }
 
-/// Read the min/max gain values from a file, dispatching by format.
-/// MP3 uses the frame scanner; AAC uses the per-frame `global_gain` scan
-/// from [`crate::aac::analyze_aac_gains`].
-fn read_gain_range(file_path: &Path) -> Result<(u8, u8)> {
-    if crate::mp4meta::is_aac_file(file_path) {
+/// Min/max `global_gain` of a file already in memory, dispatching by
+/// container. MP3 uses the frame scanner; AAC uses the per-frame scan from
+/// [`crate::aac::analyze_aac_gains`].
+fn gain_range_of(data: &[u8]) -> Result<(u8, u8)> {
+    if crate::mp4meta::is_aac_data(data) {
         #[cfg(feature = "aac")]
         {
-            let analysis = crate::aac::analyze_aac_gains(file_path)?;
+            let analysis = crate::aac::analyze_aac_gains_from_data(data)?;
             return Ok((analysis.min_gain(), analysis.max_gain()));
         }
         #[cfg(not(feature = "aac"))]
@@ -296,12 +301,49 @@ fn read_gain_range(file_path: &Path) -> Result<(u8, u8)> {
             });
         }
     }
-    let data = fs::read(file_path).map_err(|e| Error::io_read(file_path, e))?;
-    scan_gain_range(&data)
+    scan_gain_range(data)
+}
+
+/// Channel mode of the first MP3 frame, reading only the head of the file.
+///
+/// [`analyze`] walks every frame to compute gain statistics, but a mono
+/// check or a Joint Stereo warning needs one header. The ID3v2 tag is
+/// skipped by its declared size (cover art can run to megabytes) and a
+/// 64 KiB window read after it, which holds the first frame plus the sync
+/// check on the one following. The rare stream that starts later than that
+/// falls back to a full read.
+pub fn read_channel_mode(file_path: &Path) -> Result<ChannelMode> {
+    use std::io::{Read, Seek, SeekFrom};
+    const WINDOW: usize = 64 * 1024;
+
+    let read_err = |e| Error::io_read(file_path, e);
+    let mut file = fs::File::open(file_path).map_err(|e| Error::io_open(file_path, e))?;
+    let mut head = [0u8; 10];
+    let n = file.read(&mut head).map_err(read_err)?;
+    let start = skip_id3v2(&head[..n]) as u64;
+    file.seek(SeekFrom::Start(start)).map_err(read_err)?;
+
+    let mut window = vec![0u8; WINDOW];
+    let mut filled = 0;
+    while filled < window.len() {
+        let n = file.read(&mut window[filled..]).map_err(read_err)?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    window.truncate(filled);
+    if let Some(header) = first_frame_header(&window) {
+        return Ok(header.channel_mode);
+    }
+
+    let data = fs::read(file_path).map_err(read_err)?;
+    first_frame_header(&data)
+        .map(|h| h.channel_mode)
+        .ok_or(Error::NoMp3Frames)
 }
 
 /// Check if an MP3 file is mono
 pub fn is_mono(file_path: &Path) -> Result<bool> {
-    let analysis = analyze(file_path)?;
-    Ok(analysis.channel_mode() == ChannelMode::Mono)
+    Ok(read_channel_mode(file_path)? == ChannelMode::Mono)
 }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -26,7 +26,7 @@ use crate::gain::{
     apply_gain_to_peak, peak_to_headroom_db, steps_to_db, Channel, GainOptions, GAIN_STEP_DB,
     MAX_GAIN,
 };
-use crate::replaygain::ReplayGainResult;
+use crate::replaygain::{AudioFileType, ReplayGainResult};
 use crate::{ape, id3v2, mp4meta, TagLayout};
 
 /// Per-process counter for `.mp3rgain_temp_*` filenames so parallel
@@ -116,6 +116,12 @@ pub struct ApplyOptions {
     /// since issue #251). Ignored when [`Self::prevent_clipping`] is on —
     /// `-k` needs the check to cap the gain.
     pub skip_clipping_check: bool,
+
+    /// Container of the file, when the caller already knows it (a
+    /// [`ReplayGainResult::file_type`], or its own detection). `None` makes
+    /// the pipeline detect it, which for an MP4 means reopening the file and
+    /// parsing `moov`; the CLI used to pay that two to four times per file.
+    pub file_type: Option<AudioFileType>,
 }
 
 impl ApplyOptions {
@@ -134,6 +140,17 @@ impl ApplyOptions {
             tag_layout: TagLayout::default(),
             channel: None,
             skip_clipping_check: false,
+            file_type: None,
+        }
+    }
+}
+
+impl ApplyOptions {
+    /// Whether the file is AAC, from the caller's hint or by detection.
+    fn is_aac(&self, file_path: &Path) -> bool {
+        match self.file_type {
+            Some(kind) => kind == AudioFileType::Aac,
+            None => mp4meta::is_aac_file(file_path),
         }
     }
 }
@@ -188,25 +205,20 @@ pub enum ClippingDetection {
 /// Does, in order:
 /// 1. Optional clipping check (headroom-based for `-g`/`-l`, peak-based
 ///    when [`ApplyOptions::track_result`] is set).
-/// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC, via temp file +
-///    atomic rename. The MP3 undo and ReplayGain tags (container chosen by
-///    [`ApplyOptions::tag_layout`] — issue #204) are folded into the same
-///    write (issues #227, #232).
-/// 3. Remaining ReplayGain tag writes: AAC mp4 metadata, and the APEv2
-///    re-write for wrap/saturated or channel applies.
-/// 4. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
+/// 2. Gain application — MP3 APE / MP3 ID3v2 / AAC — plus every tag write,
+///    all onto one temp file that is then renamed over the original. The
+///    undo, `MP3GAIN_MINMAX` and ReplayGain tags land in whichever
+///    container [`ApplyOptions::tag_layout`] selects (issue #204), and a
+///    failure anywhere leaves the original untouched (issues #227, #232).
+/// 3. Mtime restoration when [`ApplyOptions::preserve_timestamp`] is on.
 pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
-    let is_aac = mp4meta::is_aac_file(file_path);
+    let is_aac = opts.is_aac(file_path);
 
     if is_aac && opts.channel.is_some() {
         return Err(Error::ChannelGainOnAac);
     }
 
-    let original_mtime = if opts.preserve_timestamp {
-        read_mtime(file_path)
-    } else {
-        None
-    };
+    let original_mtime = read_mtime_if(file_path, opts.preserve_timestamp);
 
     // 1) Clipping check + cap.
     //
@@ -222,80 +234,37 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
     let (actual_steps, clipping_prevented, clipping_detected) =
         check_clipping(file_path, opts, is_aac, &mut aac_analysis, &mut mp3_data)?;
 
-    // 2) Apply gain to bytes. MP3 reports global_gain saturation (issue
-    // #207); AAC clamps in its own path and isn't tallied here.
+    // 2) Apply gain to bytes and write every tag, in one visible write.
+    // MP3 reports global_gain saturation (issue #207); AAC clamps in its own
+    // path and isn't tallied here.
     //
-    // The MP3 paths fold the tag writes into the same visible write as the
-    // gain apply (issue #232): ID3v2 writes undo + minmax + ReplayGain TXXX
-    // frames onto the temp file before the rename, and the APE path embeds
-    // the arithmetic `REPLAYGAIN_*` items in the tag the gain apply already
-    // rewrites. Wrap mode and channel applies keep the separate APE
-    // ReplayGain write in step 3 below.
+    // Each path folds its tag writes into the temp file the gain apply
+    // produces, before the rename (issue #232): a failure anywhere leaves the
+    // original untouched, and no path pays a second full-file rewrite after
+    // the rename. AAC chains the ReplayGain freeform tags onto the same
+    // container rebuild as the undo tag (always arithmetic — AAC clamps
+    // internally, and mp3gain has no AAC, so it is interop-neutral).
+    // `tag_layout` selects a *container for MP3 tags* and must not gate the
+    // AAC write: doing so once skipped the mp4 ReplayGain tags for an `.m4a`
+    // processed under `-s i`, leaving stale values for players to
+    // double-apply.
     let mut saturation = SaturationStats::default();
-    let mut ape_rg_folded = false;
     let modified = if is_aac {
-        apply_aac_bytes(file_path, actual_steps, opts, aac_analysis)?
+        let rg = opts
+            .write_replaygain_tags
+            .then(|| compute_rg_residual(file_path, opts, actual_steps, false))
+            .flatten()
+            .map(|res| res.to_mp4());
+        apply_aac_bytes(file_path, actual_steps, opts, aac_analysis, rg.as_ref())?
     } else if opts.tag_layout.mp3gain_in_id3v2() {
         saturation = apply_mp3_id3v2_bytes(file_path, actual_steps, opts, mp3_data.take())?;
         saturation.frames
     } else {
-        // Under Split the ReplayGain values belong in ID3v2, so nothing is
-        // folded into the APE write here — step 3 handles them.
-        let folded_rg = if opts.write_replaygain_tags
-            && opts.tag_layout == TagLayout::Ape
-            && opts.channel.is_none()
-            && !opts.wrap
-        {
-            compute_rg_residual(file_path, opts, actual_steps, false).map(|r| r.to_ape())
-        } else {
-            None
-        };
-        ape_rg_folded = folded_rg.is_some();
-        saturation =
-            apply_mp3_ape_bytes(file_path, actual_steps, opts, folded_rg, mp3_data.take())?;
+        saturation = apply_mp3_ape_bytes(file_path, actual_steps, opts, mp3_data.take())?;
         saturation.frames
     };
 
-    // 3) Remaining ReplayGain tag writes.
-    //
-    // AAC writes to mp4 freeform metadata (always arithmetic — AAC clamps
-    // internally, and mp3gain has no AAC, so it is interop-neutral).
-    // `tag_layout` selects a *container for MP3 tags*, so it must not gate
-    // the AAC branch — doing so silently skipped the mp4 ReplayGain tags for
-    // an `.m4a` processed under `-s i`, leaving stale values for players to
-    // double-apply. MP3 under `-s i` was already handled in step 2; the other
-    // MP3 layouts land below, where saturation or `-w` wrap means the loudness
-    // shift is not uniform, so the modified file is re-analyzed for the true
-    // post-apply residual and the APE items rewritten. Channel applies keep
-    // the legacy separate write.
-    if opts.write_replaygain_tags {
-        let needs_reanalysis =
-            !is_aac && (opts.wrap || saturation.saturated_low > 0 || saturation.saturated_high > 0);
-        if is_aac {
-            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, false) {
-                mp4meta::write_replaygain_tags(file_path, &res.to_mp4())?;
-            }
-        } else if opts.tag_layout.mp3gain_in_id3v2() {
-            // Folded into the step-2 temp file by apply_mp3_id3v2_bytes.
-        } else if opts.tag_layout == TagLayout::Split {
-            // Write the authoritative ID3v2 values *before* dropping the
-            // APEv2 copies mp3gain or an earlier `-s a` run may have left:
-            // removing them first means a failed ID3v2 write (ENOSPC, a
-            // locked file) leaves the file with no ReplayGain values at all.
-            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
-            {
-                id3v2::write_id3v2_replaygain(file_path, &res.to_id3v2())?;
-            }
-            ape::remove_ape_replaygain(file_path)?;
-        } else if !ape_rg_folded || needs_reanalysis {
-            if let Some(res) = compute_rg_residual(file_path, opts, actual_steps, needs_reanalysis)
-            {
-                ape::write_ape_replaygain(file_path, &res.to_ape())?;
-            }
-        }
-    }
-
-    // 4) Restore mtime.
+    // 3) Restore mtime.
     if let Some(mtime) = original_mtime {
         restore_timestamp(file_path, mtime);
     }
@@ -322,7 +291,7 @@ pub fn apply_with_options(file_path: &Path, opts: &ApplyOptions) -> Result<Apply
 /// "would apply N steps" message lines up with what a real apply
 /// would do.
 pub fn predict_apply(file_path: &Path, opts: &ApplyOptions) -> Result<ApplyReport> {
-    let is_aac = mp4meta::is_aac_file(file_path);
+    let is_aac = opts.is_aac(file_path);
     let mut aac_analysis: AacAnalysisCache = None;
     let (actual_steps, clipping_prevented, clipping_detected) =
         check_clipping(file_path, opts, is_aac, &mut aac_analysis, &mut None)?;
@@ -438,12 +407,13 @@ fn apply_aac_bytes(
     steps: i32,
     opts: &ApplyOptions,
     analysis: AacAnalysisCache,
+    replaygain: Option<&mp4meta::ReplayGainTags>,
 ) -> Result<usize> {
     with_temp_file(file_path, |r, w| {
         if opts.write_undo {
-            aac::apply_aac_gain_with_undo_to_path_with_analysis(r, w, steps, analysis)
+            aac::apply_aac_gain_with_undo_to_path_with_analysis(r, w, steps, analysis, replaygain)
         } else {
-            aac::apply_aac_gain_to_path_with_analysis(r, w, steps, analysis)
+            aac::apply_aac_gain_to_path_with_analysis(r, w, steps, analysis, replaygain)
         }
     })
 }
@@ -454,6 +424,7 @@ fn apply_aac_bytes(
     _steps: i32,
     _opts: &ApplyOptions,
     _analysis: AacAnalysisCache,
+    _replaygain: Option<&mp4meta::ReplayGainTags>,
 ) -> Result<usize> {
     Err(Error::FeatureNotAvailable {
         feature: "AAC support",
@@ -568,13 +539,39 @@ fn compute_rg_residual(
     })
 }
 
+/// MP3 apply for the APEv2-undo layouts ([`TagLayout::Split`] and
+/// [`TagLayout::Ape`]). The undo and `MP3GAIN_MINMAX` items go into the
+/// APEv2 tag the gain apply rewrites anyway; the `REPLAYGAIN_*` values go
+/// wherever the layout puts them, still on the same temp file:
+///
+/// - `Ape`: embedded in that same APEv2 write when the residual is
+///   arithmetic. Under `-w` wrap or saturation the loudness shift is not
+///   uniform, so the modified temp is re-analyzed for the true post-apply
+///   residual and the items rewritten (a tail-only rewrite). Channel applies
+///   take the same second write.
+/// - `Split`: ID3v2 TXXX frames written onto the temp, then any APEv2
+///   `REPLAYGAIN_*` copies mp3gain or an earlier `-s a` run left behind are
+///   dropped, in that order, so a failed ID3v2 write never leaves the file
+///   with no ReplayGain values in either container.
+///
+/// Doing all of this before the rename (as the `-s i` path already did)
+/// replaces the two visible rewrites the default layout used to pay after
+/// it: a full-file copy for the ID3v2 write plus the APEv2 tail rewrite.
 fn apply_mp3_ape_bytes(
     file_path: &Path,
     steps: i32,
     opts: &ApplyOptions,
-    replaygain: Option<ape::ApeReplayGain>,
     preread: Option<Vec<u8>>,
 ) -> Result<SaturationStats> {
+    let write_rg = opts.write_replaygain_tags && opts.track_result.is_some();
+    let folded_rg =
+        if write_rg && opts.tag_layout == TagLayout::Ape && opts.channel.is_none() && !opts.wrap {
+            compute_rg_residual(file_path, opts, steps, false).map(|r| r.to_ape())
+        } else {
+            None
+        };
+    let ape_rg_folded = folded_rg.is_some();
+
     with_temp_file(file_path, |r, w| {
         let mut gain = GainOptions::new(steps)
             .wrap(opts.wrap)
@@ -582,10 +579,25 @@ fn apply_mp3_ape_bytes(
         if let Some(ch) = opts.channel {
             gain = gain.channel(ch);
         }
-        if let Some(rg) = replaygain {
+        if let Some(rg) = folded_rg {
             gain = gain.replaygain(rg);
         }
-        gain.apply_to_path_with_stats_preread(r, w, preread)
+        let stats = gain.apply_to_path_with_stats_preread(r, w, preread)?;
+
+        if write_rg {
+            let reanalyze = opts.wrap || stats.saturated_low > 0 || stats.saturated_high > 0;
+            if opts.tag_layout == TagLayout::Split {
+                if let Some(res) = compute_rg_residual(w, opts, steps, reanalyze) {
+                    id3v2::write_id3v2_replaygain_direct(w, &res.to_id3v2())?;
+                }
+                ape::remove_ape_replaygain(w)?;
+            } else if !ape_rg_folded || reanalyze {
+                if let Some(res) = compute_rg_residual(w, opts, steps, reanalyze) {
+                    ape::write_ape_replaygain(w, &res.to_ape())?;
+                }
+            }
+        }
+        Ok(stats)
     })
 }
 
@@ -607,6 +619,9 @@ fn apply_mp3_id3v2_bytes(
         }
         let stats = gain.apply_to_path_with_stats_preread(r, w, preread)?;
 
+        // Parsed once: the undo read below and the frame write at the end
+        // both work on this tag, where they used to parse the temp twice.
+        let mut tag = id3v2::read_tag(w)?;
         let mut rg = id3v2::Id3v2ReplayGain::default();
 
         if opts.write_undo {
@@ -615,8 +630,8 @@ fn apply_mp3_id3v2_bytes(
                 Some(Channel::Right) => (0, steps),
                 None => (steps, steps),
             };
-            let existing = id3v2::read_id3v2_replaygain(w).unwrap_or_default();
-            let (existing_left, existing_right) = ape::parse_undo_values(existing.undo.as_deref());
+            let existing_undo = id3v2::get_txxx(&tag, ape::TAG_MP3GAIN_UNDO);
+            let (existing_left, existing_right) = ape::parse_undo_values(existing_undo.as_deref());
 
             // MP3GAIN_UNDO stores the *undo* delta (mp3gain convention, issue
             // #210): applying `+delta` makes the stored undo `-delta`,
@@ -629,7 +644,7 @@ fn apply_mp3_id3v2_bytes(
             // without removing anything, so it can never be cleaned up again.
             // Only keep a 0,0 value when one is already stored, so an
             // existing tag is still updated rather than left stale.
-            if (undo_left, undo_right) != (0, 0) || existing.undo.is_some() {
+            if (undo_left, undo_right) != (0, 0) || existing_undo.is_some() {
                 rg.undo = Some(ape::format_undo_value(undo_left, undo_right, opts.wrap));
 
                 // MP3GAIN_MINMAX is the *post-apply* global_gain range
@@ -661,7 +676,7 @@ fn apply_mp3_id3v2_bytes(
         }
 
         if rg.undo.is_some() || rg.track_gain.is_some() {
-            id3v2::write_id3v2_replaygain_direct(w, &rg)?;
+            id3v2::write_rg_frames_direct(w, &mut tag, &rg)?;
         }
         Ok(stats)
     })
@@ -770,6 +785,16 @@ pub fn read_mtime(path: &Path) -> Option<SystemTime> {
     std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
 }
 
+/// [`read_mtime`] when `preserve` is set, `None` otherwise: the snapshot a
+/// caller takes before a write it will later [`restore_timestamp`] from.
+pub fn read_mtime_if(path: &Path, preserve: bool) -> Option<SystemTime> {
+    if preserve {
+        read_mtime(path)
+    } else {
+        None
+    }
+}
+
 /// Values written by [`write_replaygain_tags_only`].
 ///
 /// Unlike the apply path these are *absolute*: no gain is baked into the
@@ -817,11 +842,7 @@ impl TagsOnlyOptions {
 /// `MP3GAIN_ALBUM_MINMAX`. Any that a previous real apply left behind stay
 /// untouched: they still describe the audio as it currently is.
 pub fn write_replaygain_tags_only(file_path: &Path, opts: &TagsOnlyOptions) -> Result<()> {
-    let original_mtime = if opts.preserve_timestamp {
-        read_mtime(file_path)
-    } else {
-        None
-    };
+    let original_mtime = read_mtime_if(file_path, opts.preserve_timestamp);
 
     let values = RgResidual {
         track_gain_db: opts.track_gain_db,

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -486,7 +486,7 @@ mod tests {
     fn absolute_gate_excludes_silence() {
         let mut samples = vec![0.0; 5 * 48000];
         append_sine(&mut samples, -23.0, 20.0, 48000);
-        samples.extend(std::iter::repeat(0.0).take(5 * 48000));
+        samples.extend(std::iter::repeat_n(0.0, 5 * 48000));
         let lufs = integrated_stereo(&samples, 48000);
         assert!((lufs - -23.0).abs() < TOLERANCE, "got {:.3}", lufs);
     }

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -95,6 +95,19 @@ impl Options {
             && self.target_offset_db() == 0.0
     }
 
+    /// A measured gain shifted by the `-m` / `-d` modifiers, as the apply and
+    /// info paths report it: `(steps, dB)`, both quantized to whole
+    /// `global_gain` steps so the two columns always agree. Every caller used
+    /// to spell this out, and one carried a comment asking to be kept in sync
+    /// with the others.
+    pub fn modified_gain(&self, base_steps: i32, base_db: f64) -> (i32, f64) {
+        let modifier_steps = self.gain_modifier_steps();
+        (
+            base_steps + modifier_steps,
+            base_db + mp3rgain::steps_to_db(modifier_steps),
+        )
+    }
+
     /// Combined `-m` (steps) and `-d` (dB) modifier expressed as mp3 gain steps.
     /// `-d` is rounded to the nearest 1.5 dB step; sub-step values silently
     /// round to zero, matching mp3gain's quantized step model.

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -75,8 +75,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         if arg == "--threads" {
             i += 1;
             if i >= args.len() {
-                eprintln!("{}: --threads requires an argument", "error".red().bold());
-                std::process::exit(1);
+                anyhow::bail!("--threads requires an argument");
             }
             opts.threads = Some(parse_thread_count(&args[i], "--threads")?);
             i += 1;
@@ -96,8 +95,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "g" => {
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -g requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-g requires an argument");
                     }
                     opts.gain_steps = Some(
                         args[i]
@@ -110,8 +108,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                     // (adjusts target level relative to 89 dB reference)
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -d requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-d requires an argument");
                     }
                     opts.gain_modifier_db = args[i]
                         .parse()
@@ -120,8 +117,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "m" => {
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -m requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-m requires an argument");
                     }
                     opts.gain_modifier = args[i]
                         .parse()
@@ -130,8 +126,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "s" => {
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -s requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-s requires an argument");
                     }
                     match args[i].as_str() {
                         "c" => opts.stored_tag_mode = StoredTagMode::Check,
@@ -146,12 +141,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                         "i" => opts.tag_layout = TagLayout::Id3v2,
                         "a" => opts.tag_layout = TagLayout::Ape,
                         other => {
-                            eprintln!(
-                                "{}: unknown -s mode '{}', use c/d/s/r/R/i/a",
-                                "error".red().bold(),
-                                other
-                            );
-                            std::process::exit(1);
+                            anyhow::bail!("unknown -s mode '{}', use c/d/s/r/R/i/a", other);
                         }
                     }
                 }
@@ -184,11 +174,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                     // -l <channel> <gain> : apply gain to specific channel
                     i += 1;
                     if i >= args.len() {
-                        eprintln!(
-                            "{}: -l requires two arguments: <channel> <gain>",
-                            "error".red().bold()
-                        );
-                        std::process::exit(1);
+                        anyhow::bail!("-l requires two arguments: <channel> <gain>");
                     }
                     let channel_arg: usize = args[i].parse().map_err(|_| {
                         anyhow::anyhow!(
@@ -205,11 +191,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
 
                     i += 1;
                     if i >= args.len() {
-                        eprintln!(
-                            "{}: -l requires two arguments: <channel> <gain>",
-                            "error".red().bold()
-                        );
-                        std::process::exit(1);
+                        anyhow::bail!("-l requires two arguments: <channel> <gain>");
                     }
                     let gain: i32 = args[i]
                         .parse()
@@ -220,8 +202,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "i" => {
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -i requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-i requires an argument");
                     }
                     opts.track_index = Some(
                         args[i]
@@ -232,8 +213,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 "j" => {
                     i += 1;
                     if i >= args.len() {
-                        eprintln!("{}: -j requires an argument", "error".red().bold());
-                        std::process::exit(1);
+                        anyhow::bail!("-j requires an argument");
                     }
                     opts.threads = Some(parse_thread_count(&args[i], "-j")?);
                 }
@@ -368,16 +348,7 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
 }
 
 pub fn expand_files_recursive(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    let mut result = Vec::new();
-
-    for path in paths {
-        if path.is_dir() {
-            result.extend(mp3rgain::collect_audio_files(path, true)?);
-        } else {
-            result.push(path.clone());
-        }
-    }
-
+    let mut result = mp3rgain::expand_audio_paths(paths)?;
     result.sort();
     // Overlapping roots (e.g. `-R music music/album`) yield duplicates,
     // which would apply gain twice to the same file.
@@ -855,5 +826,32 @@ mod tests {
         assert_eq!(opts.gain_steps, Some(2));
         assert!(opts.preserve_timestamp);
         assert_eq!(opts.files.len(), 2);
+    }
+
+    /// A flag missing its argument is an error like an invalid value, not a
+    /// `process::exit` from inside the parser.
+    #[test]
+    fn missing_argument_is_an_error() {
+        for argv in [
+            vec!["-g"],
+            vec!["-d"],
+            vec!["-m"],
+            vec!["-s"],
+            vec!["-i"],
+            vec!["-j"],
+            vec!["--threads"],
+            vec!["-l"],
+            vec!["-l", "0"],
+            vec!["-s", "z"],
+        ] {
+            let err = match parse_args(&args(&argv)) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("{argv:?} should be rejected"),
+            };
+            assert!(
+                err.contains("requires") || err.contains("unknown -s mode"),
+                "{argv:?}: {err}"
+            );
+        }
     }
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,13 +1,12 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::replaygain::{self, AlbumAnalysisReport, ReplayGainResult};
-use mp3rgain::{mp4meta, peak_to_pcm_sample, steps_to_db};
+use mp3rgain::{mp4meta, peak_to_pcm_sample};
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
-use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
     finish_without_summary, for_each_file_with_analysis_bar, run_album_analysis, TSV_HEADER,
 };
@@ -40,9 +39,6 @@ enum Row {
 }
 
 fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
-    let threads = effective_threads(opts);
-    let parallel = threads > 1 && files.len() > 1;
-
     // Partition by container, keeping original indices so output stays in
     // input order. MP3 files are preferred for the album summary (mp3gain
     // parity when folders mix formats).
@@ -56,8 +52,8 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
         }
     }
 
-    let mp3_report = analyze_set(&mp3_set, opts, threads, parallel);
-    let mp4_report = analyze_set(&mp4_set, opts, threads, parallel);
+    let mp3_report = analyze_set(&mp3_set, opts);
+    let mp4_report = analyze_set(&mp4_set, opts);
 
     // Assemble per-file rows in input order.
     let mut rows: Vec<Option<Row>> = (0..files.len()).map(|_| None).collect();
@@ -133,10 +129,10 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
     if any_ok {
         if let Some(report) = summary_report {
-            // Match the apply path (-a): album_gain_steps() + gain_modifier_steps()
-            let modifier_steps = opts.gain_modifier_steps();
-            let album_gain_steps = report.album.album_gain_steps() + modifier_steps;
-            let album_gain_db = report.album.album_gain_db() + steps_to_db(modifier_steps);
+            let (album_gain_steps, album_gain_db) = opts.modified_gain(
+                report.album.album_gain_steps(),
+                report.album.album_gain_db(),
+            );
             let album_max_amp = peak_to_pcm_sample(report.album.album_peak());
 
             match opts.output_format {
@@ -173,17 +169,12 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
 /// Run one lenient album analysis over a partition, driving a progress bar.
 /// Returns `None` for an empty set or when every file in the set failed.
-fn analyze_set(
-    set: &[(usize, &Path)],
-    opts: &Options,
-    threads: usize,
-    parallel: bool,
-) -> Option<AlbumAnalysisReport> {
+fn analyze_set(set: &[(usize, &Path)], opts: &Options) -> Option<AlbumAnalysisReport> {
     if set.is_empty() {
         return None;
     }
     let paths: Vec<&Path> = set.iter().map(|&(_, p)| p).collect();
-    run_album_analysis(&paths, opts, threads, parallel, true).ok()
+    run_album_analysis(&paths, opts, true).ok()
 }
 
 /// Basic per-file info (JSON output or builds without the replaygain feature).

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -17,7 +17,7 @@ use crate::commands::utils::{
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
 use crate::processors::replaygain::{
-    capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
+    apply_is_noop, capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
 };
 use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
 use crate::util::get_filename;
@@ -108,33 +108,23 @@ fn stored_album_report(files: &[PathBuf], opts: &Options) -> Option<AlbumAnalysi
         return None;
     }
     let mut tracks = Vec::with_capacity(files.len());
-    let mut album_gain: Option<f64> = None;
-    let mut album_peak: f64 = 0.0;
+    let mut album_values = Vec::with_capacity(files.len());
     for file in files {
         let tags = mp3rgain::read_gain_tags_auto(file, opts.tag_layout).ok()?;
-        if tags.algorithm.is_some() {
-            return None;
-        }
-        let gain_db = tags.track_gain_db()?;
-        let peak = tags.track_peak_value()?;
-        let file_album_gain = tags.album_gain_db()?;
-        album_peak = album_peak.max(tags.album_peak_value()?);
-        match album_gain {
-            Some(g) if (g - file_album_gain).abs() > 0.05 => return None,
-            Some(_) => {}
-            None => album_gain = Some(file_album_gain),
-        }
+        let values = tags.rg1_album_values()?;
+        album_values.push((values.album_gain_db, values.album_peak));
         tracks.push(ReplayGainResult::from_stored_tags(
-            gain_db,
-            peak,
+            values.track_gain_db,
+            values.track_peak,
             AudioFileType::from_path(file),
             opts.analysis_mode,
         ));
     }
+    let (album_gain, album_peak) = mp3rgain::consistent_album_gain(album_values)?;
     Some(AlbumAnalysisReport {
         album: AlbumGainResult::from_stored_tags(
             tracks,
-            album_gain?,
+            album_gain,
             album_peak,
             opts.analysis_mode,
         ),
@@ -182,7 +172,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 println!("  {} Analyzing tracks...", "->".cyan());
             }
-            run_album_analysis(&file_refs, opts, threads, parallel, opts.skip_errors)
+            run_album_analysis(&file_refs, opts, opts.skip_errors)
         }
     };
 
@@ -279,21 +269,21 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             let steps = modified_gain_steps;
 
             // A net 0-step album adjustment still has work to do when tags
-            // would be written or `-k` must attenuate a clipping track — the
+            // would be written or `-k` must attenuate a clipping track, the
             // same reasoning as the track path (issue #206). Skipping outright
             // loses the per-track REPLAYGAIN_* tags for an album that merely
             // happens to sit on target (reported on the Hydrogenaudio forum:
             // album gain -0.04 dB, yet track 3 wants +1.46 dB).
-            let writes_rg_tags = opts.stored_tag_mode != StoredTagMode::Skip
-                || album_result
-                    .tracks()
-                    .iter()
-                    .any(|t| t.file_type() == AudioFileType::Aac);
-            let clip_prevention_applies =
-                opts.prevent_clipping && album_result.tracks().iter().any(|t| t.peak() > 1.0);
-
-            // --tags-only always has a tag to write (issue #308).
-            if !opts.tags_only && steps == 0 && !writes_rg_tags && !clip_prevention_applies {
+            let any_aac = album_result
+                .tracks()
+                .iter()
+                .any(|t| t.file_type() == AudioFileType::Aac);
+            let max_peak = album_result
+                .tracks()
+                .iter()
+                .map(|t| t.peak())
+                .fold(0.0, f64::max);
+            if apply_is_noop(opts, steps, any_aac, max_peak) {
                 if opts.output_format == OutputFormat::Json {
                     let json_results: Vec<JsonFileResult> = files
                         .iter()

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -19,13 +19,15 @@ use crate::util::get_filename;
 /// Run one album analysis over `paths`, driving the shared album progress
 /// bar. Serial runs get the byte-level bar via `on_progress`; parallel runs
 /// tick per file via `on_complete`. Shared by `cmd_info` and `cmd_album_gain`.
+/// The thread count follows `-j` (see [`effective_threads`]); only
+/// `skip_errors` varies between callers.
 pub fn run_album_analysis(
     paths: &[&Path],
     opts: &Options,
-    threads: usize,
-    parallel: bool,
     skip_errors: bool,
 ) -> mp3rgain::error::Result<AlbumAnalysisReport> {
+    let threads = effective_threads(opts);
+    let parallel = threads > 1 && paths.len() > 1;
     let show_progress = !opts.quiet && opts.output_format == OutputFormat::Text;
     let mp = MultiProgress::new();
     let pb = if show_progress {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -363,6 +363,14 @@ fn next_frame(
     None
 }
 
+/// Header of the first accepted (non-Xing) frame, or `None` when `data`
+/// holds no MP3 frame. Cheap: stops at the first hit instead of walking the
+/// file, for callers that only need the stream's channel mode or version.
+pub(crate) fn first_frame_header(data: &[u8]) -> Option<FrameHeader> {
+    let audio_end = find_audio_end(data);
+    next_frame(data, skip_id3v2(data), audio_end, None).map(|(_, header, _)| header)
+}
+
 /// Internal function to iterate over frames
 pub(crate) fn iterate_frames<F>(data: &[u8], mut callback: F) -> Result<usize>
 where

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -1,10 +1,12 @@
-use crate::analysis::{analyze_data, ChannelMode};
+use crate::analysis::ChannelMode;
 use crate::ape::{
     parse_undo_values, parse_undo_wrap, read_ape_tag, replace_ape_tag, ApeReplayGain,
     TAG_MP3GAIN_ALBUM_MINMAX, TAG_MP3GAIN_MINMAX, TAG_MP3GAIN_UNDO,
 };
 use crate::error::{Error, Result};
-use crate::frame::{apply_gain_to_data, scan_gain_range, GainMode, SaturationStats};
+use crate::frame::{
+    apply_gain_to_data, first_frame_header, scan_gain_range, GainMode, SaturationStats,
+};
 
 use std::fs;
 use std::path::Path;
@@ -321,7 +323,14 @@ pub fn undo_gain(file_path: &Path) -> Result<usize> {
     tag.remove_replaygain();
 
     let new_data = replace_ape_tag(&data, &tag);
-    crate::apply::atomic_write(file_path, &new_data)?;
+    // Under the split layout the REPLAYGAIN_* residuals live in ID3v2 and
+    // described the gained audio too (issue #306). Strip them on the temp
+    // file so the rollback and both containers' cleanup land in one rename,
+    // where a separate pass afterwards cost a second full-file copy.
+    crate::apply::with_temp_file(file_path, |original, temp| {
+        fs::write(temp, &new_data).map_err(|e| Error::io_write(original, e))?;
+        crate::id3v2::remove_id3v2_rg_values_direct(temp)
+    })?;
 
     Ok(frames)
 }
@@ -446,6 +455,17 @@ fn apply_gain_with_undo_impl_to_path(
     Ok(stats)
 }
 
+/// Channel-specific gain needs two channels; one frame header answers that,
+/// where the previous `analyze_data` walked every frame and computed gain
+/// statistics that were then discarded.
+fn ensure_not_mono(data: &[u8]) -> Result<()> {
+    let header = first_frame_header(data).ok_or(Error::NoMp3Frames)?;
+    if header.channel_mode == ChannelMode::Mono {
+        return Err(Error::ChannelGainOnMono);
+    }
+    Ok(())
+}
+
 /// Apply gain to a specific channel (no undo)
 fn apply_gain_channel_impl(
     mut data: Vec<u8>,
@@ -453,10 +473,7 @@ fn apply_gain_channel_impl(
     channel: Channel,
     gain_steps: i32,
 ) -> Result<SaturationStats> {
-    let analysis = analyze_data(&data)?;
-    if analysis.channel_mode() == ChannelMode::Mono {
-        return Err(Error::ChannelGainOnMono);
-    }
+    ensure_not_mono(&data)?;
 
     let stats = apply_gain_to_data(
         &mut data,
@@ -477,10 +494,7 @@ fn apply_gain_channel_with_undo(
     channel: Channel,
     gain_steps: i32,
 ) -> Result<SaturationStats> {
-    let analysis = analyze_data(&data)?;
-    if analysis.channel_mode() == ChannelMode::Mono {
-        return Err(Error::ChannelGainOnMono);
-    }
+    ensure_not_mono(&data)?;
 
     let mut tag = read_ape_tag(&data).unwrap_or_default();
 

--- a/src/id3v2.rs
+++ b/src/id3v2.rs
@@ -45,7 +45,7 @@ pub struct Id3v2ReplayGain {
     pub minmax: Option<String>,
 }
 
-fn read_tag(path: &Path) -> Result<id3::Tag> {
+pub(crate) fn read_tag(path: &Path) -> Result<id3::Tag> {
     match id3::Tag::read_from_path(path) {
         Ok(tag) => Ok(tag),
         Err(id3::Error {
@@ -124,7 +124,7 @@ fn write_tag(path: &Path, tag: &mut id3::Tag) -> Result<()> {
     })
 }
 
-fn get_txxx(tag: &id3::Tag, description: &str) -> Option<String> {
+pub(crate) fn get_txxx(tag: &id3::Tag, description: &str) -> Option<String> {
     let desc_upper = description.to_uppercase();
     tag.extended_texts()
         .find(|t| t.description.to_uppercase() == desc_upper)
@@ -195,8 +195,19 @@ pub fn write_id3v2_replaygain(path: &Path, rg: &Id3v2ReplayGain) -> Result<()> {
 /// are already writing onto a not-yet-visible temp file (issue #232).
 pub(crate) fn write_id3v2_replaygain_direct(path: &Path, rg: &Id3v2ReplayGain) -> Result<()> {
     let mut tag = read_tag(path)?;
-    add_rg_frames(&mut tag, rg);
-    write_tag_direct(path, &mut tag)
+    write_rg_frames_direct(path, &mut tag, rg)
+}
+
+/// [`write_id3v2_replaygain_direct`] on a tag the caller already parsed with
+/// [`read_tag`], so a caller that needs to inspect the existing frames first
+/// (the `-s i` apply reads the prior `MP3GAIN_UNDO`) parses the tag once.
+pub(crate) fn write_rg_frames_direct(
+    path: &Path,
+    tag: &mut id3::Tag,
+    rg: &Id3v2ReplayGain,
+) -> Result<()> {
+    add_rg_frames(tag, rg);
+    write_tag_direct(path, tag)
 }
 
 /// Delete all ReplayGain and undo TXXX frames from ID3v2 tag
@@ -239,7 +250,12 @@ pub fn undo_gain_id3v2(path: &Path) -> Result<usize> {
         for desc in ALL_RG_DESCRIPTIONS {
             remove_txxx_ci(&mut tag, desc);
         }
-        write_tag_direct(temp, &mut tag)
+        write_tag_direct(temp, &mut tag)?;
+        // The APEv2 copies (a stale `REPLAYGAIN_*` set from mp3gain or an
+        // earlier `-s a` run, and the album range) described the gained
+        // audio too. A tail rewrite on the temp folds their removal into the
+        // same rename instead of a second visible write after it.
+        crate::ape::remove_ape_undone_gain_values(temp)
     })?;
     Ok(frames)
 }
@@ -248,20 +264,39 @@ pub fn undo_gain_id3v2(path: &Path) -> Result<usize> {
 /// `REPLAYGAIN_*` TXXX frames, leaving any `MP3GAIN_UNDO` / `MP3GAIN_MINMAX`
 /// alone. Files without ReplayGain frames are left untouched rather than
 /// rewritten.
+#[allow(dead_code)]
 pub(crate) fn remove_id3v2_rg_values(path: &Path) -> Result<()> {
     let mut tag = read_tag(path)?;
+    if !strip_rg_values(&mut tag) {
+        return Ok(());
+    }
+    write_tag(path, &mut tag)
+}
+
+/// [`remove_id3v2_rg_values`] for a not-yet-visible temp file the caller is
+/// about to rename into place (the APEv2 undo path), so the ID3v2 cleanup
+/// rides along instead of costing a second full-file copy.
+pub(crate) fn remove_id3v2_rg_values_direct(path: &Path) -> Result<()> {
+    let mut tag = read_tag(path)?;
+    if !strip_rg_values(&mut tag) {
+        return Ok(());
+    }
+    write_tag_direct(path, &mut tag)
+}
+
+/// Remove the `REPLAYGAIN_*` frames from `tag`; `false` if there were none.
+fn strip_rg_values(tag: &mut id3::Tag) -> bool {
     let has_rg = tag.extended_texts().any(|t| {
         RG_VALUE_DESCRIPTIONS
             .iter()
             .any(|d| t.description.eq_ignore_ascii_case(d))
     });
-    if !has_rg {
-        return Ok(());
+    if has_rg {
+        for desc in RG_VALUE_DESCRIPTIONS {
+            remove_txxx_ci(tag, desc);
+        }
     }
-    for desc in RG_VALUE_DESCRIPTIONS {
-        remove_txxx_ci(&mut tag, desc);
-    }
-    write_tag(path, &mut tag)
+    has_rg
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,25 +216,16 @@ pub fn undo_gain_auto(file_path: &Path, layout: TagLayout) -> Result<usize> {
         !ape_has_undo() && id3v2_has_undo()
     };
 
-    let frames = if use_id3v2 {
-        id3v2::undo_gain_id3v2(file_path)?
-    } else {
-        gain::undo_gain(file_path)?
-    };
-
     // Issue #306: under the split layout the REPLAYGAIN_* values live in the
     // container that did not hold the undo tag, and they described the
-    // pre-undo audio. Strip stale copies there too. Best-effort: the rollback
-    // already succeeded, so a metadata hiccup here must not turn the undo
-    // into an error.
-    if frames > 0 {
-        if use_id3v2 {
-            let _ = ape::remove_ape_undone_gain_values(file_path);
-        } else {
-            let _ = id3v2::remove_id3v2_rg_values(file_path);
-        }
+    // pre-undo audio. Both undo paths strip those stale copies inside their
+    // own temp-file write, so the rollback and the cleanup of both
+    // containers land in one rename.
+    if use_id3v2 {
+        id3v2::undo_gain_id3v2(file_path)
+    } else {
+        gain::undo_gain(file_path)
     }
-    Ok(frames)
 }
 
 /// Delete ReplayGain / undo tags, auto-dispatching by file format and tag mode.
@@ -294,7 +285,8 @@ pub struct StoredGainTags {
 }
 
 impl StoredGainTags {
-    fn empty(source: GainTagSource) -> Self {
+    /// A snapshot with every tag absent, attributed to `source`.
+    pub fn empty(source: GainTagSource) -> Self {
         Self {
             source,
             track_gain: None,
@@ -326,6 +318,30 @@ impl StoredGainTags {
     /// `REPLAYGAIN_ALBUM_PEAK` parsed to a linear peak.
     pub fn album_peak_value(&self) -> Option<f64> {
         self.album_peak.as_deref().and_then(ape::parse_rg_peak)
+    }
+
+    /// `(gain_db, peak)` from `REPLAYGAIN_TRACK_*` when the stored values can
+    /// stand in for a ReplayGain 1.0 analysis (`-s R`, issue #298): both tags
+    /// present and parseable, and no `REPLAYGAIN_ALGORITHM` marker, which
+    /// would mean BS.1770 values that don't match the RG1 target. The CLI's
+    /// `-s R` and the GUI's "Use stored tags" share this rule.
+    pub fn rg1_track_values(&self) -> Option<(f64, f64)> {
+        if self.algorithm.is_some() {
+            return None;
+        }
+        Some((self.track_gain_db()?, self.track_peak_value()?))
+    }
+
+    /// Album variant of [`Self::rg1_track_values`]: additionally requires the
+    /// `REPLAYGAIN_ALBUM_*` pair.
+    pub fn rg1_album_values(&self) -> Option<StoredAlbumValues> {
+        let (track_gain_db, track_peak) = self.rg1_track_values()?;
+        Some(StoredAlbumValues {
+            track_gain_db,
+            track_peak,
+            album_gain_db: self.album_gain_db()?,
+            album_peak: self.album_peak_value()?,
+        })
     }
 
     /// True if at least one gain tag is present.
@@ -428,6 +444,58 @@ pub fn read_gain_tags_auto(file_path: &Path, layout: TagLayout) -> Result<Stored
             tag_present: false,
         })),
     }
+}
+
+/// One file's stored RG1 values in album mode, from
+/// [`StoredGainTags::rg1_album_values`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StoredAlbumValues {
+    pub track_gain_db: f64,
+    pub track_peak: f64,
+    pub album_gain_db: f64,
+    pub album_peak: f64,
+}
+
+/// Two stored `REPLAYGAIN_ALBUM_GAIN` values are "the same album" within this
+/// many dB: the 6-decimal tag format and mp3gain's own rounding both stay
+/// well inside it.
+pub const ALBUM_GAIN_TOLERANCE_DB: f64 = 0.05;
+
+/// The shared album gain and the loudest album peak across the members of
+/// one album, from each file's stored `(album_gain_db, album_peak)`, or
+/// `None` if the set is empty or the gains disagree by more than
+/// [`ALBUM_GAIN_TOLERANCE_DB`]. Stored values are residuals of each file's
+/// current loudness, so a partial or inconsistent set cannot be mixed with a
+/// fresh analysis: any gap means the whole album gets rescanned (`-s R`,
+/// issue #298; GUI issue #302).
+pub fn consistent_album_gain(values: impl IntoIterator<Item = (f64, f64)>) -> Option<(f64, f64)> {
+    let mut album_gain: Option<f64> = None;
+    let mut album_peak: f64 = 0.0;
+    for (gain, peak) in values {
+        album_peak = album_peak.max(peak);
+        match album_gain {
+            Some(g) if (g - gain).abs() > ALBUM_GAIN_TOLERANCE_DB => return None,
+            Some(_) => {}
+            None => album_gain = Some(gain),
+        }
+    }
+    Some((album_gain?, album_peak))
+}
+
+/// Expand directories in `paths` into the supported audio files they contain
+/// (recursively), keeping plain file paths as they are and preserving input
+/// order. Shared by the CLI's `-R` and the GUI's folder drop / Add Folder, so
+/// the two agree on what a directory expands to.
+pub fn expand_audio_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut result = Vec::with_capacity(paths.len());
+    for path in paths {
+        if path.is_dir() {
+            result.extend(collect_audio_files(path, true)?);
+        } else {
+            result.push(path.clone());
+        }
+    }
+    Ok(result)
 }
 
 /// Read the cumulative *applied* left-channel gain, in steps, without
@@ -541,6 +609,71 @@ mod undo_steps_tests {
         // No tag at all stays None rather than reading as 0.
         let path = write_temp("untagged.mp3", &vec![0u8; 8_000]);
         assert_eq!(read_undo_steps(&path, TagLayout::Split), None);
+    }
+}
+
+#[cfg(test)]
+mod stored_tag_tests {
+    use super::*;
+
+    fn tags(track: Option<&str>, peak: Option<&str>, algorithm: Option<&str>) -> StoredGainTags {
+        StoredGainTags {
+            track_gain: track.map(str::to_string),
+            track_peak: peak.map(str::to_string),
+            algorithm: algorithm.map(str::to_string),
+            ..StoredGainTags::empty(GainTagSource::Split)
+        }
+    }
+
+    /// The `-s R` trust rule shared by the CLI and GUI: both track values
+    /// parse, and no BS.1770 marker.
+    #[test]
+    fn rg1_track_values_requires_both_values_and_no_algorithm_marker() {
+        let (gain, peak) = tags(Some("+1.500000 dB"), Some("0.912345"), None)
+            .rg1_track_values()
+            .unwrap();
+        assert!((gain - 1.5).abs() < 1e-9);
+        assert!((peak - 0.912345).abs() < 1e-9);
+
+        assert!(tags(Some("+1.5 dB"), None, None)
+            .rg1_track_values()
+            .is_none());
+        assert!(tags(None, Some("0.9"), None).rg1_track_values().is_none());
+        assert!(tags(Some("junk"), Some("0.9"), None)
+            .rg1_track_values()
+            .is_none());
+        assert!(tags(Some("+1.5 dB"), Some("0.9"), Some("ITU-R BS.1770"))
+            .rg1_track_values()
+            .is_none());
+    }
+
+    #[test]
+    fn rg1_album_values_needs_the_album_pair_too() {
+        let mut t = tags(Some("+1.5 dB"), Some("0.9"), None);
+        assert!(t.rg1_album_values().is_none());
+        t.album_gain = Some("-2.000000 dB".into());
+        t.album_peak = Some("0.999".into());
+        let v = t.rg1_album_values().unwrap();
+        assert!((v.album_gain_db - -2.0).abs() < 1e-9);
+        assert!((v.album_peak - 0.999).abs() < 1e-9);
+        assert!((v.track_gain_db - 1.5).abs() < 1e-9);
+    }
+
+    /// Members must agree on the album gain (within the tolerance) and the
+    /// album peak is the loudest member's. A gap or a disagreement means the
+    /// whole album gets rescanned.
+    #[test]
+    fn consistent_album_gain_agrees_within_tolerance_and_takes_max_peak() {
+        let (gain, peak) =
+            consistent_album_gain([(-3.0, 0.8), (-3.04, 0.95), (-2.97, 0.5)]).unwrap();
+        assert!(
+            (gain - -3.0).abs() < 1e-9,
+            "first member's gain is reported"
+        );
+        assert!((peak - 0.95).abs() < 1e-9);
+
+        assert!(consistent_album_gain([(-3.0, 0.8), (-3.2, 0.9)]).is_none());
+        assert!(consistent_album_gain(std::iter::empty()).is_none());
     }
 }
 

--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -1230,10 +1230,18 @@ pub fn is_mp4_file(file_path: &Path) -> bool {
         Ok(n) => n,
         Err(_) => return false,
     };
+    is_mp4_header(&buf[..bytes_read])
+}
+
+/// [`is_mp4_file`] on the first bytes of a file already in memory. Only the
+/// leading 128 bytes are inspected.
+fn is_mp4_header(head: &[u8]) -> bool {
+    let buf = &head[..head.len().min(128)];
+    let bytes_read = buf.len();
     if bytes_read < 12 {
         return false;
     }
-    let size = read_u32_be(&buf, 0) as usize;
+    let size = read_u32_be(buf, 0) as usize;
     if &buf[4..8] != b"ftyp" || size < 12 {
         return false;
     }
@@ -1405,8 +1413,12 @@ pub(crate) fn find_trak_sample_info(
 /// Navigates moov → trak → mdia → minf → stbl → stsd to find the codec.
 pub fn detect_mp4_audio_codec(file_path: &Path) -> Option<Mp4AudioCodec> {
     let moov = read_moov_content(file_path)?;
-    traks(&moov, 0, moov.len())
-        .find_map(|(trak_start, trak_size)| detect_codec_in_trak(&moov, trak_start, trak_size))
+    detect_codec_in_moov(&moov, 0, moov.len())
+}
+
+fn detect_codec_in_moov(data: &[u8], moov_start: usize, moov_size: usize) -> Option<Mp4AudioCodec> {
+    traks(data, moov_start, moov_size)
+        .find_map(|(trak_start, trak_size)| detect_codec_in_trak(data, trak_start, trak_size))
 }
 
 fn detect_codec_in_trak(data: &[u8], trak_start: usize, trak_size: usize) -> Option<Mp4AudioCodec> {
@@ -1428,6 +1440,23 @@ pub fn is_aac_file(file_path: &Path) -> bool {
         detect_mp4_audio_codec(file_path),
         Some(Mp4AudioCodec::Aac) | None
     )
+}
+
+/// [`is_aac_file`] on a whole file already in memory, so a caller holding
+/// the bytes doesn't reopen the file to classify it. Same rule: MP4 brand
+/// plus an `mp4a` (or undetectable) codec.
+pub fn is_aac_data(data: &[u8]) -> bool {
+    if !is_mp4_header(data) {
+        return false;
+    }
+    let codec = find_box(data, MOOV).and_then(|(moov_pos, moov_header)| {
+        detect_codec_in_moov(
+            data,
+            moov_pos + moov_header.header_size as usize,
+            moov_header.content_size() as usize,
+        )
+    });
+    matches!(codec, Some(Mp4AudioCodec::Aac) | None)
 }
 
 /// Count the number of audio tracks in an MP4 file.
@@ -1599,6 +1628,7 @@ mod tests {
             );
             assert_eq!(count_audio_tracks(&path), 2, "{name}");
             assert!(is_aac_file(&path), "{name}");
+            assert!(is_aac_data(&std::fs::read(&path).unwrap()), "{name}");
         }
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1709,6 +1739,7 @@ mod tests {
         f.write_all(b"ID3\x04\x00\x00\x00\x00\x00\x00").unwrap();
         drop(f);
         assert!(!is_mp4_file(&path));
+        assert!(!is_aac_data(b"ID3\x04\x00\x00\x00\x00\x00\x00"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/processors/apply.rs
+++ b/src/processors/apply.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use colored::*;
 use mp3rgain::apply::{apply_with_options, predict_apply, ApplyOptions};
-use mp3rgain::{analyze, mp4meta, steps_to_db, Channel};
+use mp3rgain::replaygain::AudioFileType;
+use mp3rgain::{mp4meta, steps_to_db, Channel};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -9,7 +10,9 @@ use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
-use super::utils::{emit_clipping_warning, report_file_error, warn_aac_multi_track};
+use super::utils::{
+    emit_clipping_warning, emit_file_warning, report_file_error, warn_aac_multi_track,
+};
 
 pub fn process_apply(file: &Path, steps: i32, opts: &Options) -> Result<(JsonFileResult, String)> {
     let mut out = String::new();
@@ -24,11 +27,17 @@ fn process_apply_into(
     out: &mut String,
 ) -> Result<JsonFileResult> {
     let filename = get_filename(file);
-    let dry_run_prefix = opts.dry_run_prefix();
 
+    // Detected once here and handed to the pipeline, which used to redo the
+    // MP4 probe (an open plus a `moov` parse) on its own.
     let is_aac = mp4meta::is_aac_file(file);
+    let file_type = Some(if is_aac {
+        AudioFileType::Aac
+    } else {
+        AudioFileType::Mp3
+    });
     if is_aac {
-        warn_aac_multi_track(file, filename, opts, dry_run_prefix);
+        warn_aac_multi_track(file, filename, opts);
     }
 
     // Dry run: don't touch the file. Headroom-based clipping prevention
@@ -47,6 +56,7 @@ fn process_apply_into(
                 let mut apply_opts = ApplyOptions::new(steps);
                 apply_opts.prevent_clipping = opts.prevent_clipping;
                 apply_opts.wrap = opts.wrap_gain;
+                apply_opts.file_type = file_type;
                 match predict_apply(file, &apply_opts) {
                     Ok(report) => {
                         let warning = emit_clipping_warning(steps, &report, opts, filename, None);
@@ -91,6 +101,7 @@ fn process_apply_into(
     // the headroom analyze inside check_clipping feeds nothing observable
     // (issue #232).
     apply_opts.skip_clipping_check = !opts.prevent_clipping && (opts.ignore_clipping || opts.quiet);
+    apply_opts.file_type = file_type;
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
@@ -154,9 +165,7 @@ fn emit_saturation_warning(
         (l, h) => format!("{l} gain value(s) clamped at 0 (silence), {h} at 255 (distortion)"),
     };
     let msg = format!("{detail} - saturated gain is not losslessly reversible");
-    if opts.output_format == OutputFormat::Text && !opts.quiet {
-        eprintln!("  {} {} - {}", "!".yellow(), filename, msg);
-    }
+    emit_file_warning(opts, filename, &msg, None);
     Some(msg)
 }
 
@@ -191,17 +200,17 @@ fn process_apply_channel_into(
     let channel_name = channel.name();
 
     // Warn if file is Joint Stereo (mp3gain only supports Stereo for -l).
-    // Check the output mode first: analyze() reads the whole file, which is
-    // wasted when the warning would not be printed anyway.
+    // One frame header answers that; the whole-file analyze() it replaced
+    // walked every frame for statistics that were then thrown away.
     if opts.output_format == OutputFormat::Text && !opts.quiet {
-        if let Ok(info) = analyze(file) {
-            if info.channel_mode() == mp3rgain::ChannelMode::JointStereo {
-                eprintln!(
-                    "  {} {} - Joint Stereo file: channel-specific gain may not work as expected",
-                    "!".yellow(),
-                    filename
-                );
-            }
+        if let Ok(mp3rgain::ChannelMode::JointStereo) = mp3rgain::analysis::read_channel_mode(file)
+        {
+            emit_file_warning(
+                opts,
+                filename,
+                "Joint Stereo file: channel-specific gain may not work as expected",
+                None,
+            );
         }
     }
 
@@ -235,6 +244,8 @@ fn process_apply_channel_into(
     // has no clipping prevention, so the headroom analyze inside
     // check_clipping is pure waste (issue #232).
     apply_opts.skip_clipping_check = true;
+    // -l is MP3-only (the pipeline rejects AAC), so skip the container probe.
+    apply_opts.file_type = Some(AudioFileType::Mp3);
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::*;
 use indicatif::ProgressBar;
 use mp3rgain::replaygain::{self, ReplayGainResult};
-use mp3rgain::{analyze, mp4meta, peak_to_pcm_sample, steps_to_db};
+use mp3rgain::{analyze, mp4meta, peak_to_pcm_sample};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -37,11 +37,9 @@ pub fn format_rg_row(
     let max_amp = rg_result.peak();
     let (max_gain, min_gain) = gain_range;
 
-    // Calculate gain with modifier, matching the apply paths (-m steps + -d dB,
-    // combined into steps via gain_modifier_steps)
-    let modifier_steps = opts.gain_modifier_steps();
-    let gain_steps = rg_result.gain_steps() + modifier_steps;
-    let gain_db = rg_result.gain_db() + steps_to_db(modifier_steps);
+    // Gain with the -m / -d modifiers folded in, the same way the apply
+    // paths report it.
+    let (gain_steps, gain_db) = opts.modified_gain(rg_result.gain_steps(), rg_result.gain_db());
 
     // Max Amplitude scaled to 32768 (mp3gain format for beets)
     // beets divides by 32768, so we output peak * 32768

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -14,7 +14,7 @@ use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
 use super::utils::{
-    analyze_track, emit_clipping_warning, report_file_error, restore_timestamp,
+    analyze_track, emit_clipping_warning, emit_file_warning, report_file_error, restore_timestamp,
     save_original_mtime, stored_track_result, warn_aac_multi_track,
 };
 
@@ -104,24 +104,12 @@ fn process_track_gain_into(
                 }
             }
 
-            // A net 0-step adjustment still has work to do when (issue #206):
-            //   - ReplayGain analysis tags would be written (AAC always; MP3
-            //     in `-s i` mode), so an already-on-target track gets its
-            //     REPLAYGAIN_* tags (re)written rather than skipped, and/or
-            //   - `-k` must attenuate a track that is already at the
-            //     reference loudness yet already clips (peak > 1.0).
-            // Only the common already-normalized, non-clipping, no-tags case
-            // keeps the cheap "no adjustment needed" skip.
-            // RG analysis tags are written for AAC always, and for MP3 in any
-            // mode that keeps tags (APE default or `-s i` ID3v2) — only `-s s`
-            // skips them (issue #204).
-            let writes_rg_tags = result.file_type() == AudioFileType::Aac
-                || opts.stored_tag_mode != StoredTagMode::Skip;
-            let clip_prevention_applies = opts.prevent_clipping && result.peak() > 1.0;
-            // --tags-only always has a tag to write, so it never takes the
-            // "nothing to do" shortcut (issue #308).
-            if !opts.tags_only && modified_steps == 0 && !writes_rg_tags && !clip_prevention_applies
-            {
+            if apply_is_noop(
+                opts,
+                modified_steps,
+                result.file_type() == AudioFileType::Aac,
+                result.peak(),
+            ) {
                 if opts.output_format == OutputFormat::Text && !opts.quiet {
                     writeln!(out, "  {} {} (no adjustment needed)", ".".cyan(), filename)?;
                 }
@@ -138,6 +126,24 @@ fn process_track_gain_into(
         }
         Err(e) => Ok(report_file_error(file, filename, e, opts)),
     }
+}
+
+/// Whether a ReplayGain apply that nets `steps == 0` has genuinely nothing to
+/// do, so the file can take the cheap "no adjustment needed" skip. It still
+/// has work when (issue #206):
+///   - ReplayGain analysis tags would be written (AAC always, since mp3gain
+///     has no AAC to stay compatible with; MP3 in any mode that keeps tags,
+///     i.e. everything but `-s s`, issue #204), so an already-on-target
+///     track gets its REPLAYGAIN_* tags (re)written rather than skipped;
+///   - `-k` must attenuate a track that already sits at the reference
+///     loudness yet already clips (`peak > 1.0`);
+///   - `--tags-only` always has a tag to write (issue #308).
+///
+/// Album mode passes "any member is AAC" and the loudest member peak.
+pub fn apply_is_noop(opts: &Options, steps: i32, any_aac: bool, max_peak: f64) -> bool {
+    let writes_rg_tags = any_aac || opts.stored_tag_mode != StoredTagMode::Skip;
+    let clip_prevention_applies = opts.prevent_clipping && max_peak > 1.0;
+    !opts.tags_only && steps == 0 && !writes_rg_tags && !clip_prevention_applies
 }
 
 /// Per-file result, buffered text output, and the post-apply `(max, min)`
@@ -185,6 +191,7 @@ fn apply_replaygain_with_album_into(
         apply_opts.track_result = Some(result.clone());
         apply_opts.prevent_clipping = opts.prevent_clipping;
         apply_opts.wrap = opts.wrap_gain;
+        apply_opts.file_type = Some(result.file_type());
         let report = predict_apply(file, &apply_opts)?;
         let warning_msg =
             emit_clipping_warning(steps, &report, opts, filename, Some(result.peak()));
@@ -233,6 +240,7 @@ fn apply_replaygain_with_album_into(
     apply_opts.write_undo = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.write_replaygain_tags = opts.stored_tag_mode != StoredTagMode::Skip;
     apply_opts.tag_layout = opts.tag_layout;
+    apply_opts.file_type = Some(AudioFileType::Mp3);
 
     match apply_with_options(file, &apply_opts) {
         Ok(report) => {
@@ -297,23 +305,13 @@ fn cap_tag_gain(
     if player_peak <= 1.0 {
         return (gain_db, None);
     }
-    let dry_run_prefix = opts.dry_run_prefix();
-
     let capped = capped_tag_gain(gain_db, peak, opts.prevent_clipping);
     if capped != gain_db {
         let msg = format!(
             "{} gain reduced from {:+.2} to {:+.2} dB to prevent clipping (peak: {:.4})",
             label, gain_db, capped, peak
         );
-        if opts.output_format == OutputFormat::Text && !opts.quiet {
-            eprintln!(
-                "  {} {}{} - {}",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                msg
-            );
-        }
+        emit_file_warning(opts, filename, &msg, None);
         return (capped, Some(msg));
     }
 
@@ -324,16 +322,12 @@ fn cap_tag_gain(
         "clipping warning: a player applying the {} gain of {:+.2} dB would peak at {:.2} (>1.00)",
         label, gain_db, player_peak
     );
-    if opts.output_format == OutputFormat::Text {
-        eprintln!(
-            "  {} {}{} - {}",
-            "!".yellow(),
-            dry_run_prefix,
-            filename,
-            msg
-        );
-        eprintln!("      Use -c to ignore clipping warnings or -k to cap the written gain");
-    }
+    emit_file_warning(
+        opts,
+        filename,
+        &msg,
+        Some("Use -c to ignore clipping warnings or -k to cap the written gain"),
+    );
     (gain_db, Some(msg))
 }
 
@@ -354,7 +348,7 @@ fn write_tags_only_into(
     let offset_db = opts.target_offset_db();
 
     if result.file_type() == AudioFileType::Aac {
-        warn_aac_multi_track(file, filename, opts, opts.dry_run_prefix());
+        warn_aac_multi_track(file, filename, opts);
     }
 
     let mut warnings: Vec<String> = Vec::new();
@@ -451,14 +445,18 @@ fn write_tags_only_into(
 
 /// Apply ReplayGain to AAC/M4A files with optional album info.
 ///
-/// Differs from the MP3 path in two ways the unified API can't model
-/// directly:
-///   - bitstream gain failures are logged and swallowed so we still
-///     write the ReplayGain tags (matches pre-issue-#153 behavior),
-///   - tag writing always runs (independent of `--stored-tag-mode`).
+/// Differs from the MP3 path in two ways:
+///   - the ReplayGain tags are always written (independent of
+///     `--stored-tag-mode`), since mp3gain has no AAC to stay compatible
+///     with;
+///   - bitstream gain failures are logged and swallowed, and the tags are
+///     still written, describing the unchanged audio (matches
+///     pre-issue-#153 behavior).
 ///
-/// We therefore drive the apply step with `write_replaygain_tags=false`
-/// and call `mp4meta::write_replaygain_tags` afterwards directly.
+/// The common case is one call: `apply_with_options` folds the ReplayGain
+/// freeform tags into the same container rewrite as the gain and undo tag.
+/// Only the fail-soft branch writes the tags in a separate pass, because
+/// there the apply produced no file to fold them into.
 fn apply_replaygain_aac_with_album_into(
     file: &Path,
     requested_steps: i32,
@@ -469,12 +467,10 @@ fn apply_replaygain_aac_with_album_into(
 ) -> Result<JsonFileResult> {
     let filename = get_filename(file);
 
-    warn_aac_multi_track(file, filename, opts, "");
+    warn_aac_multi_track(file, filename, opts);
 
-    // mtime must be restored AFTER the ReplayGain tag write, not after the
-    // apply step alone — otherwise `mp4meta::write_replaygain_tags` below
-    // bumps the timestamp again. So we keep mtime handling on this side
-    // and tell apply_with_options to leave it alone.
+    // mtime is restored here, after whichever write happened last, so the
+    // fallback tag write cannot bump it again.
     let original_mtime = save_original_mtime(file, opts);
 
     let mut apply_opts = ApplyOptions::new(requested_steps);
@@ -483,103 +479,82 @@ fn apply_replaygain_aac_with_album_into(
     apply_opts.prevent_clipping = opts.prevent_clipping;
     apply_opts.wrap = opts.wrap_gain;
     apply_opts.preserve_timestamp = false;
-    // AAC tag writing is fail-soft, so we drive it ourselves below.
-    apply_opts.write_replaygain_tags = false;
+    apply_opts.write_replaygain_tags = true;
+    apply_opts.file_type = Some(AudioFileType::Aac);
 
-    let mut actual_steps = 0;
-    let mut warning_msg: Option<String> = None;
-    let mut gain_modified: usize = 0;
-
-    // apply_with_options handles temp file, mtime restore, and the
-    // clipping check. We only swallow bitstream errors so we can still
-    // record the ReplayGain tags afterwards.
-    match apply_with_options(file, &apply_opts) {
-        Ok(report) => {
-            actual_steps = report.actual_steps;
-            gain_modified = report.modified;
-            warning_msg = emit_clipping_warning(
+    let (actual_steps, gain_modified, warning_msg) = match apply_with_options(file, &apply_opts) {
+        Ok(report) => (
+            report.actual_steps,
+            report.modified,
+            emit_clipping_warning(
                 requested_steps,
                 &report,
                 opts,
                 filename,
                 Some(result.peak()),
-            );
-        }
+            ),
+        ),
         Err(e) => {
-            // No gain was baked into the bitstream, so actual_steps stays 0
-            // — otherwise the residual tags written below would claim a
-            // loudness shift that never happened.
-            if opts.output_format == OutputFormat::Text && !opts.quiet {
-                eprintln!(
-                    "  {} {} - bitstream gain failed: {} (tags still written)",
-                    "!".yellow(),
-                    filename,
-                    e
-                );
+            emit_file_warning(
+                opts,
+                filename,
+                &format!("bitstream gain failed: {} (tags still written)", e),
+                None,
+            );
+            // No gain was baked into the bitstream, so the tags carry the
+            // full measured values rather than a residual that would claim
+            // a loudness shift that never happened.
+            let mut tags = mp4meta::ReplayGainTags::default();
+            tags.set_track(result.gain_db(), result.peak());
+            if let Some(album) = album_info {
+                tags.set_album(album.album_gain_db, album.album_peak);
             }
+            tags.set_algorithm(result.analysis_mode());
+            if let Err(e) = mp4meta::write_replaygain_tags(file, &tags) {
+                return Ok(report_file_error(file, filename, e, opts));
+            }
+            (0, 0, None)
+        }
+    };
+
+    if let Some(mtime) = original_mtime {
+        restore_timestamp(file, mtime);
+    }
+
+    let tag_type = if album_info.is_some() {
+        "track+album tags"
+    } else {
+        "tags"
+    };
+
+    if opts.output_format == OutputFormat::Text && !opts.quiet {
+        if gain_modified > 0 {
+            writeln!(
+                out,
+                "  {} {} ({} gains modified + {} written, {:+.1} dB)",
+                "v".green(),
+                filename,
+                gain_modified,
+                tag_type,
+                result.gain_db()
+            )?;
+        } else {
+            writeln!(
+                out,
+                "  {} {} ({} written, {:+.1} dB)",
+                "v".green(),
+                filename,
+                tag_type,
+                result.gain_db()
+            )?;
         }
     }
 
-    // Post-apply residual (issue #210), mirroring the MP3 path in
-    // apply_with_options. AAC clamps internally with no saturation tally, so
-    // the loudness shift is the arithmetic applied gain.
-    let applied_db = steps_to_db(actual_steps);
-    let mut tags = mp4meta::ReplayGainTags::default();
-    tags.set_track(
-        result.gain_db() - applied_db,
-        apply_gain_to_peak(result.peak(), applied_db),
-    );
-    if let Some(album) = album_info {
-        tags.set_album(
-            album.album_gain_db - applied_db,
-            apply_gain_to_peak(album.album_peak, applied_db),
-        );
-    }
-    tags.set_algorithm(result.analysis_mode());
-
-    match mp4meta::write_replaygain_tags(file, &tags) {
-        Ok(()) => {
-            if let Some(mtime) = original_mtime {
-                restore_timestamp(file, mtime);
-            }
-
-            let tag_type = if album_info.is_some() {
-                "track+album tags"
-            } else {
-                "tags"
-            };
-
-            if opts.output_format == OutputFormat::Text && !opts.quiet {
-                if gain_modified > 0 {
-                    writeln!(
-                        out,
-                        "  {} {} ({} gains modified + {} written, {:+.1} dB)",
-                        "v".green(),
-                        filename,
-                        gain_modified,
-                        tag_type,
-                        result.gain_db()
-                    )?;
-                } else {
-                    writeln!(
-                        out,
-                        "  {} {} ({} written, {:+.1} dB)",
-                        "v".green(),
-                        filename,
-                        tag_type,
-                        result.gain_db()
-                    )?;
-                }
-            }
-
-            Ok(JsonFileResult {
-                status: Some(FileStatus::Success),
-                gain_applied_steps: Some(actual_steps),
-                gain_applied_db: Some(steps_to_db(actual_steps)),
-                warning: warning_msg,
-                ..JsonFileResult::from_analysis(file, result)
-            })
-        }
-        Err(e) => Ok(report_file_error(file, filename, e, opts)),
-    }
+    Ok(JsonFileResult {
+        status: Some(FileStatus::Success),
+        gain_applied_steps: Some(actual_steps),
+        gain_applied_db: Some(steps_to_db(actual_steps)),
+        warning: warning_msg,
+        ..JsonFileResult::from_analysis(file, result)
+    })
 }

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -11,6 +11,27 @@ pub use mp3rgain::apply::restore_timestamp;
 use crate::cli::options::{Options, OutputFormat};
 use crate::json_output::JsonFileResult;
 
+/// One yellow `!` warning line for `filename` in text mode (never under
+/// `-q`), with an optional indented hint beneath it. Every per-file warning
+/// (clipping, saturation, tags-only cap, multi-track AAC) goes through here
+/// so the stderr shape stays uniform instead of each emitter re-spelling
+/// the format string.
+pub fn emit_file_warning(opts: &Options, filename: &str, msg: &str, hint: Option<&str>) {
+    if opts.output_format != OutputFormat::Text || opts.quiet {
+        return;
+    }
+    eprintln!(
+        "  {} {}{} - {}",
+        "!".yellow(),
+        opts.dry_run_prefix(),
+        filename,
+        msg
+    );
+    if let Some(hint) = hint {
+        eprintln!("      {}", hint);
+    }
+}
+
 /// Shared error arm for the per-file processors: red stderr line in text
 /// mode, plus the JSON error record.
 pub fn report_file_error(
@@ -59,11 +80,7 @@ pub fn stored_track_result(file: &Path, opts: &Options) -> Option<ReplayGainResu
         return None;
     }
     let tags = mp3rgain::read_gain_tags_auto(file, opts.tag_layout).ok()?;
-    if tags.algorithm.is_some() {
-        return None;
-    }
-    let gain_db = tags.track_gain_db()?;
-    let peak = tags.track_peak_value()?;
+    let (gain_db, peak) = tags.rg1_track_values()?;
     Some(ReplayGainResult::from_stored_tags(
         gain_db,
         peak,
@@ -73,11 +90,7 @@ pub fn stored_track_result(file: &Path, opts: &Options) -> Option<ReplayGainResu
 }
 
 pub fn save_original_mtime(file: &Path, opts: &Options) -> Option<SystemTime> {
-    if opts.preserve_timestamp && !opts.dry_run {
-        mp3rgain::apply::read_mtime(file)
-    } else {
-        None
-    }
+    mp3rgain::apply::read_mtime_if(file, opts.preserve_timestamp && !opts.dry_run)
 }
 
 /// Render the user-visible clipping warning after a real or predicted apply.
@@ -92,7 +105,6 @@ pub fn emit_clipping_warning(
     filename: &str,
     track_peak: Option<f64>,
 ) -> Option<String> {
-    let dry_run_prefix = opts.dry_run_prefix();
     let (prevented_detail, warn_msg) = match report.clipping_detected {
         Some(ClippingDetection::Headroom(headroom_steps)) => (
             String::new(),
@@ -115,45 +127,35 @@ pub fn emit_clipping_warning(
             "gain reduced from {} to {} steps to prevent clipping{}",
             requested_steps, report.actual_steps, prevented_detail
         );
-        if opts.output_format == OutputFormat::Text && !opts.quiet {
-            eprintln!(
-                "  {} {}{} - {}",
-                "!".yellow(),
-                dry_run_prefix,
-                filename,
-                msg
-            );
-        }
+        emit_file_warning(opts, filename, &msg, None);
         return Some(msg);
     }
     if opts.ignore_clipping || opts.quiet {
         return None;
     }
-    if opts.output_format == OutputFormat::Text {
-        eprintln!(
-            "  {} {}{} - {}",
-            "!".yellow(),
-            dry_run_prefix,
-            filename,
-            warn_msg
-        );
-        eprintln!("      Use -c to ignore clipping warnings or -k to prevent clipping");
-    }
+    emit_file_warning(
+        opts,
+        filename,
+        &warn_msg,
+        Some("Use -c to ignore clipping warnings or -k to prevent clipping"),
+    );
     Some(warn_msg)
 }
 
-pub fn warn_aac_multi_track(file: &Path, filename: &str, opts: &Options, dry_run_prefix: &str) {
+pub fn warn_aac_multi_track(file: &Path, filename: &str, opts: &Options) {
     if opts.output_format != OutputFormat::Text || opts.quiet {
         return;
     }
     let track_count = mp4meta::count_audio_tracks(file);
     if track_count > 1 {
-        eprintln!(
-            "  {} {}{} - {} audio tracks detected, processing first track only",
-            "!".yellow(),
-            dry_run_prefix,
+        emit_file_warning(
+            opts,
             filename,
-            track_count
+            &format!(
+                "{} audio tracks detected, processing first track only",
+                track_count
+            ),
+            None,
         );
     }
 }

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -2034,8 +2034,23 @@ impl std::fmt::Display for PeakAmplitudeResult {
 #[cfg(feature = "replaygain")]
 pub fn find_peak_amplitude(file_path: &Path) -> Result<PeakAmplitudeResult> {
     let file = std::fs::File::open(file_path).map_err(|e| Error::io_open(file_path, e))?;
+    find_peak_amplitude_from_source(file_path, Box::new(file))
+}
 
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+/// [`find_peak_amplitude`] over bytes already in memory, for callers that
+/// read the file for another scan and shouldn't pay a second disk read.
+/// `file_path` is only used for the format hint and error messages.
+#[cfg(feature = "replaygain")]
+pub fn find_peak_amplitude_in_data(file_path: &Path, data: Vec<u8>) -> Result<PeakAmplitudeResult> {
+    find_peak_amplitude_from_source(file_path, Box::new(std::io::Cursor::new(data)))
+}
+
+#[cfg(feature = "replaygain")]
+fn find_peak_amplitude_from_source(
+    file_path: &Path,
+    source: Box<dyn MediaSource>,
+) -> Result<PeakAmplitudeResult> {
+    let mss = MediaSourceStream::new(source, Default::default());
 
     let mut hint = Hint::new();
     if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
@@ -2148,6 +2163,17 @@ pub fn find_peak_amplitude(file_path: &Path) -> Result<PeakAmplitudeResult> {
 
 #[cfg(not(feature = "replaygain"))]
 pub fn find_peak_amplitude(_file_path: &Path) -> Result<PeakAmplitudeResult> {
+    Err(Error::FeatureNotAvailable {
+        feature: "Peak amplitude analysis",
+        feature_flag: "replaygain",
+    })
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn find_peak_amplitude_in_data(
+    _file_path: &Path,
+    _data: Vec<u8>,
+) -> Result<PeakAmplitudeResult> {
     Err(Error::FeatureNotAvailable {
         feature: "Peak amplitude analysis",
         feature_flag: "replaygain",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -814,3 +814,31 @@ fn write_replaygain_tags_only_preserves_audio_and_mp3gain_tags() {
     );
     cleanup(&path);
 }
+
+// =============================================================================
+// Header-only channel mode
+// =============================================================================
+
+/// `read_channel_mode` reads one frame header instead of walking the file;
+/// it must agree with the full analysis on every fixture, including the
+/// joint-stereo one the `-l` warning exists for.
+#[test]
+fn read_channel_mode_matches_full_analysis() {
+    for name in [
+        "test_stereo.mp3",
+        "test_mono.mp3",
+        "test_joint_stereo.mp3",
+        "test_vbr.mp3",
+    ] {
+        let path = Path::new("tests/fixtures").join(name);
+        let expected = analyze(&path).unwrap().channel_mode();
+        assert_eq!(
+            mp3rgain::analysis::read_channel_mode(&path).unwrap(),
+            expected,
+            "{name}"
+        );
+    }
+    assert!(
+        mp3rgain::analysis::read_channel_mode(Path::new("tests/fixtures/missing.mp3")).is_err()
+    );
+}


### PR DESCRIPTION
Follow-ups from the whole-codebase review behind 3.5.0, covering the items that release left open: the apply / undo write paths and the logic the CLI and GUI still implemented twice.

## Efficiency

- **Default split layout: one rewrite instead of three.** A ReplayGain apply used to do gain + APEv2 undo via temp + rename, then a full-file copy for the ID3v2 `REPLAYGAIN_*` write, then an APEv2 tail rewrite. The ID3v2 frames and the APEv2 cleanup are now written onto the same temp file before the rename, the way the `-s i` path already worked, so a failure anywhere leaves the original untouched. The `-s a` wrap / saturation re-analysis write moved onto the temp too.
- **AAC: one container rebuild instead of two.** The ReplayGain freeform tags are chained onto the same rebuild as the undo tag. The CLI's fail-soft AAC path keeps its "tags still written after a bitstream failure" behavior, but only takes the separate write when the apply itself failed.
- **Undo: no second visible write.** Both undo paths strip the stale cross-container ReplayGain values on their temp file instead of rewriting the file again after the rename.
- `ApplyOptions::file_type` lets callers pass a container they already detected; the pipeline used to reopen the file and parse `moov` on its own, two to four times per AAC file across one CLI operation.
- The `-l` mono check and Joint Stereo warning read one frame header (`analysis::read_channel_mode`) instead of walking the whole file for statistics that were discarded.
- `find_max_amplitude` reads the file once for the gain scan and the decode; the `-s i` apply parses the ID3v2 tag once; the AAC analyzer reuses one `Vec` per sample instead of allocating per element.

## Reuse

- `StoredGainTags::rg1_track_values` / `rg1_album_values` and `consistent_album_gain` hold the `-s R` trust rule once; the CLI and the GUI "Use stored tags" path both call them instead of carrying their own copies (with the 0.05 dB tolerance spelled out in each).
- The GUI's `StoredTagsView` wraps `StoredGainTags` instead of copying its fields; `expand_audio_paths`, `read_mtime_if`, `Options::modified_gain`, `apply_is_noop` and `emit_file_warning` replace the remaining per-frontend copies.
- Tag deletion gets its own `TagsDeleted` worker event instead of reusing `FileApplied` with `actual_steps: 0`.
- `parse_args` reports a missing flag argument as an error like an invalid one, instead of `process::exit` from inside the parser.

## Verification

- `cargo test --all-features`: 187 passed (5 new: header-only channel mode against every fixture, the stored-tag trust helpers, `consistent_album_gain`, missing-argument parse errors, in-memory AAC detection). GUI: 4 passed. `cargo clippy -- -D warnings` clean for both crates.
- Every apply path (split, ape, id3, wrap, tags-only, manual `-g`, channel `-l`) and apply + undo under both layouts were run with this branch and with the 3.5.0 build on the same fixture; all outputs are byte-identical.

## Not included

The GUI `FileEntry` refactor (deriving the display columns from one per-row applied offset) is the remaining structural item from the review. It touches every apply / undo handler in the GUI and is too large for a patch release; it stays on the list.