### PR TITLE
fix: detect AAC audio in MP4 video files (#327)

### DIFF
--- a/src/mp4meta.rs
+++ b/src/mp4meta.rs
@@ -1261,6 +1261,9 @@ fn is_mp4_header(head: &[u8]) -> bool {
 pub(crate) const MP4A: u32 = u32::from_be_bytes(*b"mp4a");
 const ALAC: u32 = u32::from_be_bytes(*b"alac");
 pub(crate) const STSD: u32 = u32::from_be_bytes(*b"stsd");
+const HDLR: u32 = u32::from_be_bytes(*b"hdlr");
+/// `hdlr` handler_type marking a trak as audio (ISO 14496-12).
+const SOUN: u32 = u32::from_be_bytes(*b"soun");
 
 /// Audio codec detected in an MP4 file
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1421,7 +1424,27 @@ fn detect_codec_in_moov(data: &[u8], moov_start: usize, moov_size: usize) -> Opt
         .find_map(|(trak_start, trak_size)| detect_codec_in_trak(data, trak_start, trak_size))
 }
 
+/// Read a trak's `hdlr` handler_type (`trak` -> `mdia` -> `hdlr`), e.g. `soun`
+/// for audio or `vide` for video. `None` when the box is absent or truncated.
+fn trak_handler_type(data: &[u8], trak_start: usize, trak_size: usize) -> Option<u32> {
+    let (mdia_pos, mdia_header) = find_box_in_container(data, trak_start, trak_size, MDIA)?;
+    let mdia_start = mdia_pos + mdia_header.header_size as usize;
+    let mdia_size = mdia_header.content_size() as usize;
+
+    let (hdlr_pos, hdlr_header) = find_box_in_container(data, mdia_start, mdia_size, HDLR)?;
+    // hdlr: version/flags(4) + pre_defined(4) + handler_type(4)
+    let handler_pos = hdlr_pos + hdlr_header.header_size as usize + 8;
+    (handler_pos + 4 <= data.len()).then(|| read_u32_be(data, handler_pos))
+}
+
 fn detect_codec_in_trak(data: &[u8], trak_start: usize, trak_size: usize) -> Option<Mp4AudioCodec> {
+    // Skip traks that are not audio. A video MP4 lists its video trak first, so
+    // reporting that trak's codec here made `is_aac_file` reject MP4 files whose
+    // audio is plain AAC, sending them down the MP3 path (issue #327). A missing
+    // hdlr is treated as "might be audio" and left to the stsd check below.
+    if matches!(trak_handler_type(data, trak_start, trak_size), Some(h) if h != SOUN) {
+        return None;
+    }
     let info = find_trak_sample_info(data, trak_start, trak_size)?;
     match info.entry_type {
         MP4A => Some(Mp4AudioCodec::Aac),
@@ -1632,6 +1655,63 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A video MP4 lists its video trak before the audio trak. Codec detection
+    /// must skip non-`soun` traks instead of reporting the first trak it finds,
+    /// or an MP4 carrying plain AAC audio gets classified as non-AAC and falls
+    /// through to the MP3 path (issue #327).
+    #[test]
+    fn test_detect_codec_skips_video_trak() {
+        fn trak(handler: &[u8; 4], codec: &[u8; 4]) -> Vec<u8> {
+            let entry = mp4_box(codec, &[]);
+            let mut stsd_content = vec![0u8; 4]; // version + flags
+            stsd_content.extend_from_slice(&1u32.to_be_bytes()); // entry count
+            stsd_content.extend_from_slice(&entry);
+            let stsd = mp4_box(b"stsd", &stsd_content);
+            let stbl = mp4_box(b"stbl", &stsd);
+            let minf = mp4_box(b"minf", &stbl);
+
+            // hdlr: version/flags(4) + pre_defined(4) + handler_type(4) + reserved(12)
+            let mut hdlr_content = vec![0u8; 8];
+            hdlr_content.extend_from_slice(handler);
+            hdlr_content.extend_from_slice(&[0u8; 13]); // reserved + empty name
+            let hdlr = mp4_box(b"hdlr", &hdlr_content);
+
+            let mut mdia_content = hdlr;
+            mdia_content.extend_from_slice(&minf);
+            mp4_box(b"trak", &mp4_box(b"mdia", &mdia_content))
+        }
+
+        let video = trak(b"vide", b"avc1");
+        let audio = trak(b"soun", b"mp4a");
+
+        for (name, order) in [
+            ("video first", [&video, &audio]),
+            ("audio first", [&audio, &video]),
+        ] {
+            let mut moov_content = Vec::new();
+            for part in order {
+                moov_content.extend_from_slice(part);
+            }
+            let moov = mp4_box(b"moov", &moov_content);
+
+            let mut data = mp4_box(b"ftyp", b"mp42\x00\x00\x02\x00mp42iso2avc1mp41");
+            data.extend_from_slice(&moov);
+            data.extend_from_slice(&mp4_box(b"mdat", &[0u8; 64]));
+
+            assert!(is_aac_data(&data), "{name}");
+            let (moov_pos, h) = find_box(&data, MOOV).unwrap();
+            assert_eq!(
+                detect_codec_in_moov(
+                    &data,
+                    moov_pos + h.header_size as usize,
+                    h.content_size() as usize
+                ),
+                Some(Mp4AudioCodec::Aac),
+                "{name}"
+            );
+        }
     }
 
     /// Tag reads load only `moov` too, so they must agree with the whole-file


### PR DESCRIPTION
Fixes #327.

## Root cause

`detect_codec_in_trak` reported the codec of the **first** trak in the `moov`, regardless of its type. A video MP4 lists its video trak first, so detection returned `Mp4AudioCodec::Unknown` for the `avc1` trak and stopped, never reaching the `mp4a` trak behind it. `is_aac_file` then returned `false` and the file was routed to the MP3 code path.

```
detect_mp4_audio_codec("video.mp4")  ->  Some(Unknown)   // avc1, first trak
is_aac_file("video.mp4")             ->  false           // so: treated as MP3
count_audio_tracks("video.mp4")      ->  2               // counted the video trak
```

## Impact was worse than reported

The issue describes gain not being applied. Applying the reporter's own steps to their sample file shows it also corrupts the video:

- The MP3 frame scanner matched a false sync pattern inside the H.264 payload, so mp3rgain **overwrote two bytes of video data** at offset 24197028 (inside a 106691-byte video packet).
- It appended a **125-byte APEv2 undo tag** past the end of the last MP4 box.
- Both happened while reporting success (`v repro.mp4 (1 frames)`), so nothing warned the user.

## Fix

Skip traks whose `mdia`/`hdlr` `handler_type` is present and not `soun`. A missing `hdlr` stays permissive and falls through to the existing `stsd` check, which keeps the synthetic fixtures that have no `hdlr` box working.

`count_audio_tracks` is fixed by the same change: it counted video traks as audio tracks and could raise a spurious multi-track warning.

## Verification

On the exact sample from the issue (`free-video1-sea-cafinet.mp4`, H.264 + AAC LC 48 kHz):

| | before | after |
|---|---|---|
| `mp3rgain -g 4` | `(1 frames)` | `(2820 gains modified)` |
| audio mean volume | -35.5 dB | -29.5 dB (+6.0 dB) |
| audio max volume | -15.0 dB | -9.0 dB (+6.0 dB) |
| video stream MD5 | `4a179f64…` (corrupted) | `d09489b8…` (identical to original) |
| file growth | +125 B APEv2 tag past last box | +227 B inside `moov/udta` |

`mp3rgain -u` restores the audio stream to an MD5 identical to the original, and the video stream MD5 is unchanged throughout.

Also checked for regressions, none of which touch the file on failure:

| input | result |
|---|---|
| video-only MP4 (no audio trak) | `No AAC audio track found` (was `No valid MP3 frames found`) |
| H.264 + ALAC | correctly detected as ALAC, not AAC |
| H.264 + AC-3 | correctly not detected as AAC |
| plain AAC `.m4a` | unchanged, still works |
| plain `.mp3` | unchanged, still works |

`cargo test`: 195 passed. `cargo fmt --check` clean for both the root crate and `mp3rgui`. The only `cargo clippy` warning is a pre-existing `excessive_precision` in `src/replaygain.rs`.

### mp3rgui

The reporter saw this in the GUI too, so `mp3rgui` was built and checked separately (it is not a workspace member):

| check | result |
|---|---|
| `cargo build --release` | OK |
| `cargo test` | 12 passed |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets` | no warnings |

The GUI's apply and analyze paths call the shared library processors, so they pick up the fix directly. Its one direct use of the detection is the channel-gain filter at `mp3rgui/src/app.rs:1182`:

```rust
.filter(|(_, f)| !mp3rgain::mp4meta::is_aac_file(&f.path))
```

Channel gain (`-l`) is MP3-only. Before this fix `is_aac_file` returned `false` for a video MP4, so that filter kept the file and handed it to the MP3 channel-gain writer; now the file is correctly excluded and the GUI reports "Channel gain only applies to MP3". The equivalent CLI path was checked directly on a video MP4 and refuses without touching the file:

```
$ mp3rgain -l 0 3 t.mp4
  x t.mp4 - No valid MP3 frames found
  [file unchanged]
```

Note this was verified through the library predicate and the CLI equivalent, not by driving the GUI interactively.

A regression test (`test_detect_codec_skips_video_trak`) builds a `moov` with `vide`/`avc1` and `soun`/`mp4a` traks in both orders. It fails without the fix.

## Out of scope

The default info output reports `Max mp3 global gain field: 255 / Min mp3 global gain field: 0` while `-x` reports `152 / 96` for the same file. This reproduces identically on a plain `.m4a`, so it predates this issue and is unrelated to MP4 video handling.

