### PR TITLE
Make -o tsv work with every command, and keep the path in the File column

### DIFF
--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -208,6 +208,12 @@ Output format:
 .BR text " (default),"
 .BR json ", or"
 .BR tsv " (tab-separated values)."
+.BR tsv
+prints the mp3gain-compatible header and one row per file, with the
+.B File
+column holding the path as given on the command line. The rows are also
+emitted while applying gain
+.RB ( \-r ", " \-a ", " \-e ", " \-g ", " \-l ).
 .TP
 .BR \-v ", " \-\-version
 Show version information and exit.
@@ -321,7 +327,10 @@ Original minimum and maximum gain values.
 Success.
 .TP
 .B 1
-Error occurred (invalid arguments, file not found, etc.).
+Error occurred (invalid arguments, file not found, etc.). A batch in which any
+single file failed exits 1, including the read-only commands (plain analysis,
+.BR \-s " c and " \-x ),
+so a scripted scan cannot mistake an unreadable file for a clean run.
 .SH SECURITY
 .B mp3rgain
 is written in Rust, providing memory safety guarantees.

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -99,8 +99,12 @@ format with the canonical header:
 
 ```
 File	MP3 gain	dB gain	Max Amplitude	Max global_gain	Min global_gain
-song.mp3	0	0.0	17234	148	100
+Albums/Foo/01.mp3	0	0.0	17234	148	100
 ```
