### PR TITLE
cli: print the ReplayGain float peak in -o tsv under --rg2 / --r128

### DIFF
--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -214,6 +214,12 @@ prints the mp3gain-compatible header and one row per file, with the
 column holding the path as given on the command line. The rows are also
 emitted while applying gain
 .RB ( \-r ", " \-a ", " \-e ", " \-g ", " \-l ).
+The
+.B Max Amplitude
+column uses mp3gain's 16-bit sample scale (peak multiplied by 32768) in the
+default ReplayGain 1.0 mode, and the ReplayGain float peak (the value written
+to REPLAYGAIN_*_PEAK) under
+.BR \-\-rg2 " and " \-\-r128 .
 .TP
 .BR \-v ", " \-\-version
 Show version information and exit.

--- a/docs/migrating-from-mp3gain.md
+++ b/docs/migrating-from-mp3gain.md
@@ -104,6 +104,8 @@ Albums/Foo/01.mp3	0	0.0	17234	148	100
 
 The `File` column carries the path exactly as it was given on the command line, the way mp3gain prints it. Up to 3.5.1 mp3rgain printed the bare filename instead, which was ambiguous when scanning several directories in one run.
 
+The `Max Amplitude` column is on mp3gain's 16-bit sample scale (peak × 32768) in the default ReplayGain 1.0 mode. Under `--rg2` / `--r128` the rows are no longer mp3gain-compatible anyway, so the column carries the ReplayGain float peak instead, the same value written to `REPLAYGAIN_*_PEAK` and reported by `-o json`.
+
 TSV rows are emitted by the gain-applying commands too, not just the bare analysis command: `-r`, `-a` and `-e` print the recommended change for every file (plus the `"Album"` summary row under `-a`) before the frames are rewritten, so `mp3rgain -o tsv -a */*.mp3` reports the same numbers `mp3rgain -o tsv */*.mp3` would.
 
 This means existing parsers that consume mp3gain output — most notably the

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -95,6 +95,20 @@ impl Options {
             && self.target_offset_db() == 0.0
     }
 
+    /// The TSV `Max Amplitude` column for a normalized peak. RG1 keeps
+    /// mp3gain's 16-bit sample scale (`peak * 32768`) so scripts written for
+    /// mp3gain keep working. The BS.1770 modes are outside mp3gain's world
+    /// anyway (and a true peak above 1.0 makes no sense as a sample value),
+    /// so they print the ReplayGain float peak: the number written to
+    /// `REPLAYGAIN_*_PEAK` and reported by `-o json` (issue #323).
+    pub fn tsv_peak(&self, peak: f64) -> f64 {
+        if self.analysis_mode == AnalysisMode::Rg1 {
+            mp3rgain::peak_to_pcm_sample(peak)
+        } else {
+            peak
+        }
+    }
+
     /// A measured gain shifted by the `-m` / `-d` modifiers, as the apply and
     /// info paths report it: `(steps, dB)`, both quantized to whole
     /// `global_gain` steps so the two columns always agree. Every caller used

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::*;
+use mp3rgain::mp4meta;
 use mp3rgain::replaygain::{self, AlbumAnalysisReport, ReplayGainResult};
-use mp3rgain::{mp4meta, peak_to_pcm_sample};
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -136,7 +136,6 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 report.album.album_gain_steps(),
                 report.album.album_gain_db(),
             );
