### PR TITLE
mp3rgui: load a system CJK font as fallback for file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See **[docs/migrating-from-mp3gain.md](docs/migrating-from-mp3gain.md)** for the
   <img src="docs/branding/mp3rgui-screenshot-compact.png" alt="mp3rgui showing track and album ReplayGain analysis for a batch of files" width="820">
 </p>
 
-`mp3rgui` covers the CLI's core workflow - track/album analysis and gain, undo, tag inspection, clipping prevention - with drag-and-drop loading and per-file progress. It shares the same apply pipeline as the CLI. Install via the table above.
+`mp3rgui` covers the CLI's core workflow - track/album analysis and gain, undo, tag inspection, clipping prevention - with drag-and-drop loading and per-file progress. It shares the same apply pipeline as the CLI. Install via the table above. File names in Japanese, Chinese or Korean are rendered with a CJK font already installed on your system; set `MP3RGUI_FONT` to a font file path to pick a different one.
 
 ## Docker / CI
 

--- a/mp3rgui/src/app.rs
+++ b/mp3rgui/src/app.rs
@@ -440,6 +440,7 @@ pub struct Mp3rgainApp {
 
 impl Mp3rgainApp {
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        crate::fonts::install(&cc.egui_ctx);
         // Restore the user's checkboxes / target from the previous session
         // (issue #202). Window geometry + column widths are handled by eframe.
         let settings: PersistedSettings = cc

--- a/mp3rgui/src/fonts.rs
+++ b/mp3rgui/src/fonts.rs
@@ -1,0 +1,233 @@
+//! System CJK font fallback (issue #321).
+//!
+//! egui's built-in fonts cover Latin, Greek and Cyrillic only, so a filename
+//! like `01-日本語の曲.mp3` renders its kana and kanji as missing-glyph boxes.
+//! Bundling Noto Sans CJK would add 15-20 MB to every binary, so instead the
+//! first CJK font the OS already ships is appended to both font families as a
+//! fallback. Only glyphs missing from egui's own fonts are taken from it, so
+//! Latin text is unchanged.
+//!
+//! Exactly one font is loaded. egui keeps two copies of the bytes (the
+//! `FontDefinitions` and the parsed `ab_glyph` font), so loading a Japanese,
+//! a Chinese and a Korean face on macOS would cost well over 100 MB.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Environment variable naming a font file to use instead of the built-in
+/// candidate list. The escape hatch for an OS font set we did not predict.
+pub const FONT_ENV: &str = "MP3RGUI_FONT";
+
+/// Language groups a candidate font primarily serves. The user's locale
+/// moves its group to the front; Japanese is the default order since every
+/// CJK font covers kana and most kanji, while Hangul needs a Korean face.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Lang {
+    Ja,
+    Zh,
+    Ko,
+}
+
+#[cfg(target_os = "macos")]
+const CANDIDATES: &[(Lang, &str)] = &[
+    (Lang::Ja, "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc"),
+    (Lang::Zh, "/System/Library/Fonts/PingFang.ttc"),
+    (Lang::Zh, "/System/Library/Fonts/Hiragino Sans GB.ttc"),
+    (Lang::Ko, "/System/Library/Fonts/AppleSDGothicNeo.ttc"),
+    (
+        Lang::Ko,
+        "/System/Library/Fonts/Supplemental/AppleGothic.ttf",
+    ),
+    (
+        Lang::Ja,
+        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+    ),
+];
+
+#[cfg(windows)]
+const CANDIDATES: &[(Lang, &str)] = &[
+    (Lang::Ja, "YuGothM.ttc"),
+    (Lang::Ja, "meiryo.ttc"),
+    (Lang::Ja, "msgothic.ttc"),
+    (Lang::Zh, "msyh.ttc"),
+    (Lang::Zh, "simsun.ttc"),
+    (Lang::Ko, "malgun.ttf"),
+];
+
+#[cfg(not(any(target_os = "macos", windows)))]
+const CANDIDATES: &[(Lang, &str)] = &[
+    (
+        Lang::Ja,
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    ),
+    (
+        Lang::Ja,
+        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+    ),
+    (
+        Lang::Ja,
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    ),
+    (
+        Lang::Ja,
+        "/usr/share/fonts/opentype/ipafont-gothic/ipagp.ttf",
+    ),
+    (
+        Lang::Ja,
+        "/usr/share/fonts/truetype/fonts-japanese-gothic.ttf",
+    ),
+    (
+        Lang::Ja,
+        "/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf",
+    ),
+    (Lang::Zh, "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc"),
+    (Lang::Ko, "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"),
+];
+
+/// Install egui's default fonts plus the system CJK fallback, if one exists.
+pub fn install(ctx: &egui::Context) {
+    let mut defs = egui::FontDefinitions::default();
+    if let Some((path, bytes)) = load_fallback() {
+        let name = path.display().to_string();
+        defs.font_data
+            .insert(name.clone(), Arc::new(egui::FontData::from_owned(bytes)));
+        for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+            defs.families.entry(family).or_default().push(name.clone());
+        }
+    }
+    ctx.set_fonts(defs);
+}
+
+fn load_fallback() -> Option<(PathBuf, Vec<u8>)> {
+    fallback_candidates()
+        .into_iter()
+        .find_map(|path| std::fs::read(&path).ok().map(|bytes| (path, bytes)))
+}
+
+/// Candidate font files in preference order: the explicit override, the
+/// fontconfig answer on Linux, then the static list with the locale's
+/// language group first.
+fn fallback_candidates() -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    if let Some(path) = std::env::var_os(FONT_ENV).filter(|p| !p.is_empty()) {
+        paths.push(PathBuf::from(path));
+    }
+    let preferred = preferred_lang();
+    #[cfg(not(any(target_os = "macos", windows)))]
+    paths.extend(fontconfig_match(preferred));
+    paths.extend(ordered_static_candidates(preferred));
+    paths
+}
+
+fn ordered_static_candidates(preferred: Lang) -> Vec<PathBuf> {
+    let (first, rest): (Vec<_>, Vec<_>) = CANDIDATES.iter().partition(|(l, _)| *l == preferred);
+    first
+        .into_iter()
+        .chain(rest)
+        .map(|(_, p)| font_path(p))
+        .collect()
+}
+
+#[cfg(windows)]
+fn font_path(name: &str) -> PathBuf {
+    let windir = std::env::var_os("WINDIR").unwrap_or_else(|| "C:\\Windows".into());
+    PathBuf::from(windir).join("Fonts").join(name)
+}
+
+#[cfg(not(windows))]
+fn font_path(name: &str) -> PathBuf {
+    PathBuf::from(name)
+}
+
+/// Language group from the POSIX locale variables. macOS apps launched from
+/// Finder and Windows have none of them set, so those fall through to `Ja`.
+fn preferred_lang() -> Lang {
+    ["LC_ALL", "LC_MESSAGES", "LANG"]
+        .iter()
+        .filter_map(|var| std::env::var(var).ok())
+        .find(|v| !v.is_empty())
+        .map(|v| lang_from_locale(&v))
+        .unwrap_or(Lang::Ja)
+}
+
+fn lang_from_locale(locale: &str) -> Lang {
+    match locale.get(..2).map(str::to_ascii_lowercase).as_deref() {
+        Some("zh") => Lang::Zh,
+        Some("ko") => Lang::Ko,
+        _ => Lang::Ja,
+    }
+}
+
+/// Ask fontconfig which file it would use for the language. Returns the
+/// path only when fontconfig actually found a font declaring that language,
+/// so a Latin-only system does not get DejaVu loaded twice for nothing.
+#[cfg(not(any(target_os = "macos", windows)))]
+fn fontconfig_match(preferred: Lang) -> Option<PathBuf> {
+    let lang = match preferred {
+        Lang::Ja => "ja",
+        Lang::Zh => "zh",
+        Lang::Ko => "ko",
+    };
+    let output = std::process::Command::new("fc-match")
+        .args(["-f", "%{file}\n%{lang}", &format!("sans-serif:lang={lang}")])
+        .output()
+        .ok()?;
+    let text = String::from_utf8(output.stdout).ok()?;
+    let (file, langs) = text.trim().split_once('\n')?;
+    langs
+        .split('|')
+        .any(|l| l == lang)
+        .then(|| PathBuf::from(file))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locale_picks_language_group() {
+        assert_eq!(lang_from_locale("ja_JP.UTF-8"), Lang::Ja);
+        assert_eq!(lang_from_locale("zh_CN.UTF-8"), Lang::Zh);
+        assert_eq!(lang_from_locale("ko_KR.UTF-8"), Lang::Ko);
+        assert_eq!(lang_from_locale("en_US.UTF-8"), Lang::Ja);
+        assert_eq!(lang_from_locale("C"), Lang::Ja);
+    }
+
+    #[test]
+    fn preferred_group_comes_first() {
+        let ordered = ordered_static_candidates(Lang::Ko);
+        let ko: Vec<PathBuf> = CANDIDATES
+            .iter()
+            .filter(|(l, _)| *l == Lang::Ko)
+            .map(|(_, p)| font_path(p))
+            .collect();
+        assert_eq!(&ordered[..ko.len()], &ko[..]);
+        assert_eq!(ordered.len(), CANDIDATES.len());
+    }
+
+    /// End-to-end on a machine that has a system CJK font: the fallback must
+    /// actually supply the glyphs from the issue #321 filename.
+    #[test]
+    fn japanese_glyphs_resolve_when_a_system_font_exists() {
+        let Some((path, bytes)) = load_fallback() else {
+            eprintln!("no system CJK font on this machine, skipping");
+            return;
+        };
+        let mut defs = egui::FontDefinitions::default();
+        let name = path.display().to_string();
+        defs.font_data
+            .insert(name.clone(), Arc::new(egui::FontData::from_owned(bytes)));
+        defs.families
+            .entry(egui::FontFamily::Proportional)
+            .or_default()
+            .push(name);
+        let fonts = egui::epaint::text::Fonts::new(1.0, 2048, defs);
+        let id = egui::FontId::proportional(14.0);
+        assert!(
+            fonts.has_glyphs(&id, "01-日本語の曲.mp3"),
+            "font: {}",
+            path.display()
+        );
+        assert!(fonts.has_glyphs(&id, "abc-123"));
+    }
+}