+
+The `File` column carries the path exactly as it was given on the command line, the way mp3gain prints it. Up to 3.5.1 mp3rgain printed the bare filename instead, which was ambiguous when scanning several directories in one run.
+
+TSV rows are emitted by the gain-applying commands too, not just the bare analysis command: `-r`, `-a` and `-e` print the recommended change for every file (plus the `"Album"` summary row under `-a`) before the frames are rewritten, so `mp3rgain -o tsv -a */*.mp3` reports the same numbers `mp3rgain -o tsv */*.mp3` would.
 
 This means existing parsers that consume mp3gain output — most notably the
 [beets](https://beets.io/) replaygain plugin's command backend — work

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -95,6 +95,7 @@ pub fn print_usage() {
     println!("    mp3rgain -n -g 2 *.mp3         Dry-run (preview changes)");
     println!("    mp3rgain -o json song.mp3      Output in JSON format");
     println!("    mp3rgain -o tsv *.mp3          Output in tab-separated format");
+    println!("    mp3rgain -o tsv -a */*.mp3     TSV rows while applying album gain");
     println!("    mp3rgain -l 0 3 song.mp3       Apply +3 steps to left channel");
     println!("    mp3rgain -l 1 -2 song.mp3      Apply -2 steps to right channel");
     println!();

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{finish_with_summary, for_each_file, report_zero_steps, TSV_HEADER};
 use crate::processors::apply::{process_apply, process_apply_channel};
-use crate::util::get_filename;
+use crate::util::get_path;
 
 pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
     if steps == 0 {
@@ -49,7 +49,7 @@ pub fn cmd_apply(files: &[PathBuf], steps: i32, opts: &Options) -> Result<()> {
             writeln!(
                 text,
                 "{}\t{}\t{:.6}\t-\t{}\t{}",
-                get_filename(file),
+                get_path(file),
                 steps,
                 db_value,
                 result.max_gain.unwrap_or(255),
@@ -76,6 +76,10 @@ pub fn cmd_apply_channel(
     let dry_run_prefix = opts.dry_run_prefix();
     let channel_name = channel.name();
 
+    if opts.output_format == OutputFormat::Tsv {
+        println!("{}", TSV_HEADER);
+    }
+
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         println!(
             "{}{} {} {} step(s) ({:+.1} dB) to {} channel of {} file(s)",
@@ -95,7 +99,19 @@ pub fn cmd_apply_channel(
     }
 
     let (json_results, successful, failed) = for_each_file(files, opts, |file| {
-        let (result, text) = process_apply_channel(file, channel, steps, opts)?;
+        let (result, mut text) = process_apply_channel(file, channel, steps, opts)?;
+        if opts.output_format == OutputFormat::Tsv {
+            // Max Amplitude needs a full decode, and per-channel gain moves
+            // scalefactors rather than global_gain, so the last three columns
+            // have no value to report here.
+            writeln!(
+                text,
+                "{}\t{}\t{:.6}\t-\t-\t-",
+                get_path(file),
+                steps,
+                db_value
+            )?;
+        }
         Ok((Some(result), text))
     })?;
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{
-    finish_without_summary, for_each_file_with_analysis_bar, run_album_analysis, TSV_HEADER,
+    exit_if_failed, finish_without_summary, for_each_file_with_analysis_bar, run_album_analysis,
+    TSV_HEADER,
 };
 use crate::processors::info::{format_rg_row, process_info, scan_gain_range_for_row};
 use crate::util::get_filename;
@@ -95,6 +96,7 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
 
     // Emit rows in input order and collect the album-level gain bounds.
     let mut any_ok = false;
+    let mut failed = 0;
     let mut album_max_gain: Option<u8> = None;
     let mut album_min_gain: Option<u8> = None;
     {
@@ -116,6 +118,7 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 }
                 Some(Row::Failed(msg)) => {
                     eprintln!("{} - {}", get_filename(file).red(), msg);
+                    failed += 1;
                 }
                 None => {}
             }
@@ -164,6 +167,7 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
         }
     }
 
+    exit_if_failed(failed);
     Ok(())
 }
 
@@ -179,10 +183,10 @@ fn analyze_set(set: &[(usize, &Path)], opts: &Options) -> Option<AlbumAnalysisRe
 
 /// Basic per-file info (JSON output or builds without the replaygain feature).
 fn cmd_info_basic(files: &[PathBuf], opts: &Options) -> Result<()> {
-    let (json_results, _, _) =
+    let (json_results, _, failed) =
         for_each_file_with_analysis_bar(files, opts, |file, analysis_pb| {
             process_info(file, opts, analysis_pb).map(|(r, t)| (Some(r), t))
         })?;
 
-    finish_without_summary(json_results, opts)
+    finish_without_summary(json_results, failed, opts)
 }

--- a/src/commands/max_amplitude.rs
+++ b/src/commands/max_amplitude.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{finish_without_summary, for_each_file};
 use crate::json_output::JsonFileResult;
-use crate::util::get_filename;
+use crate::util::{get_filename, get_path};
 
 pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
     if opts.output_format == OutputFormat::Text && !opts.quiet {
@@ -19,10 +19,10 @@ pub fn cmd_max_amplitude(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let (json_results, _, _) =
+    let (json_results, _, failed) =
         for_each_file(files, opts, |file| Ok(process_max_amplitude(file, opts)))?;
 
-    finish_without_summary(json_results, opts)
+    finish_without_summary(json_results, failed, opts)
 }
 
 fn process_max_amplitude(file: &Path, opts: &Options) -> (Option<JsonFileResult>, String) {
@@ -65,7 +65,11 @@ fn process_max_amplitude(file: &Path, opts: &Options) -> (Option<JsonFileResult>
                     writeln!(
                         out,
                         "{}\t{:.6}\t{}\t{}\t{}",
-                        filename, max_pcm_sample, headroom_text, max_gain, min_gain
+                        get_path(file),
+                        max_pcm_sample,
+                        headroom_text,
+                        max_gain,
+                        min_gain
                     )
                     .ok();
                     (None, out)
@@ -84,14 +88,12 @@ fn process_max_amplitude(file: &Path, opts: &Options) -> (Option<JsonFileResult>
             }
         }
         Err(e) => {
-            if opts.output_format == OutputFormat::Json {
-                (Some(JsonFileResult::error(file, e)), out)
-            } else {
-                if !opts.quiet {
-                    eprintln!("{} - {}", filename.red(), e);
-                }
-                (None, out)
+            if opts.output_format != OutputFormat::Json && !opts.quiet {
+                eprintln!("{} - {}", filename.red(), e);
             }
+            // The record is only printed in JSON mode, but it is what makes
+            // the failure countable, so it is built in every mode.
+            (Some(JsonFileResult::error(file, e)), out)
         }
     }
 }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -4,7 +4,7 @@ use mp3rgain::replaygain::{
     self, AlbumAnalysisReport, AlbumGainResult, AudioFileType, ReplayGainResult,
     REPLAYGAIN_REFERENCE_DB,
 };
-use mp3rgain::AacAlbumInfo;
+use mp3rgain::{peak_to_pcm_sample, AacAlbumInfo};
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -13,9 +13,10 @@ use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
     create_json_summary, exit_if_failed, finish_with_album_summary, finish_with_summary,
-    for_each_file_with_analysis_bar, run_album_analysis, update_counters,
+    for_each_file_with_analysis_bar, run_album_analysis, update_counters, TSV_HEADER,
 };
 use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
+use crate::processors::info::{scan_gain_range_for_row, tsv_rg_row};
 use crate::processors::replaygain::{
     apply_is_noop, capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
 };
@@ -58,6 +59,10 @@ pub fn cmd_track_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
 
     let dry_run_prefix = opts.dry_run_prefix();
+
+    if opts.output_format == OutputFormat::Tsv {
+        println!("{}", TSV_HEADER);
+    }
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         if opts.tags_only {
@@ -137,6 +142,10 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
 
     let dry_run_prefix = opts.dry_run_prefix();
+
+    if opts.output_format == OutputFormat::Tsv {
+        println!("{}", TSV_HEADER);
+    }
 
     if opts.output_format == OutputFormat::Text && !opts.quiet {
         println!(
@@ -237,6 +246,12 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             };
 
             let album_info = AacAlbumInfo::from(&album_result);
+
+            // mp3gain-compatible TSV rows, emitted before the apply so the
+            // global_gain columns describe the files as they were scanned.
+            if opts.output_format == OutputFormat::Tsv {
+                emit_album_tsv_rows(files, &album_result, &file_to_track, opts)?;
+            }
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
                 println!();
@@ -478,6 +493,59 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
             }
             std::process::exit(1);
         }
+    }
+
+    Ok(())
+}
+
+/// Per-file rows plus the `"Album"` summary row for `-a -o tsv`, matching what
+/// `-o tsv` alone prints for the same set of files.
+fn emit_album_tsv_rows(
+    files: &[PathBuf],
+    album_result: &AlbumGainResult,
+    file_to_track: &[Option<usize>],
+    opts: &Options,
+) -> Result<()> {
+    // The frame scan re-reads each file, so run it in parallel the way
+    // cmd_info does rather than serializing it inside the emit loop.
+    let gain_ranges: Vec<(u8, u8)> = files
+        .par_iter()
+        .enumerate()
+        .map(|(i, file)| match file_to_track[i] {
+            Some(_) => scan_gain_range_for_row(file),
+            None => (255, 0),
+        })
+        .collect();
+
+    let mut album_max_gain: Option<u8> = None;
+    let mut album_min_gain: Option<u8> = None;
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    for (i, file) in files.iter().enumerate() {
+        let Some(track_idx) = file_to_track[i] else {
+            continue;
+        };
+        let track = &album_result.tracks()[track_idx];
+        handle.write_all(tsv_rg_row(file, opts, track, gain_ranges[i]).as_bytes())?;
+        let (max_gain, min_gain) = gain_ranges[i];
+        album_max_gain = album_max_gain.max(Some(max_gain));
+        album_min_gain = Some(album_min_gain.map_or(min_gain, |m: u8| m.min(min_gain)));
+    }
+
+    if album_max_gain.is_some() {
+        let (album_gain_steps, album_gain_db) = opts.modified_gain(
+            album_result.album_gain_steps(),
+            album_result.album_gain_db(),
+        );
+        writeln!(
+            handle,
+            "\"Album\"\t{}\t{:.6}\t{:.6}\t{}\t{}",
+            album_gain_steps,
+            album_gain_db,
+            peak_to_pcm_sample(album_result.album_peak()),
+            album_max_gain.unwrap_or(255),
+            album_min_gain.unwrap_or(0)
+        )?;
     }
 
     Ok(())

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -12,7 +12,7 @@ use crate::cli::options::{Options, OutputFormat};
 use crate::commands::utils::{finish_with_summary, finish_without_summary, for_each_file};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::processors::utils::{report_file_error, restore_timestamp, save_original_mtime};
-use crate::util::get_filename;
+use crate::util::{get_filename, get_path};
 
 /// Tags plus per-container labels for display in cmd_check_tags
 struct CheckTagInfo<'a> {
@@ -65,7 +65,7 @@ impl CheckTagInfo<'_> {
                     // The algorithm column is appended last so existing
                     // column indices stay stable for scripts.
                     "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                    filename,
+                    get_path(file_path),
                     tags.undo.as_deref().unwrap_or("-"),
                     tags.minmax.as_deref().unwrap_or("-"),
                     tags.track_gain.as_deref().unwrap_or("-"),
@@ -132,6 +132,9 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
             };
             writeln!(out, "  {} [DRY RUN] {} ({})", "~".cyan(), filename, action)?;
         }