-            let album_max_amp = peak_to_pcm_sample(report.album.album_peak());
 
             match opts.output_format {
                 OutputFormat::Tsv => {
@@ -144,7 +143,7 @@ fn cmd_info_replaygain(files: &[PathBuf], opts: &Options) -> Result<()> {
                         "\"Album\"\t{}\t{:.6}\t{:.6}\t{}\t{}",
                         album_gain_steps,
                         album_gain_db,
-                        album_max_amp,
+                        opts.tsv_peak(report.album.album_peak()),
                         album_max_gain.unwrap_or(255),
                         album_min_gain.unwrap_or(0)
                     );

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -4,7 +4,7 @@ use mp3rgain::replaygain::{
     self, AlbumAnalysisReport, AlbumGainResult, AudioFileType, ReplayGainResult,
     REPLAYGAIN_REFERENCE_DB,
 };
-use mp3rgain::{peak_to_pcm_sample, AacAlbumInfo};
+use mp3rgain::AacAlbumInfo;
 use rayon::prelude::*;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -542,7 +542,7 @@ fn emit_album_tsv_rows(
             "\"Album\"\t{}\t{:.6}\t{:.6}\t{}\t{}",
             album_gain_steps,
             album_gain_db,
-            peak_to_pcm_sample(album_result.album_peak()),
+            opts.tsv_peak(album_result.album_peak()),
             album_max_gain.unwrap_or(255),
             album_min_gain.unwrap_or(0)
         )?;

--- a/src/processors/info.rs
+++ b/src/processors/info.rs
@@ -35,7 +35,7 @@ pub fn tsv_rg_row(
         get_path(file),
         gain_steps,
         gain_db,
-        peak_to_pcm_sample(rg_result.peak()),
+        opts.tsv_peak(rg_result.peak()),
         max_gain,
         min_gain
     )

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -591,6 +591,38 @@ fn tsv_rows_carry_the_path_as_given() {
     assert_eq!(row.split('\t').next(), Some(path), "row: {}", row);
 }
 
+/// Reported on the Hydrogenaudio forum (issue #323): `-o tsv` printed the
+/// peak on mp3gain's 16-bit sample scale while `-o json` printed the
+/// ReplayGain float. RG1 keeps the mp3gain scale for compatibility; the
+/// BS.1770 modes report the same float the tags and JSON carry.
+#[test]
+fn tsv_peak_matches_json_in_rg2_mode_and_mp3gain_scale_in_rg1() {
+    let album = TempAlbum::new(&["test_mono.mp3"]);
+    let path = album.files[0].to_str().unwrap();
+
+    let tsv_peak = |mode: &[&str]| -> f64 {
+        let mut argv = mode.to_vec();
+        argv.extend_from_slice(&["-r", "-n", "-o", "tsv", path]);
+        let text = stdout_of(&run(&argv));
+        let row = text.lines().nth(1).expect("TSV data row");
+        row.split('\t').nth(3).unwrap().parse().unwrap()
+    };
+    let json_peak = |mode: &[&str]| -> f64 {
+        let mut argv = mode.to_vec();
+        argv.extend_from_slice(&["-r", "-n", "-o", "json", path]);
+        json_of(&run(&argv))["files"][0]["peak"]
+            .as_f64()
+            .expect("json peak")
+    };
+
+    let rg1_json = json_peak(&[]);
+    assert!((tsv_peak(&[]) - rg1_json * 32768.0).abs() < 0.01);
+
+    let rg2_json = json_peak(&["--rg2"]);
+    assert!((tsv_peak(&["--rg2"]) - rg2_json).abs() < 1e-6);
+    assert!(rg2_json < 2.0, "float peak, not a sample value: {rg2_json}");
+}
+
 /// Reported on the Hydrogenaudio forum: `-o tsv` only produced rows for the
 /// bare analysis command. Combined with `-r` or `-a` it printed nothing at all.
 #[test]


### PR DESCRIPTION
Fixes #323.

## Problem

`-o tsv` printed the `Max Amplitude` column as `peak * 32768` in every mode, while `-o json` printed the ReplayGain float peak. skamp pointed out the mismatch on Hydrogenaudio.

## Fix

The unit now follows the analysis mode, through a new `Options::tsv_peak` helper used by all three TSV emitters (per-file rows, the `"Album"` row in `-a`, and the album row in the info command):

- Default RG1 mode: unchanged. The column stays on mp3gain's 16-bit sample scale, so beets and other mp3gain-format consumers keep working, and the existing TSV golden tests pass untouched.
- `--rg2` / `--r128`: the column carries the ReplayGain float peak, the same value written to `REPLAYGAIN_*_PEAK` and reported by `-o json`. Those rows were never mp3gain-compatible, and a true peak above 1.0 was turning into a meaningless sample value.

The `-x` text output and the "Max PCM sample at current gain" line in text mode are not touched; they remain mp3gain-identical.

## Sample

```
$ mp3rgain -r -n -o tsv test_mono.mp3
tests/fixtures/test_mono.mp3	2	3.700000	3896.272461	210	115
$ mp3rgain --rg2 -r -n -o tsv test_mono.mp3
tests/fixtures/test_mono.mp3	3	4.198487	0.118905	210	115
```

## Docs

Man page and `docs/migrating-from-mp3gain.md` now state the unit per mode.

## Verification

- New CLI test `tsv_peak_matches_json_in_rg2_mode_and_mp3gain_scale_in_rg1` checks both modes against the JSON peak.
- `cargo test`: all suites pass. `cargo clippy --all-targets` adds no warnings, `cargo fmt --check` clean.