--- a/mp3rgui/src/main.rs
+++ b/mp3rgui/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod fonts;
 mod panic_hook;
 mod startup;
 mod ui;

--- a/packages/aur-gui/PKGBUILD
+++ b/packages/aur-gui/PKGBUILD
@@ -8,7 +8,7 @@ url='https://mp3rgain.tyna.ninja/'
 license=('MIT')
 depends=('gcc-libs' 'gtk3')
 makedepends=('rust' 'cargo')
-optdepends=('mp3rgain: CLI tool for batch processing')
+optdepends=('mp3rgain: CLI tool for batch processing' 'noto-fonts-cjk: display CJK characters in file names')
 source=("https://github.com/M-Igashi/mp3rgain/archive/v${pkgver}.tar.gz")
 sha256sums=('SKIP')
 

--- a/packages/debian-gui/debian/control
+++ b/packages/debian-gui/debian/control
@@ -12,7 +12,7 @@ Rules-Requires-Root: no
 Package: mp3rgui
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: mp3rgain
+Recommends: mp3rgain, fonts-noto-cjk
 Description: GUI for mp3rgain - lossless MP3 volume adjustment
  mp3rgui is a graphical interface for mp3rgain, a modern mp3gain
  replacement written in Rust that adjusts MP3 file volumes losslessly