+        if opts.output_format == OutputFormat::Tsv {
+            writeln!(out, "{}\t-\tdry-run", get_path(file))?;
+        }
         return Ok((
             JsonFileResult {
                 file: file.display().to_string(),
@@ -179,6 +182,14 @@ fn process_delete_tags(file: &Path, opts: &Options) -> Result<(JsonFileResult, S
                 };
                 writeln!(out, "  {} {} ({})", "v".green(), filename, note)?;
             }
+            if opts.output_format == OutputFormat::Tsv {
+                writeln!(
+                    out,
+                    "{}\t{}\tdeleted",
+                    get_path(file),
+                    undone_frames.map_or("-".to_string(), |f| f.to_string())
+                )?;
+            }
             Ok((
                 JsonFileResult {
                     file: file.display().to_string(),
@@ -203,26 +214,26 @@ pub fn cmd_check_tags(files: &[PathBuf], opts: &Options) -> Result<()> {
         println!();
     }
 
-    let (json_results, _, _) =
+    let (json_results, _, failed) =
         for_each_file(files, opts, |file| Ok(process_check_tags(file, opts)))?;
 
-    finish_without_summary(json_results, opts)
+    finish_without_summary(json_results, failed, opts)
 }
 
 /// Shared error arm for the tag-read branches of `process_check_tags`:
-/// stderr line in text/TSV mode, error record in JSON mode.
+/// stderr line in text/TSV mode, plus the error record. The record is only
+/// printed in JSON mode, but it is what makes the failure countable, so it is
+/// built in every mode.
 fn tag_read_error(
     file: &Path,
     filename: &str,
     e: impl std::fmt::Display,
     opts: &Options,
-) -> Option<JsonFileResult> {
+) -> JsonFileResult {
     if opts.output_format != OutputFormat::Json {
         eprintln!("{} - {}", filename.red(), e);
-        None
-    } else {
-        Some(JsonFileResult::error(file, e))
     }
+    JsonFileResult::error(file, e)
 }
 
 fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, String) {
@@ -231,7 +242,7 @@ fn process_check_tags(file: &Path, opts: &Options) -> (Option<JsonFileResult>, S
 
     let tags = match read_gain_tags_auto(file, opts.tag_layout) {
         Ok(tags) => tags,
-        Err(e) => return (tag_read_error(file, filename, e, opts), out),
+        Err(e) => return (Some(tag_read_error(file, filename, e, opts)), out),
     };
 
     let (undo_label, minmax_label, no_tag_msg) = match tags.source {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -239,9 +239,15 @@ pub fn exit_if_failed(failed: usize) {
     }
 }
 
-/// Epilogue for read-only commands (check tags, max amplitude): JSON output
-/// without a summary block, nothing otherwise.
-pub fn finish_without_summary(json_results: Vec<JsonFileResult>, opts: &Options) -> Result<()> {
+/// Epilogue for read-only commands (info, check tags, max amplitude): JSON
+/// output without a summary block, nothing otherwise. Still exits non-zero on
+/// a failed file, so `mp3rgain -o tsv typo.mp3` in a script is not mistaken
+/// for a successful scan (issue #228 covered the writing commands only).
+pub fn finish_without_summary(
+    json_results: Vec<JsonFileResult>,
+    failed: usize,
+    opts: &Options,
+) -> Result<()> {
     if opts.output_format == OutputFormat::Json {
         let output = JsonOutput {
             files: Some(json_results),
@@ -250,6 +256,7 @@ pub fn finish_without_summary(json_results: Vec<JsonFileResult>, opts: &Options)
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
     }
+    exit_if_failed(failed);
     Ok(())
 }
 

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use crate::cli::options::{Options, OutputFormat};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::processors::utils::analyze_track;
-use crate::util::get_filename;
+use crate::util::{get_filename, get_path};
 
 /// Scan the file's global_gain range for an info row. MP3-only: AAC files
 /// fail the frame scan and get the (255, 0) placeholder mp3gain also prints.
@@ -17,6 +17,28 @@ pub fn scan_gain_range_for_row(file: &Path) -> (u8, u8) {
     analyze(file)
         .map(|info| (info.max_gain(), info.min_gain()))
         .unwrap_or((255, 0))
+}
+
+/// One mp3gain-compatible TSV row from a ReplayGain analysis result.
+/// Shared by the info command and the gain-applying commands (`-r`, `-a`),
+/// which emit the recommended change before touching the frames.
+pub fn tsv_rg_row(
+    file: &Path,
+    opts: &Options,
+    rg_result: &ReplayGainResult,
+    gain_range: (u8, u8),
+) -> String {
+    let (gain_steps, gain_db) = opts.modified_gain(rg_result.gain_steps(), rg_result.gain_db());
+    let (max_gain, min_gain) = gain_range;
+    format!(
+        "{}\t{}\t{:.6}\t{:.6}\t{}\t{}\n",
+        get_path(file),
+        gain_steps,
+        gain_db,
+        peak_to_pcm_sample(rg_result.peak()),
+        max_gain,
+        min_gain
+    )
 }
 
 /// Format one mp3gain-compatible per-file row from a ReplayGain analysis
@@ -47,11 +69,7 @@ pub fn format_rg_row(
 
     match opts.output_format {
         OutputFormat::Tsv => {
-            writeln!(
-                out,
-                "{}\t{}\t{:.6}\t{:.6}\t{}\t{}",
-                filename, gain_steps, gain_db, max_amplitude_scaled, max_gain, min_gain
-            )?;
+            out.push_str(&tsv_rg_row(file, opts, rg_result, gain_range));
         }
         OutputFormat::Text => {
             if !opts.quiet {
@@ -154,7 +172,7 @@ fn process_info_into(
                 }
             }
             OutputFormat::Tsv => {
-                writeln!(out, "{}\t-\t-\t-\t-\t-", filename)?;
+                writeln!(out, "{}\t-\t-\t-\t-\t-", get_path(file))?;
             }
             OutputFormat::Json => {}
         }
@@ -214,7 +232,7 @@ fn process_info_into(
                     writeln!(
                         out,
                         "{}\t{}\t{:.1}\t{:.6}\t{}\t{}",
-                        filename,
+                        get_path(file),
                         info.headroom_steps(),
                         info.headroom_db(),
                         1.0,

--- a/src/processors/replaygain.rs
+++ b/src/processors/replaygain.rs
@@ -13,6 +13,7 @@ use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::json_output::{FileStatus, JsonFileResult};
 use crate::util::get_filename;
 
+use super::info::{scan_gain_range_for_row, tsv_rg_row};
 use super::utils::{
     analyze_track, emit_clipping_warning, emit_file_warning, report_file_error, restore_timestamp,
     save_original_mtime, stored_track_result, warn_aac_multi_track,
@@ -63,6 +64,18 @@ fn process_track_gain_into(
 
     match analysis {
         Ok(result) => {
+            // mp3gain-compatible TSV row for the recommended change. Emitted
+            // before the apply, so the global_gain range describes the file as
+            // it was scanned, the same values `-o tsv` alone reports.
+            if opts.output_format == OutputFormat::Tsv {
+                out.push_str(&tsv_rg_row(
+                    file,
+                    opts,
+                    &result,
+                    scan_gain_range_for_row(file),
+                ));
+            }
+
             // Apply gain modifier (-m steps + -d dB, combined into steps)
             let base_steps = result.gain_steps();
             let modifier_steps = opts.gain_modifier_steps();

--- a/src/processors/undo.rs
+++ b/src/processors/undo.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::cli::options::{Options, OutputFormat};
 use crate::json_output::{FileStatus, JsonFileResult};
-use crate::util::get_filename;
+use crate::util::{get_filename, get_path};
 
 use super::utils::{report_file_error, restore_timestamp, save_original_mtime};
 
@@ -25,6 +25,9 @@ fn process_undo_into(file: &Path, opts: &Options, out: &mut String) -> Result<Js
     if opts.dry_run {
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             writeln!(out, "  {} [DRY RUN] {} (would undo)", "~".cyan(), filename)?;
+        }
+        if opts.output_format == OutputFormat::Tsv {
+            writeln!(out, "{}\t-\tdry-run", get_path(file))?;
         }
         return Ok(JsonFileResult {
             file: file.display().to_string(),
@@ -48,6 +51,9 @@ fn process_undo_into(file: &Path, opts: &Options, out: &mut String) -> Result<Js
                         filename
                     )?;
                 }
+                if opts.output_format == OutputFormat::Tsv {
+                    writeln!(out, "{}\t0\tno-change", get_path(file))?;
+                }
 
                 Ok(JsonFileResult {
                     file: file.display().to_string(),
@@ -69,6 +75,9 @@ fn process_undo_into(file: &Path, opts: &Options, out: &mut String) -> Result<Js
                         filename,
                         frames
                     )?;
+                }
+                if opts.output_format == OutputFormat::Tsv {
+                    writeln!(out, "{}\t{}\trestored", get_path(file), frames)?;
                 }
 
                 Ok(JsonFileResult {

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -32,15 +32,17 @@ pub fn emit_file_warning(opts: &Options, filename: &str, msg: &str, hint: Option
     }
 }
 
-/// Shared error arm for the per-file processors: red stderr line in text
-/// mode, plus the JSON error record.
+/// Shared error arm for the per-file processors: red stderr line in text and
+/// TSV mode, plus the JSON error record. TSV rows go to stdout, so the stderr
+/// line cannot corrupt the stream, and staying silent left a failing file with
+/// no explanation at all.
 pub fn report_file_error(
     file: &Path,
     filename: &str,
     e: impl std::fmt::Display,
     opts: &Options,
 ) -> JsonFileResult {
-    if opts.output_format == OutputFormat::Text && !opts.quiet {
+    if opts.output_format != OutputFormat::Json && !opts.quiet {
         eprintln!("  {} {} - {}", "x".red(), filename, e);
     }
     JsonFileResult::error(file, e)

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,3 +6,13 @@ pub fn get_filename(path: &Path) -> &str {
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
 }
+
+/// Path as given on the command line, for machine-readable output.
+///
+/// TSV rows used to print the bare filename, which is ambiguous as soon as
+/// more than one directory is scanned in a single run (reported on the
+/// Hydrogenaudio forum). JSON has always carried the full path; TSV now
+/// matches it.
+pub fn get_path(path: &Path) -> std::borrow::Cow<'_, str> {
+    path.to_string_lossy()
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -577,3 +577,101 @@ fn tags_only_k_caps_written_gain_at_headroom() {
     let written = track_gain_db(file).expect("REPLAYGAIN_TRACK_GAIN");
     assert!((written - got).abs() < 0.01, "written {}", written);
 }
+
+/// Reported on the Hydrogenaudio forum: TSV rows printed the bare filename,
+/// which collides as soon as more than one album is scanned in a single run.
+#[test]
+fn tsv_rows_carry_the_path_as_given() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let file = &album.files[0];
+    let path = file.to_str().unwrap();
+
+    let text = stdout_of(&run(&["-o", "tsv", path]));
+    let row = text.lines().nth(1).expect("TSV data row");
+    assert_eq!(row.split('\t').next(), Some(path), "row: {}", row);
+}
+
+/// Reported on the Hydrogenaudio forum: `-o tsv` only produced rows for the
+/// bare analysis command. Combined with `-r` or `-a` it printed nothing at all.
+#[test]
+fn tsv_rows_are_emitted_by_the_gain_applying_commands() {
+    for args in [
+        vec!["-r", "-n"],
+        vec!["-a", "-n"],
+        vec!["-e", "-n"],
+        vec!["-g", "1", "-n"],
+    ] {
+        let album = TempAlbum::new(&["test_mono.mp3"]);
+        let path = album.files[0].to_str().unwrap();
+
+        let mut argv = args.clone();
+        argv.extend_from_slice(&["-o", "tsv", path]);
+        let text = stdout_of(&run(&argv));
+
+        assert!(
+            text.starts_with("File\tMP3 gain\t"),
+            "{:?} lost the TSV header: {:?}",
+            args,
+            text
+        );
+        let row = text
+            .lines()
+            .nth(1)
+            .unwrap_or_else(|| panic!("{:?} emitted no TSV row", args));
+        assert_eq!(row.split('\t').next(), Some(path), "row: {}", row);
+    }
+}
+
+/// `-a -o tsv` reports the same recommended gain as `-o tsv` alone, including
+/// the trailing `"Album"` summary row.
+#[test]
+fn tsv_album_mode_matches_the_analysis_only_rows() {
+    let album = TempAlbum::new(&["test_mono.mp3", "test_stereo.mp3"]);
+    let mut analysis = vec!["-o", "tsv"];
+    analysis.extend(album.args());
+    let expected = stdout_of(&run(&analysis));
+
+    let mut applied = vec!["-o", "tsv", "-a", "-n"];
+    applied.extend(album.args());
+    assert_eq!(stdout_of(&run(&applied)), expected);
+    assert!(expected.contains("\"Album\"\t"), "{}", expected);
+}
+
+/// Issue #228 gave the writing commands a non-zero exit on failure but left
+/// the read-only ones (info, `-s c`, `-x`) reporting success for a file they
+/// could not even open, in every output format.
+#[test]
+fn read_only_commands_exit_non_zero_on_an_unreadable_file() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let good = album.files[0].to_str().unwrap().to_string();
+    let missing = album
+        .dir
+        .join("no_such_file.mp3")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    for command in [vec![], vec!["-s", "c"], vec!["-x"]] {
+        for format in [vec![], vec!["-o", "tsv"], vec!["-o", "json"]] {
+            let base: Vec<&str> = command.iter().chain(format.iter()).copied().collect();
+
+            let mut ok = base.clone();
+            ok.push(&good);
+            assert!(
+                run(&ok).status.success(),
+                "{:?} failed on a readable file",
+                ok
+            );
+
+            for files in [vec![&missing], vec![&good, &missing]] {
+                let mut argv = base.clone();
+                argv.extend(files.iter().map(|f| f.as_str()));
+                assert!(
+                    !run(&argv).status.success(),
+                    "{:?} exited 0 despite an unreadable file",
+                    argv
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reported by skamp on the [Hydrogenaudio forum](https://hydrogenaud.io/) against 3.5.1:

> Looks good to me, except for one thing: `-o tsv` doesn't seem to work with other parameters for some reason. `-o text` and `-o json` do work.
>
> Also, with `-o tsv` on its own, it outputs filenames without their relative paths. That's a problem when scanning multiple albums / directories at once.

## 1. `-o tsv` was ignored by most commands

TSV output was only wired into the bare analysis command, `-g`, `-s c` and `-x`. Every other command tested `output_format == Text` or `== Json` and fell through both arms, so `-o tsv` combined with `-r`, `-a`, `-e`, `-l`, `-u` or `-s d` printed nothing at all and still exited 0.

```
$ mp3rgain -o tsv -a -n albumA/a.mp3 albumB/b.mp3     # 3.5.1
$ echo $?
0
```

The gain-applying commands now emit the mp3gain-compatible header and one row per file. Rows are printed **before** the frames are rewritten, so the `Max/Min global_gain` columns describe the file as it was scanned, matching what `-o tsv` alone reports. `-a` also emits the trailing `"Album"` summary row, which makes `-o tsv -a` byte-identical to `-o tsv` over the same files (asserted in a test).

`-l` has no Max Amplitude and no meaningful `global_gain` range to report, since per-channel gain moves scalefactors rather than `global_gain`, so those three columns carry `-` rather than a fabricated value. `-u` and `-s d` do not fit the gain columns at all and get a short `path <TAB> frames <TAB> status` row instead of silence.

Per-file errors were swallowed entirely in TSV mode too, leaving a failing file with no explanation anywhere. They now go to stderr, which cannot corrupt the rows on stdout.

## 2. The `File` column dropped the path

TSV rows used `get_filename()` (basename only). JSON has always carried the full path, and mp3gain itself echoes the argument path verbatim, so this was a compatibility bug as well as an ambiguity one. The column now carries the path exactly as given on the command line.

```
$ mp3rgain -R -o tsv -a -n .
File	MP3 gain	dB gain	Max Amplitude	Max global_gain	Min global_gain
./albumA/a.mp3	-37	-55.170000	19349834301440.000000	255	255
./albumB/b.mp3	2	3.700000	3896.272461	210	115
"Album"	-37	-55.170000	19349834301440.000000	255	115
```

beets' command backend parses these rows positionally and passes absolute paths, so it is unaffected.

## 3. Read-only commands exited 0 on an unreadable file

Found while testing the above. Issue #228 gave the writing commands a non-zero exit on failure, but `finish_without_summary` never called `exit_if_failed`, and `-s c` / `-x` discarded their error records outside JSON mode so there was nothing to count. Plain analysis, `-s c` and `-x` therefore returned 0 for a file they could not even open, in every output format. The CLI reference already documented exit 1 for unreadable input, so this brings the implementation in line with the docs.

A file with no gain tags (`FileStatus::NoTag`) is still not a failure and keeps exiting 0.

## Verification

```
--- nonexistent file ---           --- all good (must stay 0) ---
nope.mp3                exit=1     albumA/a.mp3 albumB/b.mp3  exit=0
-o tsv nope.mp3         exit=1     -o tsv ...                 exit=0
-o json nope.mp3        exit=1     -o json ...                exit=0
-x nope.mp3             exit=1     -x albumA/a.mp3            exit=0
-s c nope.mp3           exit=1     -s c albumA/a.mp3          exit=0
```

Four CLI regression tests added. `cargo fmt --check`, `cargo clippy` and `cargo test` (191 tests) all pass. Docs updated: `--help`, the man page and `docs/migrating-from-mp3gain.md`.