### PR TITLE
cli: -a --per-directory computes one album gain per folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Binaries for all platforms are on [GitHub Releases](https://github.com/M-Igashi/
 mp3rgain -r song.mp3          # Normalize a single track (ReplayGain)
 mp3rgain -a *.mp3             # Normalize an album
 mp3rgain -s R -a -R /music    # Apply from stored tags, rescan only where missing (v3.4+)
+mp3rgain -a --per-directory -R /music  # One album per folder, whole library in one run (v3.7+)
 mp3rgain -g 2 song.mp3        # Manual gain (+3.0 dB; 1 step = 1.5 dB)
 mp3rgain -u song.mp3          # Undo
 mp3rgain song.mp3             # Show file info

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -72,6 +72,7 @@ All options from the original mp3gain are fully implemented in mp3rgain:
 | Option | Description |
 |--------|-------------|
 | `-R` | Recursive directory processing |
+| `--per-directory` | With `-a`: one album per directory, like rsgain's directory-based album detection |
 | `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only when tags are missing (mp3gain's *default* behavior, opt-in here) |
 | `-n` / `--dry-run` | Dry-run mode (preview changes without modifying files) |
 | `-o json` | JSON output format (for scripting and automation) |

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -64,6 +64,19 @@ Each file is normalized individually to the 89 dB reference level.
 Analyze and apply Album gain using the ReplayGain 1.0 algorithm.
 All files are treated as an album and normalized together.
 .TP
+.B \-\-per\-directory
+With
+.BR \-a ,
+treat each directory as its own album instead of pooling every file into
+one. Files are grouped by their parent directory as given on the command
+line, so
+.B \-a \-\-per\-directory \-R /music
+computes and applies one album gain per folder in a single run. A
+directory that fails analysis is reported and the run continues with the
+next one. In JSON output the per-directory results appear in an
+.B albums
+array.
+.TP
 .B \-\-rg2
 Measure loudness with the ReplayGain 2.0 algorithm (ITU-R BS.1770
 integrated loudness, gated) against the \-18 LUFS reference instead of

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -50,7 +50,9 @@ pub struct Options {
     // without modifying a single audio frame (issue #308), the loudgain /
     // rsgain workflow. Requires -r / -a / -e.
     pub tags_only: bool,
-    pub skip_album: bool,         // -e: skip album analysis
+    pub skip_album: bool, // -e: skip album analysis
+    // --per-directory: with -a, one album per parent directory (issue #324).
+    pub per_directory: bool,
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files
 

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -32,6 +32,12 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
             continue;
         }
 
+        if arg == "--per-directory" {
+            opts.per_directory = true;
+            i += 1;
+            continue;
+        }
+
         if arg == "--rg2" {
             if opts.analysis_mode == AnalysisMode::R128 {
                 anyhow::bail!("--rg2 and --r128 are mutually exclusive");
@@ -304,6 +310,11 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
     // (issue #292). Checked after the loop so flag order doesn't matter.
     if opts.true_peak && opts.analysis_mode == AnalysisMode::Rg1 {
         anyhow::bail!("--true-peak requires --rg2 or --r128");
+    }
+
+    // --per-directory only changes how -a groups files (issue #324).
+    if opts.per_directory && !(opts.album_gain && !opts.skip_album) {
+        anyhow::bail!("--per-directory requires -a");
     }
 
     // --tags-only (issue #308) writes ReplayGain metadata and nothing else, so

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -28,6 +28,8 @@ pub fn print_usage() {
     println!("    -m <i>      Modify suggested gain by integer i");
     println!("    -r          Apply Track gain (ReplayGain analysis)");
     println!("    -a          Apply Album gain (ReplayGain analysis)");
+    println!("    --per-directory  With -a: one album per directory, so a whole library");
+    println!("                     can be album-tagged in one run (pairs with -R)");
     println!("    --rg2       ReplayGain 2.0 analysis (BS.1770, -18 LUFS reference)");
     println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
     println!("    --true-peak Measure true peak (BS.1770-4 Annex 2) for REPLAYGAIN_*_PEAK");
@@ -90,6 +92,7 @@ pub fn print_usage() {
     println!("    mp3rgain -w -g 10 song.mp3     Apply gain with wrapping");
     println!("    mp3rgain -t -g 2 song.mp3      Apply gain using temp file");
     println!("    mp3rgain -R /path/to/music     Process directory recursively");
+    println!("    mp3rgain -a --per-directory -R /music  One album per folder");
     println!("    mp3rgain -Rpa --skip-errors /music  Album-scan a library, skipping");
     println!("                                        files that fail to decode");
     println!("    mp3rgain -n -g 2 *.mp3         Dry-run (preview changes)");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,7 +16,7 @@ use crate::cli::parse_args::expand_files_recursive;
 use apply::{cmd_apply, cmd_apply_channel};
 use info::cmd_info;
 use max_amplitude::cmd_max_amplitude;
-use replaygain::{cmd_album_gain, cmd_track_gain};
+use replaygain::{cmd_album_gain, cmd_album_gain_per_directory, cmd_track_gain};
 use tags::{cmd_check_tags, cmd_delete_tags};
 use undo::cmd_undo;
 
@@ -99,7 +99,10 @@ pub fn run(mut opts: Options) -> Result<()> {
     }
 
     if opts.album_gain && !opts.skip_album {
-        // -a: apply album gain (ReplayGain)
+        // -a: apply album gain (ReplayGain), per directory with --per-directory
+        if opts.per_directory {
+            return cmd_album_gain_per_directory(&opts.files, &opts);
+        }
         return cmd_album_gain(&opts.files, &opts);
     }
 

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -6,6 +6,7 @@ use mp3rgain::replaygain::{
 };
 use mp3rgain::AacAlbumInfo;
 use rayon::prelude::*;
+use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -13,9 +14,12 @@ use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
     create_json_summary, exit_if_failed, finish_with_album_summary, finish_with_summary,
-    for_each_file_with_analysis_bar, run_album_analysis, update_counters, TSV_HEADER,
+    for_each_file_with_analysis_bar, print_dry_run_notice, run_album_analysis, update_counters,
+    TSV_HEADER,
 };
-use crate::json_output::{FileStatus, JsonAlbumResult, JsonFileResult, JsonOutput};
+use crate::json_output::{
+    FileStatus, JsonAlbumResult, JsonDirectoryAlbum, JsonFileResult, JsonOutput,
+};
 use crate::processors::info::{scan_gain_range_for_row, tsv_rg_row};
 use crate::processors::replaygain::{
     apply_is_noop, capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
@@ -138,21 +142,30 @@ fn stored_album_report(files: &[PathBuf], opts: &Options) -> Option<AlbumAnalysi
     })
 }
 
-pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
-    require_replaygain_feature();
+/// Outcome of one album run, before the JSON / exit-code epilogue.
+struct AlbumRun {
+    json_results: Vec<JsonFileResult>,
+    album: Option<JsonAlbumResult>,
+    successful: usize,
+    failed: usize,
+}
 
-    let dry_run_prefix = opts.dry_run_prefix();
-
+/// TSV header plus the text-mode banner shared by both album commands.
+fn print_album_intro(file_count: usize, directories: Option<usize>, opts: &Options) {
     if opts.output_format == OutputFormat::Tsv {
         println!("{}", TSV_HEADER);
     }
-
     if opts.output_format == OutputFormat::Text && !opts.quiet {
+        let scope = match directories {
+            Some(n) => format!(" in {} directory(ies)", n),
+            None => String::new(),
+        };
         println!(
-            "{}{} Analyzing album gain for {} file(s){}",
-            dry_run_prefix,
+            "{}{} Analyzing album gain for {} file(s){}{}",
+            opts.dry_run_prefix(),
             "mp3rgain".green().bold(),
-            files.len(),
+            file_count,
+            scope,
             if opts.tags_only {
                 " (tags only, audio unchanged)"
             } else {
@@ -162,7 +175,99 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
         print_target_with_modifier(opts);
         println!();
     }
+}
 
+pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
+    require_replaygain_feature();
+    print_album_intro(files.len(), None, opts);
+    let run = run_album(files, opts)?;
+    finish_with_album_summary(
+        files.len(),
+        run.json_results,
+        run.album,
+        run.successful,
+        run.failed,
+        opts,
+    )
+}
+
+/// `-a --per-directory`: one album per parent directory (issue #324), the
+/// grouping the GUI has used since #159. Directories are processed in path
+/// order; one that fails analysis is counted and the run moves on to the
+/// next, so a whole library can be tagged in a single invocation.
+pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result<()> {
+    require_replaygain_feature();
+    let groups = group_by_parent(files);
+    print_album_intro(files.len(), Some(groups.len()), opts);
+
+    let mut json_results = Vec::with_capacity(files.len());
+    let mut albums = Vec::with_capacity(groups.len());
+    let (mut successful, mut failed) = (0, 0);
+    for (i, (dir, group)) in groups.iter().enumerate() {
+        if opts.output_format == OutputFormat::Text && !opts.quiet {
+            if i > 0 {
+                println!();
+            }
+            println!(
+                "{} ({} file(s))",
+                dir.display().to_string().bold(),
+                group.len()
+            );
+        }
+        let run = run_album(group, opts)?;
+        if let Some(album) = run.album {
+            albums.push(JsonDirectoryAlbum {
+                directory: dir.display().to_string(),
+                files: group.len(),
+                album,
+            });
+        }
+        json_results.extend(run.json_results);
+        successful += run.successful;
+        failed += run.failed;
+    }
+
+    if opts.output_format == OutputFormat::Json {
+        let output = JsonOutput {
+            files: Some(json_results),
+            album: None,
+            albums: Some(albums),
+            summary: Some(create_json_summary(
+                files.len(),
+                successful,
+                failed,
+                opts.dry_run,
+            )),
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_dry_run_notice(opts);
+    }
+    exit_if_failed(failed);
+    Ok(())
+}
+
+/// Group files by their immediate parent directory, as given on the command
+/// line. Bare file names land in `.`.
+fn group_by_parent(files: &[PathBuf]) -> BTreeMap<PathBuf, Vec<PathBuf>> {
+    let mut groups: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+    for file in files {
+        let dir = file
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        groups
+            .entry(dir.to_path_buf())
+            .or_default()
+            .push(file.clone());
+    }
+    groups
+}
+
+/// Analyze and apply album gain to `files` as one album, returning what the
+/// epilogue needs instead of printing JSON or exiting, so the per-directory
+/// driver can aggregate several albums (issue #324).
+fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
     let file_refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
 
     let threads = effective_threads(opts);
@@ -299,8 +404,9 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 .map(|t| t.peak())
                 .fold(0.0, f64::max);
             if apply_is_noop(opts, steps, any_aac, max_peak) {
-                if opts.output_format == OutputFormat::Json {
-                    let json_results: Vec<JsonFileResult> = files
+                let json_results: Vec<JsonFileResult> = if opts.output_format == OutputFormat::Json
+                {
+                    files
                         .iter()
                         .enumerate()
                         .map(|(i, file)| match file_to_track[i] {
@@ -318,21 +424,19 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                                 failure_msgs[i].as_deref().unwrap_or("analysis failed"),
                             ),
                         })
-                        .collect();
-                    return finish_with_album_summary(
-                        files.len(),
-                        json_results,
-                        Some(json_album),
-                        0,
-                        failure_count,
-                        opts,
-                    );
-                }
-                if !opts.quiet {
-                    println!("  {} No adjustment needed", ".".cyan());
-                }
-                exit_if_failed(failure_count);
-                return Ok(());
+                        .collect()
+                } else {
+                    if !opts.quiet {
+                        println!("  {} No adjustment needed", ".".cyan());
+                    }
+                    Vec::new()
+                };
+                return Ok(AlbumRun {
+                    json_results,
+                    album: Some(json_album),
+                    successful: 0,
+                    failed: failure_count,
+                });
             }
 
             let pb = create_progress_bar(files.len(), opts);
@@ -466,36 +570,33 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
                 mp3rgain::write_album_minmax(&album_files);
             }
 
-            finish_with_album_summary(
-                files.len(),
+            Ok(AlbumRun {
                 json_results,
-                Some(json_album),
+                album: Some(json_album),
                 successful,
                 failed,
-                opts,
-            )?;
+            })
         }
         Err(e) => {
-            if opts.output_format == OutputFormat::Json {
-                let output = JsonOutput {
-                    files: None,
-                    album: None,
-                    summary: Some(create_json_summary(
-                        files.len(),
-                        0,
-                        files.len(),
-                        opts.dry_run,
-                    )),
-                };
-                println!("{}", serde_json::to_string_pretty(&output)?);
+            // Every file counts as failed. JSON gets one error entry per file
+            // so the caller can see which album broke; text goes to stderr.
+            let json_results = if opts.output_format == OutputFormat::Json {
+                files
+                    .iter()
+                    .map(|f| JsonFileResult::error(f, e.to_string()))
+                    .collect()
             } else {
                 eprintln!("{}: Failed to analyze album: {}", "error".red().bold(), e);
-            }
-            std::process::exit(1);
+                Vec::new()
+            };
+            Ok(AlbumRun {
+                json_results,
+                album: None,
+                successful: 0,
+                failed: files.len(),
+            })
         }
     }
-
-    Ok(())
 }
 
 /// Per-file rows plus the `"Album"` summary row for `-a -o tsv`, matching what

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -181,6 +181,7 @@ pub fn report_zero_steps(files: &[PathBuf], opts: &Options) -> Result<()> {
         let output = JsonOutput {
             files: Some(vec![]),
             album: None,
+            albums: None,
             summary: Some(create_json_summary(files.len(), 0, 0, opts.dry_run)),
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -216,6 +217,7 @@ pub fn finish_with_album_summary(
         let output = JsonOutput {
             files: Some(json_results),
             album,
+            albums: None,
             summary: Some(create_json_summary(
                 total_files,
                 successful,
@@ -252,6 +254,7 @@ pub fn finish_without_summary(
         let output = JsonOutput {
             files: Some(json_results),
             album: None,
+            albums: None,
             summary: None,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -19,8 +19,19 @@ pub struct JsonOutput {
     pub files: Option<Vec<JsonFileResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub album: Option<JsonAlbumResult>,
+    /// `-a --per-directory`: one entry per directory (issue #324).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub albums: Option<Vec<JsonDirectoryAlbum>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<JsonSummary>,
+}
+
+#[derive(Serialize)]
+pub struct JsonDirectoryAlbum {
+    pub directory: String,
+    pub files: usize,
+    #[serde(flatten)]
+    pub album: JsonAlbumResult,
 }
 
 #[derive(Serialize, Clone, Default)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -623,6 +623,74 @@ fn tsv_peak_matches_json_in_rg2_mode_and_mp3gain_scale_in_rg1() {
     assert!(rg2_json < 2.0, "float peak, not a sample value: {rg2_json}");
 }
 
+/// Requested on the Hydrogenaudio forum (issue #324): `-a --per-directory`
+/// computes one album gain per folder, so a library can be tagged in one
+/// run. Each directory must get the same album gain it would get alone.
+#[test]
+fn per_directory_album_gain_matches_each_directory_run_alone() {
+    let root = TempAlbum::new(&[]);
+    let mut dirs = Vec::new();
+    for (name, fixtures) in [
+        ("A", vec!["test_mono.mp3", "test_vbr.mp3"]),
+        ("B", vec!["test_stereo.mp3", "test_joint_stereo.mp3"]),
+    ] {
+        let dir = root.dir.join(name);
+        fs::create_dir(&dir).unwrap();
+        for f in fixtures {
+            fs::copy(Path::new("tests/fixtures").join(f), dir.join(f)).unwrap();
+        }
+        dirs.push(dir);
+    }
+    let root_arg = root.dir.to_str().unwrap();
+
+    let out = run(&["-a", "--per-directory", "-n", "-R", "-o", "json", root_arg]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json = json_of(&out);
+    let albums = json["albums"].as_array().expect("albums array");
+    assert_eq!(albums.len(), 2);
+    assert_eq!(json["files"].as_array().unwrap().len(), 4);
+    assert_eq!(json["summary"]["total_files"], 4);
+
+    for (dir, album) in dirs.iter().zip(albums) {
+        assert_eq!(album["directory"], dir.to_str().unwrap());
+        assert_eq!(album["files"], 2);
+        let alone = json_of(&run(&[
+            "-a",
+            "-n",
+            "-R",
+            "-o",
+            "json",
+            dir.to_str().unwrap(),
+        ]));
+        assert_eq!(
+            album["gain_db"],
+            alone["album"]["gain_db"],
+            "{}",
+            dir.display()
+        );
+    }
+    assert_ne!(
+        albums[0]["gain_db"], albums[1]["gain_db"],
+        "the two directories should not share one album gain"
+    );
+
+    // Without the flag everything is still one album.
+    let pooled = json_of(&run(&["-a", "-n", "-R", "-o", "json", root_arg]));
+    assert!(pooled["albums"].is_null());
+    assert!(pooled["album"]["gain_db"].is_number());
+}
+
+#[test]
+fn per_directory_requires_album_mode() {
+    let out = run(&["--per-directory", "-r", "tests/fixtures/test_mono.mp3"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--per-directory requires -a"));
+}
+
 /// Reported on the Hydrogenaudio forum: `-o tsv` only produced rows for the
 /// bare analysis command. Combined with `-r` or `-a` it printed nothing at all.
 #[test]


### PR DESCRIPTION
Fixes #324.

## Problem

`-a` treats every file it is given as one album, including everything collected by `-R`, so album-tagging a library meant looping over directories in the shell. Requested by skamp on Hydrogenaudio, comparing to rsgain's one-directory-is-one-album behavior.

## Change

New `--per-directory` flag, valid only with `-a`:

- Files are grouped by their immediate parent directory as given on the command line, in path order. This is the rule the GUI has used since #159, so `-R Artist` and `-R Artist/*` give identical results and no shell globbing is required. Bare file names group under `.`.
- The existing album pipeline runs once per group unchanged: analysis, `-s R` stored-tag reuse, `--tags-only`, `-k`, `-n`, `--skip-errors`, and the `MP3GAIN_ALBUM_MINMAX` write.
- Without the flag, `-a` behaves exactly as before. Multi-disc albums split into subfolders still pool by default.
- Text output prints a heading per directory before its album summary. TSV rows are per file and need nothing extra; each directory gets its own `"Album"` row.
- JSON gains an `albums` array with one object per directory (`directory`, `files`, plus the usual album fields); the flat `files` list and `summary` cover the whole run. The single-album `album` object is untouched when the flag is off.
- A directory whose analysis fails is reported, counted as failed, and the run moves on to the next one. Exit code is non-zero if anything failed.

## Refactor

`cmd_album_gain` was one 350-line function that printed JSON and called `process::exit` in three places. It is now `run_album`, which returns an `AlbumRun` (per-file JSON records, album block, success and failure counts), plus a thin epilogue. The per-directory driver loops over `run_album`. The only observable change to the single-album path is that a total analysis failure in JSON mode now lists one error entry per file instead of omitting `files`; the summary and exit code are the same.

Albums are processed sequentially; files within an album are still analyzed in parallel. Running several small albums concurrently is a possible follow-up.

## Sample

```
$ mp3rgain -a --per-directory -n -R /music/Metallica
[DRY RUN] mp3rgain Analyzing album gain for 3 file(s) in 2 directory(ies)
  Target: 89 dB (ReplayGain 1.0)

/music/Metallica/A (2 file(s))
  -> Analyzing tracks...

  Album loudness: 61.1 dB
  Album gain:     +3.7 dB (2 steps)
  Album peak:     0.1189

  ~ [DRY RUN] test_mono.mp3 (would apply +3.0 dB, 2 steps)
  ~ [DRY RUN] test_vbr.mp3 (would apply +3.0 dB, 2 steps)

/music/Metallica/B (1 file(s))
  ...
```

## Docs

`--help`, man page, README quick start and `docs/COMPARISON.md`.

## Verification

- New CLI test builds two directories from the fixtures and checks that `-a --per-directory -R root -o json` yields two `albums` entries whose `gain_db` equals `-a -o json` run on each directory alone, that the two differ, and that the flag-less run still produces a single `album`. A second test checks `--per-directory` without `-a` is rejected.
- `cargo test`: all suites pass. `cargo clippy --all-targets` adds no warnings, `cargo fmt --check` clean.