--- a/packages/ppa-gui/debian/control
+++ b/packages/ppa-gui/debian/control
@@ -12,7 +12,7 @@ Rules-Requires-Root: no
 Package: mp3rgui
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: mp3rgain
+Recommends: mp3rgain, fonts-noto-cjk
 Description: GUI for mp3rgain - lossless MP3 volume adjustment
  mp3rgui is a graphical interface for mp3rgain, a modern mp3gain
  replacement written in Rust that adjusts MP3 file volumes losslessly


### PR DESCRIPTION
Fixes #321.

## Problem

egui's built-in fonts cover Latin, Greek and Cyrillic only. A file named `01-日本語の曲.mp3` therefore showed up in the file list as `01-□□□□□□.mp3`. Processing was unaffected; only the display was wrong.

## Fix

At startup `mp3rgui` now loads the first CJK font the OS already ships and appends it to egui's `Proportional` and `Monospace` families as a fallback. egui only takes glyphs from it that its own fonts lack, so Latin text is unchanged.

- macOS: Hiragino Sans W3, then PingFang / Hiragino Sans GB, Apple SD Gothic Neo, Arial Unicode
- Windows: Yu Gothic, Meiryo, MS Gothic, Microsoft YaHei, SimSun, Malgun Gothic, resolved under `%WINDIR%\Fonts`
- Linux: `fc-match` for the locale's language (only accepted when the returned font actually declares that language), then the usual Noto Sans CJK, IPA, Droid, WenQuanYi and Nanum paths
- `LC_ALL` / `LC_MESSAGES` / `LANG` starting with `zh` or `ko` move that group to the front; everything else prefers Japanese, since any CJK font covers kana and most kanji while Hangul needs a Korean face
- `MP3RGUI_FONT=<path>` overrides the list entirely, mirroring `MP3RGUI_RENDERER`

Exactly one font is loaded. egui keeps two copies of the font bytes, so loading a Japanese, a Chinese and a Korean face on macOS would cost well over 100 MB of RSS; Hiragino Sans W3 costs about 16 MB.

Bundling Noto Sans CJK was rejected because it adds 15 to 20 MB to every binary on every platform, while the fonts are already present on macOS and Windows.

## Packaging

The `.deb` (Debian and PPA) GUI packages now `Recommends: fonts-noto-cjk`, and the AUR GUI package lists `noto-fonts-cjk` in `optdepends`.

## Verification

- `cargo test` in `mp3rgui`: 12 passed. The new `japanese_glyphs_resolve_when_a_system_font_exists` test builds egui's font atlas with the detected system font and asserts `has_glyphs` for `01-日本語の曲.mp3`. It ran against Hiragino Sans W3 on this Mac and skips with a message on machines without a CJK font.
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean for both crates.
- Linux and Windows branches are compiled only on their targets, so CI covers them; they were not run locally.

Co-authored-by: FUGAMARU
