### PR TITLE
perf: analyze albums concurrently under -a --per-directory (#332)

### DIFF
--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -78,7 +78,10 @@ computes and applies one album gain per folder in a single run. A
 directory that fails analysis is reported and the run continues with the
 next one. In JSON output the per-directory results appear in an
 .B albums
-array.
+array. Directories are analyzed concurrently, so the worker threads stay
+busy across folder boundaries; results, text output and exit status are
+still ordered by path, exactly as under
+.BR "\-j 1" .
 .TP
 .B \-\-rg2
 Measure loudness with the ReplayGain 2.0 algorithm (ITU-R BS.1770

--- a/docs/perf-parallel.md
+++ b/docs/perf-parallel.md
@@ -193,5 +193,62 @@ Plus, in this PR's scope:
   atomicity is sufficient for diagnostics. Order across files may
   differ between runs.
 
+## Album-crossing parallelism for `-a --per-directory` (3.8, issue [#332])
+
+Until 3.7.0, `-a --per-directory` walked the album groups in a sequential loop and parallelized only *within* an album. Every album boundary was a barrier: while the last and longest track of an album finished on one core, the rest of the pool sat idle, and with N albums in one invocation that tail was paid N times. skamp saw it from the outside on the Hydrogenaudio thread, without instrumentation: "with foobar2000, all CPU cores remain fully active until the very last *file* (not album, file). With mp3rgain, I see short drops of CPU as it is scanning albums one by one."
+
+The fix nests the parallelism instead of flattening it. The outer loop over album groups became a `par_iter`, and the existing inner `par_iter` over an album's files is untouched, so rayon's work-stealing fills an album's tail with files from the next album. A flat `par_iter` over every file with grouping applied afterwards was rejected: it would hold one `LoudnessHistogram` (48 KB) or `BlockEnergies` per file for the whole run, which is 480 MB on a 10,000-file library. Nested, each album still drops its per-track state the moment it folds, so live state tracks the albums in flight rather than the size of the library.
+
+### Benchmark
+
+Synthesized corpus, one directory per album, 6 tracks each with deliberately ragged lengths (120/150/180/210/150/270 s) so every album has a long tail to drain; 44.1 kHz stereo MP3 at 320 kbps. MacBook Air (M3, 2024), 4 performance + 4 efficiency cores, fanless. Median of 3 runs, `-q -n`, warm cache.
+
+| Corpus | Command | 3.7.0 | this change | one pooled album (no barrier) |
+|---|---|---|---|---|
+| 6 albums, 36 files, 1.8 h | `-a --per-directory --rg2 --true-peak` | 6.47 s | **5.03 s** (1.29x) | 4.78 s |
+| 12 albums, 72 files, 3.6 h | `-a --per-directory --rg2 --true-peak` | 13.62 s | **11.25 s** (1.21x) | 10.92 s |
+| 12 albums, 72 files, 3.6 h | `-a --per-directory` (RG1) | 4.12 s | **3.02 s** (1.36x) | 2.87 s |
+
+The rightmost column is the floor: the same files analyzed as a single pooled album, which has no album boundary to stall on. The per-directory run now sits within 3 to 5% of it, so the barrier is gone rather than merely reduced.
+
+`-j 1` is unaffected (18.56 s → 18.37 s on the 6-album corpus): with one worker thread there is nothing to overlap, so that path keeps the sequential loop, the per-album progress bars and the direct-to-stdout writes it always had.
+
+### Memory
+
+Peak RSS, same corpus, `--rg2 --true-peak`:
+
+| Run | 6 albums / 36 files | 12 albums / 72 files |
+|---|---|---|
+| `-a --per-directory` (this change) | 6.5 MB | 6.4 MB |
+| `-a` pooled into one album | 6.3 MB | 8.1 MB |
+
+Per-directory stays flat as the library doubles; pooling does not. That is the property the nested form buys, and it is why the flat-scan alternative was not taken.
+
+### Output identity
+
+Albums finish out of order, so everything observable is re-ordered before it is shown. Album runs are collected by index, so the JSON `albums` array, the `files` array, the counters and the exit code are all built in group order after the fact. Each album's text is buffered and flushed only once every earlier album has been flushed, so a finished album still prints immediately unless an earlier one is outstanding. The album fold was already associative and folded in input order, which is what keeps the numbers bit-identical.
+
+Verified on the 12-album corpus and on a 30-file apply, against the 3.7.0 binary:
+
+```sh
+# -o json, -o tsv, text stdout and text stderr all byte-identical
+mp3rgain-3.7.0 -a --per-directory --rg2 --true-peak -n -R -o json . > base.json
+mp3rgain-new   -a --per-directory --rg2 --true-peak -n -R -o json . > new.json
+diff base.json new.json    # exits 0, and likewise for -j 1 vs -j 8
+
+# a real (non dry-run) apply over 6 concurrent albums, MP3 + AAC
+diff <(cd base && find . -type f | sort | xargs shasum) \
+     <(cd new  && find . -type f | sort | xargs shasum)   # exits 0
+```
+
+One thing does move: per-file warnings (clipping, saturation) are emitted by the apply workers straight to stderr, as they already were inside a single album, so they are not grouped by album and their position relative to an album's buffered stderr lines can differ. The album-level lines are the ones that had to stay grouped, because "Failed to analyze album" names nothing on its own.
+
+### Not in scope
+
+The other half of [#332] is granularity: the smallest schedulable unit is still one whole file, so a 9-minute track cannot be split or stolen once a worker picks it up, and thread efficiency is down to 71% at 4 threads even with no album boundary anywhere. Splitting a file into chunks with overlap-warmup is a separate design problem, and [#334] (the true-peak inner loop, a measured 2.1x on 68% of the analysis cost) is a bigger and cheaper win that should land before either.
+
 [#125]: https://github.com/M-Igashi/mp3rgain/issues/125
 [#126]: https://github.com/M-Igashi/mp3rgain/issues/126
+
+[#332]: https://github.com/M-Igashi/mp3rgain/issues/332
+[#334]: https://github.com/M-Igashi/mp3rgain/issues/334

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -200,7 +200,7 @@ fn analyze_set(set: &[(usize, &Path)], opts: &Options) -> Option<AlbumAnalysisRe
         return None;
     }
     let paths: Vec<&Path> = set.iter().map(|&(_, p)| p).collect();
-    run_album_analysis(&paths, opts, true).ok()
+    run_album_analysis(&paths, opts, true, None).ok()
 }
 
 /// Basic per-file info (JSON output or builds without the replaygain feature).

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use colored::*;
+use indicatif::{MultiProgress, ProgressBar};
 use mp3rgain::replaygain::{
     self, AlbumAnalysisReport, AlbumGainResult, AudioFileType, ReplayGainResult,
     REPLAYGAIN_REFERENCE_DB,
@@ -9,6 +10,7 @@ use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use crate::cli::options::{Options, OutputFormat, StoredTagMode};
 use crate::commands::threading::effective_threads;
@@ -25,7 +27,10 @@ use crate::processors::replaygain::{
     apply_is_noop, capped_tag_gain, process_apply_replaygain_with_album, process_track_gain,
 };
 use crate::processors::utils::report_unsupported_format;
-use crate::progress::{create_progress_bar, progress_finish, progress_inc, progress_set_message};
+use crate::progress::{
+    create_labeled_file_count_pb_in, create_progress_bar, progress_finish, progress_inc,
+    progress_set_message,
+};
 use crate::util::get_filename;
 
 fn print_target_with_modifier(opts: &Options) {
@@ -167,6 +172,111 @@ struct AlbumRun {
     failed: usize,
 }
 
+/// Where one album's text goes.
+///
+/// `-a` on its own writes straight through, so a long album still reports as
+/// it goes. `-a --per-directory` runs albums concurrently (issue #332), where
+/// writing straight through would interleave two albums mid-line, so each
+/// album buffers and the driver flushes the buffers in group order.
+///
+/// Only the album-level lines come through here. Per-file warnings (clipping,
+/// saturation) are emitted by the apply workers straight to stderr, as they
+/// already were inside a single album, so they name their file but are not
+/// grouped by album. The album-level lines are the ones that have to be:
+/// "Failed to analyze album" identifies nothing on its own.
+enum AlbumSink {
+    Direct(io::Stdout, io::Stderr),
+    Buffered { out: Vec<u8>, err: Vec<u8> },
+}
+
+impl AlbumSink {
+    fn direct() -> Self {
+        Self::Direct(io::stdout(), io::stderr())
+    }
+
+    fn buffered() -> Self {
+        Self::Buffered {
+            out: Vec::new(),
+            err: Vec::new(),
+        }
+    }
+
+    fn out(&mut self) -> &mut dyn Write {
+        match self {
+            Self::Direct(out, _) => out,
+            Self::Buffered { out, .. } => out,
+        }
+    }
+
+    fn err(&mut self) -> &mut dyn Write {
+        match self {
+            Self::Direct(_, err) => err,
+            Self::Buffered { err, .. } => err,
+        }
+    }
+
+    /// Copy the buffered bytes to the real streams; a no-op when direct.
+    fn drain(self) -> io::Result<()> {
+        if let Self::Buffered { out, err } = self {
+            io::stdout().write_all(&out)?;
+            io::stderr().write_all(&err)?;
+        }
+        Ok(())
+    }
+}
+
+/// Flushes each album's buffered output as soon as every earlier album has
+/// been flushed. Concurrent albums finish out of order, so without this the
+/// group order in the text output would depend on which album happened to
+/// win; with it, a finished album still prints immediately unless an earlier
+/// one is outstanding.
+#[derive(Default)]
+struct OrderedFlush {
+    /// `(next index to print, albums finished ahead of their turn)`
+    state: Mutex<(usize, BTreeMap<usize, AlbumSink>)>,
+}
+
+impl OrderedFlush {
+    fn submit(&self, index: usize, sink: AlbumSink) -> io::Result<()> {
+        let mut guard = self.state.lock().expect("output lock poisoned");
+        let (next, pending) = &mut *guard;
+        pending.insert(index, sink);
+        while let Some(sink) = pending.remove(next) {
+            sink.drain()?;
+            *next += 1;
+        }
+        Ok(())
+    }
+}
+
+/// The two progress bars of a concurrent `--per-directory` run, each sized to
+/// the whole file list. A per-album bar would reset at every boundary and
+/// several albums would be drawing at once; these span the run, and analysis
+/// and apply get one each because they now overlap in time (issue #332).
+struct AlbumBars {
+    _mp: MultiProgress,
+    analysis: Option<ProgressBar>,
+    apply: Option<ProgressBar>,
+}
+
+impl AlbumBars {
+    fn new(total: usize, opts: &Options) -> Self {
+        let mp = MultiProgress::new();
+        let analysis = create_labeled_file_count_pb_in(&mp, "Analyzing", total, opts);
+        let apply = create_labeled_file_count_pb_in(&mp, "Applying", total, opts);
+        Self {
+            _mp: mp,
+            analysis,
+            apply,
+        }
+    }
+
+    fn finish(self) {
+        progress_finish(self.analysis);
+        progress_finish(self.apply);
+    }
+}
+
 /// TSV header plus the text-mode banner shared by both album commands.
 fn print_album_intro(file_count: usize, directories: Option<usize>, opts: &Options) {
     if opts.output_format == OutputFormat::Tsv {
@@ -197,7 +307,7 @@ fn print_album_intro(file_count: usize, directories: Option<usize>, opts: &Optio
 pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
     print_album_intro(files.len(), None, opts);
-    let run = run_album(files, opts)?;
+    let run = run_album(files, opts, &mut AlbumSink::direct(), None)?;
     finish_with_album_summary(
         files.len(),
         run.json_results,
@@ -209,29 +319,76 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 }
 
 /// `-a --per-directory`: one album per parent directory (issue #324), the
-/// grouping the GUI has used since #159. Directories are processed in path
-/// order; one that fails analysis is counted and the run moves on to the
-/// next, so a whole library can be tagged in a single invocation.
+/// grouping the GUI has used since #159. A directory that fails analysis is
+/// counted and the run moves on, so a whole library can be tagged in a single
+/// invocation.
+///
+/// Albums are analyzed concurrently on the shared rayon pool (issue #332).
+/// The per-file parallelism inside an album stays exactly as it was, so
+/// rayon fills an album's tail — the stretch where one long track is still
+/// decoding and the rest of the pool has nothing to do — with files from the
+/// next album, instead of draining at every album boundary. Each album still
+/// drops its per-track analysis state when it folds, so live memory tracks
+/// the albums in flight rather than the size of the library.
+///
+/// Everything the caller can observe stays in group order: results are
+/// collected by index, text output is buffered per album and flushed in
+/// order, and the counters are summed afterwards rather than by the workers.
 pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
     let groups = group_by_parent(files);
     print_album_intro(files.len(), Some(groups.len()), opts);
 
-    let mut json_results = Vec::with_capacity(files.len());
-    let mut albums = Vec::with_capacity(groups.len());
-    let (mut successful, mut failed) = (0, 0);
-    for (i, (dir, group)) in groups.iter().enumerate() {
+    // One album, or -j 1, has nothing to overlap: keep the direct-to-stdout
+    // path and the per-album bars rather than buffering for no reason.
+    let concurrent = groups.len() > 1 && effective_threads(opts) > 1;
+    let bars = concurrent.then(|| AlbumBars::new(files.len(), opts));
+    let flush = OrderedFlush::default();
+    let entries: Vec<(&PathBuf, &Vec<PathBuf>)> = groups.iter().collect();
+
+    let run_group = |i: usize, dir: &Path, group: &[PathBuf]| -> Result<AlbumRun> {
+        let mut sink = if concurrent {
+            AlbumSink::buffered()
+        } else {
+            AlbumSink::direct()
+        };
         if opts.output_format == OutputFormat::Text && !opts.quiet {
             if i > 0 {
-                println!();
+                writeln!(sink.out())?;
             }
-            println!(
+            writeln!(
+                sink.out(),
                 "{} ({} file(s))",
                 dir.display().to_string().bold(),
                 group.len()
-            );
+            )?;
         }
-        let run = run_album(group, opts)?;
+        let run = run_album(group, opts, &mut sink, bars.as_ref())?;
+        flush.submit(i, sink)?;
+        Ok(run)
+    };
+
+    let runs: Vec<AlbumRun> = if concurrent {
+        entries
+            .par_iter()
+            .enumerate()
+            .map(|(i, &(dir, group))| run_group(i, dir, group))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        entries
+            .iter()
+            .enumerate()
+            .map(|(i, &(dir, group))| run_group(i, dir, group))
+            .collect::<Result<Vec<_>>>()?
+    };
+    if let Some(bars) = bars {
+        bars.finish();
+    }
+
+    let mut json_results = Vec::with_capacity(files.len());
+    let mut albums = Vec::with_capacity(groups.len());
+    let (mut successful, mut failed) = (0, 0);
+    for ((dir, group), run) in entries.iter().zip(runs) {
         if let Some(album) = run.album {
             albums.push(JsonDirectoryAlbum {
                 directory: dir.display().to_string(),
@@ -264,6 +421,14 @@ pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result
     Ok(())
 }
 
+/// Tick a shared progress bar past files that were never decoded or written,
+/// so it still reaches its total.
+fn advance(pb: Option<&ProgressBar>, files: usize) {
+    if let Some(pb) = pb {
+        pb.inc(files as u64);
+    }
+}
+
 /// Group files by their immediate parent directory, as given on the command
 /// line. Bare file names land in `.`.
 fn group_by_parent(files: &[PathBuf]) -> BTreeMap<PathBuf, Vec<PathBuf>> {
@@ -284,7 +449,16 @@ fn group_by_parent(files: &[PathBuf]) -> BTreeMap<PathBuf, Vec<PathBuf>> {
 /// Analyze and apply album gain to `files` as one album, returning what the
 /// epilogue needs instead of printing JSON or exiting, so the per-directory
 /// driver can aggregate several albums (issue #324).
-fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
+///
+/// Text goes to `sink` rather than straight to stdout, and `bars`, when
+/// present, replaces the per-album progress bars with ones shared by every
+/// album in the run: both are what let several albums run at once (#332).
+fn run_album(
+    files: &[PathBuf],
+    opts: &Options,
+    sink: &mut AlbumSink,
+    bars: Option<&AlbumBars>,
+) -> Result<AlbumRun> {
     let file_refs: Vec<&Path> = files.iter().map(|p| p.as_path()).collect();
 
     let threads = effective_threads(opts);
@@ -295,15 +469,27 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
     let album_analysis = match stored_album_report(files, opts) {
         Some(report) => {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
-                println!("  {} Using stored tags (no rescan)", "->".cyan());
+                writeln!(
+                    sink.out(),
+                    "  {} Using stored tags (no rescan)",
+                    "->".cyan()
+                )?;
             }
+            // Nothing was decoded, so the shared bar has to be told that this
+            // album's files are accounted for or it never reaches its total.
+            advance(bars.and_then(|b| b.analysis.as_ref()), files.len());
             Ok(report)
         }
         None => {
             if opts.output_format == OutputFormat::Text && !opts.quiet {
-                println!("  {} Analyzing tracks...", "->".cyan());
+                writeln!(sink.out(), "  {} Analyzing tracks...", "->".cyan())?;
             }
-            run_album_analysis(&file_refs, opts, opts.skip_errors)
+            run_album_analysis(
+                &file_refs,
+                opts,
+                opts.skip_errors,
+                bars.and_then(|b| b.analysis.as_ref()),
+            )
         }
     };
 
@@ -331,12 +517,24 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                 if mp4meta::unsupported_audio_format(&files[idx]).is_some() {
                     unsupported[idx] = true;
                     if report_skipped {
-                        eprintln!("  {} {} - {} (skipped)", "!".yellow(), filename, msg);
+                        writeln!(
+                            sink.err(),
+                            "  {} {} - {} (skipped)",
+                            "!".yellow(),
+                            filename,
+                            msg
+                        )?;
                     }
                 } else {
                     failure_count += 1;
                     if report_skipped {
-                        eprintln!("  {} {} - {} (skipped)", "x".red(), filename, msg);
+                        writeln!(
+                            sink.err(),
+                            "  {} {} - {} (skipped)",
+                            "x".red(),
+                            filename,
+                            msg
+                        )?;
                     }
                 }
                 failure_msgs[idx] = Some(msg);
@@ -385,22 +583,26 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
             // mp3gain-compatible TSV rows, emitted before the apply so the
             // global_gain columns describe the files as they were scanned.
             if opts.output_format == OutputFormat::Tsv {
-                emit_album_tsv_rows(files, &album_result, &file_to_track, opts)?;
+                emit_album_tsv_rows(files, &album_result, &file_to_track, opts, sink)?;
             }
 
             if opts.output_format == OutputFormat::Text && !opts.quiet {
-                println!();
-                println!(
+                let out = sink.out();
+                writeln!(out)?;
+                writeln!(
+                    out,
                     "  Album loudness: {:.1} {}",
                     album_result.album_loudness_db(),
                     opts.analysis_mode.unit()
-                );
+                )?;
                 match album_tag_gain_db {
-                    Some(tag_gain) => println!(
+                    Some(tag_gain) => writeln!(
+                        out,
                         "  Album gain:     {:+.2} dB (tag value, audio unchanged)",
                         tag_gain
-                    ),
-                    None => println!(
+                    )?,
+                    None => writeln!(
+                        out,
                         "  Album gain:     {:+.1} dB ({} steps{})",
                         album_result.album_gain_db(),
                         album_result.album_gain_steps(),
@@ -409,10 +611,10 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                         } else {
                             String::new()
                         }
-                    ),
+                    )?,
                 }
-                println!("  Album peak:     {:.4}", album_result.album_peak());
-                println!();
+                writeln!(out, "  Album peak:     {:.4}", album_result.album_peak())?;
+                writeln!(out)?;
             }
 
             // Apply album gain to all files
@@ -456,10 +658,13 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                         .collect()
                 } else {
                     if !opts.quiet {
-                        println!("  {} No adjustment needed", ".".cyan());
+                        writeln!(sink.out(), "  {} No adjustment needed", ".".cyan())?;
                     }
                     Vec::new()
                 };
+                // No file is touched, so the shared apply bar has to be
+                // advanced here for the same reason as the analysis one.
+                advance(bars.and_then(|b| b.apply.as_ref()), files.len());
                 return Ok(AlbumRun {
                     json_results,
                     album: Some(json_album),
@@ -468,7 +673,12 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                 });
             }
 
-            let pb = create_progress_bar(files.len(), opts);
+            // A concurrent run shares one apply bar across every album; a
+            // single album owns its bar and clears it when it is done.
+            let pb = match bars {
+                Some(bars) => bars.apply.clone(),
+                None => create_progress_bar(files.len(), opts),
+            };
             let mut json_results: Vec<JsonFileResult> = Vec::with_capacity(files.len());
             let mut successful = 0;
             let mut failed = 0;
@@ -502,14 +712,11 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let stdout = io::stdout();
-                let mut handle = stdout.lock();
                 for (_, _, text, _) in &collected {
                     if !text.is_empty() {
-                        handle.write_all(text.as_bytes())?;
+                        sink.out().write_all(text.as_bytes())?;
                     }
                 }
-                drop(handle);
 
                 for (file_idx, _, _, range) in &collected {
                     range_by_idx[*file_idx] = *range;
@@ -559,7 +766,7 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                                 Some(&album_info),
                             )?;
                             if !text.is_empty() {
-                                print!("{}", text);
+                                write!(sink.out(), "{}", text)?;
                             }
                             range_by_idx[i] = range;
                             result
@@ -576,7 +783,9 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                 }
             }
 
-            progress_finish(pb);
+            if bars.is_none() {
+                progress_finish(pb);
+            }
 
             // MP3GAIN_ALBUM_MINMAX: the album-wide post-apply global_gain range,
             // matching mp3gain's album (`-a`) mode (issue #210). Written to every
@@ -606,6 +815,10 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
             })
         }
         Err(e) => {
+            // Nothing is applied for a failed album, so its files still have
+            // to be counted off the shared apply bar.
+            advance(bars.and_then(|b| b.apply.as_ref()), files.len());
+
             // An album with nothing adjustable in it (every member ALAC, say)
             // is a set of skips, not a failure: the track path reports exactly
             // that for the same files, and `-a` should not disagree
@@ -641,7 +854,12 @@ fn run_album(files: &[PathBuf], opts: &Options) -> Result<AlbumRun> {
                     .map(|f| JsonFileResult::error(f, e.to_string()))
                     .collect()
             } else {
-                eprintln!("{}: Failed to analyze album: {}", "error".red().bold(), e);
+                writeln!(
+                    sink.err(),
+                    "{}: Failed to analyze album: {}",
+                    "error".red().bold(),
+                    e
+                )?;
                 Vec::new()
             };
             Ok(AlbumRun {
@@ -661,6 +879,7 @@ fn emit_album_tsv_rows(
     album_result: &AlbumGainResult,
     file_to_track: &[Option<usize>],
     opts: &Options,
+    sink: &mut AlbumSink,
 ) -> Result<()> {
     // The frame scan re-reads each file, so run it in parallel the way
     // cmd_info does rather than serializing it inside the emit loop.
@@ -676,8 +895,7 @@ fn emit_album_tsv_rows(
     let mut any_row = false;
     let mut album_max_gain: Option<u8> = None;
     let mut album_min_gain: Option<u8> = None;
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
+    let handle = sink.out();
     for (i, file) in files.iter().enumerate() {
         let Some(track_idx) = file_to_track[i] else {
             continue;

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -21,14 +21,21 @@ use crate::util::get_filename;
 /// tick per file via `on_complete`. Shared by `cmd_info` and `cmd_album_gain`.
 /// The thread count follows `-j` (see [`effective_threads`]); only
 /// `skip_errors` varies between callers.
+///
+/// `shared_pb` belongs to a `--per-directory` run, where several albums are
+/// analyzed at once (issue #332). It spans every album, so this call ticks it
+/// once per finished file and never takes the byte-level callback: two albums
+/// decoding concurrently have no single byte total to report.
 pub fn run_album_analysis(
     paths: &[&Path],
     opts: &Options,
     skip_errors: bool,
+    shared_pb: Option<&ProgressBar>,
 ) -> mp3rgain::error::Result<AlbumAnalysisReport> {
     let threads = effective_threads(opts);
     let parallel = threads > 1 && paths.len() > 1;
-    let show_progress = !opts.quiet && opts.output_format == OutputFormat::Text;
+    let show_progress =
+        shared_pb.is_none() && !opts.quiet && opts.output_format == OutputFormat::Text;
     let mp = MultiProgress::new();
     let pb = if show_progress {
         Some(create_album_progress_pb_in(&mp, paths.len(), parallel))
@@ -37,6 +44,12 @@ pub fn run_album_analysis(
     };
     let file_names: Vec<&str> = paths.iter().map(|p| get_filename(p)).collect();
     let (on_progress, on_complete) = album_progress_callbacks(&pb, file_names);
+    let on_shared_complete = |_: usize, path: &Path| {
+        if let Some(pb) = shared_pb {
+            pb.set_message(get_filename(path).to_string());
+            pb.inc(1);
+        }
+    };
 
     let report = replaygain::analyze_album_with_options(
         paths,
@@ -44,8 +57,11 @@ pub fn run_album_analysis(
             track_index: opts.track_index,
             threads,
             skip_errors,
-            on_progress: (!parallel).then_some(&on_progress as _),
-            on_complete: parallel.then_some(&on_complete as _),
+            on_progress: (shared_pb.is_none() && !parallel).then_some(&on_progress as _),
+            on_complete: match shared_pb {
+                Some(_) => Some(&on_shared_complete as _),
+                None => parallel.then_some(&on_complete as _),
+            },
             cancel: None,
             mode: opts.analysis_mode,
             true_peak: opts.true_peak,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -19,6 +19,12 @@ pub const ANALYSIS_PROGRESS_MIN_SIZE: u64 = 1_000_000;
 /// Standard file-count progress bar template used across commands.
 const FILE_COUNT_TEMPLATE: &str = "{spinner:.cyan} [{bar:40.cyan/blue}] {pos}/{len} {msg}";
 
+/// File-count template with a phase label, for the bars that span a whole
+/// `--per-directory` run (issue #332). Analysis and apply overlap in time
+/// once albums run concurrently, so each phase needs its own labelled bar.
+const LABELED_FILE_COUNT_TEMPLATE: &str =
+    "{spinner:.cyan} {prefix:<9} [{bar:30.cyan/blue}] {pos}/{len} {msg}";
+
 /// Build a bar style from a template, using the shared progress characters.
 fn bar_style(template: &str) -> ProgressStyle {
     ProgressStyle::default_bar()
@@ -53,6 +59,23 @@ pub fn create_file_count_pb_in(
     }
     let pb = mp.add(ProgressBar::new(total as u64));
     pb.set_style(bar_style(FILE_COUNT_TEMPLATE));
+    Some(pb)
+}
+
+/// Labelled file-count bar attached to a `MultiProgress`, sized to the whole
+/// run rather than to one album (issue #332).
+pub fn create_labeled_file_count_pb_in(
+    mp: &MultiProgress,
+    label: &'static str,
+    total: usize,
+    opts: &Options,
+) -> Option<ProgressBar> {
+    if !file_count_enabled(total, opts) {
+        return None;
+    }
+    let pb = mp.add(ProgressBar::new(total as u64));
+    pb.set_style(bar_style(LABELED_FILE_COUNT_TEMPLATE));
+    pb.set_prefix(label);
     Some(pb)
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -684,6 +684,52 @@ fn per_directory_album_gain_matches_each_directory_run_alone() {
     assert!(pooled["album"]["gain_db"].is_number());
 }
 
+/// Albums run concurrently under `--per-directory` (issue #332), so the
+/// output can no longer rely on one album finishing before the next starts.
+/// Every observable part of the run — group order, gain values, text layout —
+/// must still match what the serial `-j 1` path produces.
+#[test]
+fn per_directory_output_is_identical_whatever_the_thread_count() {
+    let root = TempAlbum::new(&[]);
+    for (name, fixtures) in [
+        ("A", vec!["test_mono.mp3", "test_vbr.mp3"]),
+        ("B", vec!["test_stereo.mp3", "test_joint_stereo.mp3"]),
+        ("C", vec!["test_vbr.mp3", "test_aac.m4a"]),
+        ("D", vec!["test_mono.mp3"]),
+    ] {
+        let dir = root.dir.join(name);
+        fs::create_dir(&dir).unwrap();
+        for f in fixtures {
+            fs::copy(Path::new("tests/fixtures").join(f), dir.join(f)).unwrap();
+        }
+    }
+    let root_arg = root.dir.to_str().unwrap();
+
+    for format in ["json", "text", "tsv"] {
+        let args = |jobs: &'static str| {
+            vec![
+                "-a",
+                "--per-directory",
+                "-n",
+                "-R",
+                "-o",
+                format,
+                "-j",
+                jobs,
+                root_arg,
+            ]
+        };
+        let serial = run(&args("1"));
+        let parallel = run(&args("4"));
+        assert!(serial.status.success() && parallel.status.success());
+        assert_eq!(
+            stdout_of(&serial),
+            stdout_of(&parallel),
+            "-o {format} differs between -j 1 and -j 4"
+        );
+    }
+}
+
 #[test]
 fn per_directory_requires_album_mode() {
     let out = run(&["--per-directory", "-r", "tests/fixtures/test_mono.mp3"]);


### PR DESCRIPTION
Removes the album barrier half of #332. `-a --per-directory` now analyzes albums concurrently, so the thread pool stays saturated across album boundaries instead of draining at each one.

Scoped to be independent of the neighbouring issues: #331 and #333 change how the groups are *formed*, this changes only how they are *scheduled*, and it touches neither `group_by_parent` nor the flag surface. #334 (true-peak inner loop) is a change inside `TruePeakMeter` and does not overlap either. Whichever of the three lands next needs no rebase against this one beyond the usual.

## The problem

`cmd_album_gain_per_directory` walked the groups in a sequential `for` loop and parallelized only *within* an album. Every album boundary was a barrier: while the last and longest track of an album finished on one core, the rest of the pool sat idle, and with N albums in one invocation that tail was paid N times. skamp saw it from the outside on the Hydrogenaudio thread, with no instrumentation at all:

> with foobar2000, all CPU cores remain fully active until the very last *file* (not album, file). With mp3rgain, I see short drops of CPU as it is scanning albums one by one.

## The change

The outer loop over album groups is now a `par_iter`; the inner per-file `par_iter` is untouched. rayon's work-stealing then fills an album's tail with files from the next album, and no barrier is left.

The flat alternative, one `par_iter` over every file with grouping applied afterwards, was rejected: it would hold one `LoudnessHistogram` (48 KB) or `BlockEnergies` per file for the whole run, which is 480 MB on a 10,000-file library. Nested, each album still drops its per-track state the moment it folds, so live state tracks the albums in flight rather than the size of the library.

Albums finish out of order, so everything observable is re-ordered before it is shown:

- Album runs are collected by index, so the JSON `albums` array, the `files` array, the counters and the exit code are all assembled in group order after the fact.
- Each album's text is buffered and flushed only once every earlier album has been flushed, so a finished album still prints immediately unless an earlier one is outstanding. It is not a batch-at-the-end flush.
- The per-album progress bars are replaced by one `Analyzing` and one `Applying` bar sized to the whole run, since the two phases now overlap in time across albums.
- A single directory, or `-j 1`, keeps the sequential loop, the per-album bars and the direct-to-stdout writes. Nothing to overlap, nothing to buffer.

## Measurements

Synthesized corpus, one directory per album, 6 tracks each with ragged lengths (120/150/180/210/150/270 s) so every album has a real tail to drain; 44.1 kHz stereo MP3 at 320 kbps. MacBook Air (M3, 2024), fanless. Median of 3 runs, `-q -n`, warm cache.

| Corpus | Command | 3.7.0 | this PR | pooled into one album (no barrier) |
|---|---|---|---|---|
| 6 albums, 36 files, 1.8 h | `-a --per-directory --rg2 --true-peak` | 6.47 s | **5.03 s** (1.29x) | 4.78 s |
| 12 albums, 72 files, 3.6 h | `-a --per-directory --rg2 --true-peak` | 13.62 s | **11.25 s** (1.21x) | 10.92 s |
| 12 albums, 72 files, 3.6 h | `-a --per-directory` (RG1) | 4.12 s | **3.02 s** (1.36x) | 2.87 s |

The rightmost column is the floor: the same files analyzed as a single pooled album, which has no album boundary to stall on. The per-directory run now sits within 3 to 5% of it, so the barrier is gone rather than merely reduced.

`-j 1` is unaffected: 18.56 s → 18.37 s on the 6-album corpus.

Peak RSS, `--rg2 --true-peak`:

| Run | 6 albums / 36 files | 12 albums / 72 files |
|---|---|---|
| `-a --per-directory` (this PR) | 6.5 MB | 6.4 MB |
| `-a` pooled into one album | 6.3 MB | 8.1 MB |

Per-directory stays flat as the library doubles; pooling does not. That is the property the nested form buys.

## Verification

Against the 3.7.0 release binary on the 12-album corpus:

- `-o json`, `-o tsv`, text stdout and text stderr: byte-identical.
- `-j 1` vs `-j 8` on the new binary: byte-identical.
- A real (non dry-run) apply over 6 concurrent albums of MP3 and AAC, both plain `-a` and `--tags-only`: all 30 output files byte-identical to the 3.7.0 run, which covers the per-album `MP3GAIN_ALBUM_MINMAX` and `AacAlbumInfo` paths.
- Failure paths (corrupt file, ALAC in an album, an album where every file fails), with and without `--skip-errors`: identical JSON, identical text stdout, identical exit codes.
- `cargo test`: 214 passed, 0 failed. New regression test asserts `-o json`, `-o text` and `-o tsv` are identical between `-j 1` and `-j 4`.
- `cargo fmt --check` and `cargo clippy --all-targets` clean (one pre-existing `excessive_precision` warning in `replaygain.rs`, untouched).

One thing does move, and it is the only behavior difference I found: per-file warnings (clipping, saturation) are emitted by the apply workers straight to stderr, as they already were inside a single album, so they are not grouped by album and their position relative to an album's buffered stderr lines can differ. The album-level lines are buffered and stay grouped, which is what matters, because `error: Failed to analyze album` names nothing on its own. Grouping the per-file warnings too would mean threading an output sink through every `emit_file_warning` call site in `src/processors/`, including the track path, which is a bigger and riskier change than this issue warrants.

The library crate is untouched, so mp3rgui is unaffected: only `src/commands/` and `src/progress.rs` changed.

## Not in this PR

The granularity half of #332. The smallest schedulable unit is still one whole file, so a 9-minute track cannot be split or stolen once a worker picks it up, and thread efficiency is down to 71% at 4 threads even with no album boundary anywhere. That needs the chunked analysis with overlap-warmup sketched in the issue, scoped to `--rg2` / `--r128`. #332 should stay open for it, or it can be split out into its own issue.

Refs #332
