### PR TITLE
cli: add --album-by, with tag grouping for releases (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Binaries for all platforms are on [GitHub Releases](https://github.com/M-Igashi/
 mp3rgain -r song.mp3          # Normalize a single track (ReplayGain)
 mp3rgain -a *.mp3             # Normalize an album
 mp3rgain -s R -a -R /music    # Apply from stored tags, rescan only where missing (v3.4+)
-mp3rgain -a --per-directory -R /music  # One album per folder, whole library in one run (v3.6.1+)
+mp3rgain -a --album-by=tag -R /music   # One album per release, whole library in one run (v3.8+)
 mp3rgain -g 2 song.mp3        # Manual gain (+3.0 dB; 1 step = 1.5 dB)
 mp3rgain -u song.mp3          # Undo
 mp3rgain song.mp3             # Show file info

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -72,7 +72,8 @@ All options from the original mp3gain are fully implemented in mp3rgain:
 | Option | Description |
 |--------|-------------|
 | `-R` | Recursive directory processing |
-| `--per-directory` | With `-a`: one album per directory, like rsgain's directory-based album detection |
+| `--album-by=dir` | With `-a`: one album per directory, like rsgain's directory-based album detection (`--per-directory` is the alias) |
+| `--album-by=tag` | With `-a`: one album per release from ALBUM/ALBUMARTIST, like foobar2000's "Scan as albums (by tags)", so multi-disc releases share one album gain |
 | `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only when tags are missing (mp3gain's *default* behavior, opt-in here) |
 | `-n` / `--dry-run` | Dry-run mode (preview changes without modifying files) |
 | `-o json` | JSON output format (for scripting and automation) |

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -67,20 +67,40 @@ Each file is normalized individually to the 89 dB reference level.
 Analyze and apply Album gain using the ReplayGain 1.0 algorithm.
 All files are treated as an album and normalized together.
 .TP
-.B \-\-per\-directory
+.BI \-\-album\-by " how"
 With
 .BR \-a ,
-treat each directory as its own album instead of pooling every file into
-one. Files are grouped by their parent directory as given on the command
-line, so
-.B \-a \-\-per\-directory \-R /music
-computes and applies one album gain per folder in a single run. A
-directory that fails analysis is reported and the run continues with the
-next one. In JSON output the per-directory results appear in an
+choose what counts as one album instead of pooling every file into one, so
+a whole library can be album\-tagged in a single run.
+.RS
+.TP
+.B dir
+One album per parent directory, as given on the command line.
+.B \-\-per\-directory
+is an alias for this. Works on untagged libraries, but a release whose discs
+live in subdirectories is scanned as one album per disc.
+.TP
+.B tag
+One album per release, keyed on MUSICBRAINZ_ALBUMID when present and
+otherwise on ALBUMARTIST (or ARTIST) plus ALBUM. Handles discs in
+subdirectories and a tree of mixed depth in one pass, which is what
+foobar2000's "Scan as albums (by tags)", beets and Picard all do. Files
+carrying no ALBUM tag fall back to directory grouping and are reported
+rather than pooled together. When two releases share one artist and album
+string, a repeated track number inside the group is reported with the
+directories involved.
+.RE
+.IP
+An album that fails analysis is reported and the run continues with the next
+one. In JSON output the results appear in an
 .B albums
-array. Directories are analyzed concurrently, so the worker threads stay
-busy across folder boundaries; results, text output and exit status are
-still ordered by path, exactly as under
+array, each entry carrying either
+.B directory
+or
+.BR album_artist / album_title
+depending on how the group was formed. Albums are analyzed concurrently, so
+the worker threads stay busy across album boundaries; results, text output
+and exit status are still deterministically ordered, exactly as under
 .BR "\-j 1" .
 .TP
 .B \-\-rg2

--- a/src/albummeta.rs
+++ b/src/albummeta.rs
@@ -1,0 +1,130 @@
+//! Album identity tags, used by `-a --album-by=tag` to decide which files
+//! belong to the same release (issue #333).
+//!
+//! One symphonia metadata probe covers every input format mp3rgain accepts:
+//! ID3v2 in MP3 and in raw ADTS, and the `ilst` atoms in M4A/MP4. Hand-rolling
+//! a reader per container, the way [`crate::id3v2`] and [`crate::mp4meta`] do
+//! for the ReplayGain tags, would mean three parsers that have to agree.
+
+use std::path::Path;
+
+/// The tags that decide which album a file belongs to.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AlbumTags {
+    pub album: Option<String>,
+    pub album_artist: Option<String>,
+    pub artist: Option<String>,
+    /// `MUSICBRAINZ_ALBUMID`, written by Picard and beets. The only field that
+    /// separates two releases carrying the same artist and album string
+    /// without guessing at how the user chose to tell them apart.
+    pub musicbrainz_album_id: Option<String>,
+    pub disc: Option<u64>,
+    pub track: Option<u64>,
+}
+
+impl AlbumTags {
+    /// The artist half of the grouping key: ALBUMARTIST, falling back to
+    /// ARTIST. Without it, two unrelated "Greatest Hits" become one album.
+    pub fn effective_artist(&self) -> Option<&str> {
+        self.album_artist.as_deref().or(self.artist.as_deref())
+    }
+
+    /// Whether this file can be grouped by release at all.
+    pub fn has_album(&self) -> bool {
+        self.album.is_some()
+    }
+}
+
+/// Read the album identity tags from `path`, or `None` when the file cannot be
+/// probed. A file that probes but carries no tags returns an empty
+/// [`AlbumTags`], which is a different thing from a file that cannot be read.
+#[cfg(feature = "replaygain")]
+pub fn read_album_tags(path: &Path) -> Option<AlbumTags> {
+    use symphonia::core::formats::probe::Hint;
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::{MetadataOptions, StandardTag};
+
+    let file = std::fs::File::open(path).ok()?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    let mut format = symphonia::default::get_probe()
+        .probe(&hint, mss, Default::default(), MetadataOptions::default())
+        .ok()?;
+
+    // Every revision is merged, not just the latest: a file routinely carries
+    // more than one (ID3v2 at the front plus ID3v1 at the end, or a second
+    // ID3v2 tag prepended by a tool), and `skip_to_latest` would throw the
+    // richer front tag away. The first revision to define a field wins, so the
+    // modern tag beats a truncated legacy one that happens to come after it.
+    let mut tags = AlbumTags::default();
+    let mut metadata = format.metadata();
+    loop {
+        if let Some(revision) = metadata.current() {
+            for tag in &revision.media.tags {
+                match &tag.std {
+                    Some(StandardTag::Album(v)) => fill(&mut tags.album, v),
+                    Some(StandardTag::AlbumArtist(v)) => fill(&mut tags.album_artist, v),
+                    Some(StandardTag::Artist(v)) => fill(&mut tags.artist, v),
+                    Some(StandardTag::MusicBrainzAlbumId(v)) => {
+                        fill(&mut tags.musicbrainz_album_id, v)
+                    }
+                    Some(StandardTag::DiscNumber(n)) => tags.disc = tags.disc.or(Some(*n)),
+                    Some(StandardTag::TrackNumber(n)) => tags.track = tags.track.or(Some(*n)),
+                    _ => {}
+                }
+            }
+        }
+        // `pop` always keeps the last revision, so this is what ends the walk.
+        if metadata.pop().is_none() {
+            break;
+        }
+    }
+    Some(tags)
+}
+
+/// Set `slot` from `value` unless it is already set, or the value is blank.
+/// Tag values are routinely present but empty, and a blank ALBUM must not
+/// become a grouping key of its own: every untagged file in a library would
+/// land in one album together.
+#[cfg(feature = "replaygain")]
+fn fill(slot: &mut Option<String>, value: &str) {
+    if slot.is_some() {
+        return;
+    }
+    let trimmed = value.trim();
+    if !trimmed.is_empty() {
+        *slot = Some(trimmed.to_string());
+    }
+}
+
+#[cfg(not(feature = "replaygain"))]
+pub fn read_album_tags(_path: &Path) -> Option<AlbumTags> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn album_artist_wins_over_artist() {
+        let tags = AlbumTags {
+            album_artist: Some("Various Artists".into()),
+            artist: Some("Pink Floyd".into()),
+            ..Default::default()
+        };
+        assert_eq!(tags.effective_artist(), Some("Various Artists"));
+    }
+
+    #[test]
+    fn artist_is_the_fallback() {
+        let tags = AlbumTags {
+            artist: Some("Pink Floyd".into()),
+            ..Default::default()
+        };
+        assert_eq!(tags.effective_artist(), Some("Pink Floyd"));
+    }
+}

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -19,6 +19,22 @@ pub enum StoredTagMode {
     Skip,   // -s s: Skip (don't write) stored tag info
 }
 
+/// `--album-by`: what counts as one album under `-a` (issues #324, #331, #333).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AlbumGrouping {
+    /// `-a` alone: every file given is pooled into one album, which is what
+    /// mp3gain's `-a` does. Unchanged.
+    #[default]
+    Pooled,
+    /// `--album-by=dir` (and its alias `--per-directory`): one album per
+    /// parent directory. Works on untagged libraries, and splits a release
+    /// whose discs live in subdirectories.
+    Dir,
+    /// `--album-by=tag`: one album per release, taken from the tags, so discs
+    /// in subdirectories and trees of mixed depth both come out right.
+    Tag,
+}
+
 #[derive(Default)]
 pub struct Options {
     // Gain options
@@ -51,8 +67,9 @@ pub struct Options {
     // rsgain workflow. Requires -r / -a / -e.
     pub tags_only: bool,
     pub skip_album: bool, // -e: skip album analysis
-    // --per-directory: with -a, one album per parent directory (issue #324).
-    pub per_directory: bool,
+    // --album-by: with -a, what counts as one album (issues #324, #333).
+    // `--per-directory` is the alias for `--album-by=dir`.
+    pub album_by: AlbumGrouping,
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files
 

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -4,8 +4,19 @@ use mp3rgain::replaygain::AnalysisMode;
 use mp3rgain::{Channel, TagLayout};
 use std::path::PathBuf;
 
-use super::options::{Options, OutputFormat, StoredTagMode};
+use super::options::{AlbumGrouping, Options, OutputFormat, StoredTagMode};
 use super::usage::{print_usage, print_version};
+
+/// `--album-by=<mode>`. Rejected rather than defaulted: a typo here silently
+/// changes which files share an album gain, which is not something the user
+/// would notice until the tags are already written.
+fn parse_album_grouping(mode: &str) -> Result<AlbumGrouping> {
+    match mode {
+        "dir" | "directory" => Ok(AlbumGrouping::Dir),
+        "tag" | "tags" => Ok(AlbumGrouping::Tag),
+        other => anyhow::bail!("unknown --album-by mode '{}' (expected dir or tag)", other),
+    }
+}
 
 fn parse_thread_count(value: &str, flag: &str) -> Result<usize> {
     value
@@ -33,8 +44,23 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         }
 
         if arg == "--per-directory" {
-            opts.per_directory = true;
+            opts.album_by = AlbumGrouping::Dir;
             i += 1;
+            continue;
+        }
+
+        if let Some(mode) = arg.strip_prefix("--album-by=") {
+            opts.album_by = parse_album_grouping(mode)?;
+            i += 1;
+            continue;
+        }
+
+        if arg == "--album-by" {
+            let mode = args
+                .get(i + 1)
+                .ok_or_else(|| anyhow::anyhow!("--album-by requires a mode (dir or tag)"))?;
+            opts.album_by = parse_album_grouping(mode)?;
+            i += 2;
             continue;
         }
 
@@ -312,9 +338,9 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         anyhow::bail!("--true-peak requires --rg2 or --r128");
     }
 
-    // --per-directory only changes how -a groups files (issue #324).
-    if opts.per_directory && !(opts.album_gain && !opts.skip_album) {
-        anyhow::bail!("--per-directory requires -a");
+    // --album-by / --per-directory only change how -a groups files (#324, #333).
+    if opts.album_by != AlbumGrouping::Pooled && !(opts.album_gain && !opts.skip_album) {
+        anyhow::bail!("--per-directory / --album-by requires -a");
     }
 
     // --tags-only (issue #308) writes ReplayGain metadata and nothing else, so

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -28,8 +28,12 @@ pub fn print_usage() {
     println!("    -m <i>      Modify suggested gain by integer i");
     println!("    -r          Apply Track gain (ReplayGain analysis)");
     println!("    -a          Apply Album gain (ReplayGain analysis)");
-    println!("    --per-directory  With -a: one album per directory, so a whole library");
-    println!("                     can be album-tagged in one run (pairs with -R)");
+    println!("    --album-by <how>  With -a: what counts as one album, so a whole library");
+    println!("                      can be album-tagged in one run (pairs with -R)");
+    println!("                        dir  one album per directory");
+    println!("                        tag  one album per release, from ALBUM/ALBUMARTIST,");
+    println!("                             so discs in subfolders share one album gain");
+    println!("    --per-directory   Alias for --album-by=dir");
     println!("    --rg2       ReplayGain 2.0 analysis (BS.1770, -18 LUFS reference)");
     println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
     println!("    --true-peak Measure true peak (BS.1770-4 Annex 2) for REPLAYGAIN_*_PEAK");
@@ -92,7 +96,7 @@ pub fn print_usage() {
     println!("    mp3rgain -w -g 10 song.mp3     Apply gain with wrapping");
     println!("    mp3rgain -t -g 2 song.mp3      Apply gain using temp file");
     println!("    mp3rgain -R /path/to/music     Process directory recursively");
-    println!("    mp3rgain -a --per-directory -R /music  One album per folder");
+    println!("    mp3rgain -a --album-by=tag -R /music   One album per release");
     println!("    mp3rgain -Rpa --skip-errors /music  Album-scan a library, skipping");
     println!("                                        files that fail to decode");
     println!("    mp3rgain -n -g 2 *.mp3         Dry-run (preview changes)");

--- a/src/commands/albumgroup.rs
+++ b/src/commands/albumgroup.rs
@@ -1,0 +1,228 @@
+//! What counts as one album under `-a` (issues #324, #333).
+//!
+//! `-a` alone pools every file, which is mp3gain's rule. `--album-by` splits
+//! the run instead: `dir` by parent directory, `tag` by release taken from the
+//! metadata.
+
+use colored::*;
+use mp3rgain::{read_album_tags, AlbumTags};
+use rayon::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use crate::cli::options::AlbumGrouping;
+
+/// How a set of files was identified as one album.
+pub enum AlbumId {
+    /// By parent directory: `--album-by=dir`, and the fallback in `tag` mode
+    /// for files that carry no ALBUM tag.
+    Directory(PathBuf),
+    /// By release, from the tags.
+    Release {
+        artist: Option<String>,
+        album: String,
+    },
+}
+
+impl AlbumId {
+    /// The heading printed above the album in text output.
+    pub fn heading(&self) -> String {
+        match self {
+            Self::Directory(dir) => dir.display().to_string(),
+            Self::Release {
+                artist: Some(artist),
+                album,
+            } => format!("{} / {}", artist, album),
+            Self::Release {
+                artist: None,
+                album,
+            } => album.clone(),
+        }
+    }
+}
+
+pub struct AlbumGroup {
+    pub id: AlbumId,
+    pub files: Vec<PathBuf>,
+}
+
+/// Split `files` into albums. Returns the groups in a deterministic order
+/// alongside the warnings the caller must surface: a grouping that silently
+/// merges two releases, or silently drops files into a fallback, is the one
+/// outcome that must not happen.
+pub fn group_files(files: &[PathBuf], mode: AlbumGrouping) -> (Vec<AlbumGroup>, Vec<String>) {
+    match mode {
+        AlbumGrouping::Tag => group_by_tags(files),
+        // Pooled never reaches here; the caller dispatches it to `cmd_album_gain`.
+        _ => (group_by_parent(files), Vec::new()),
+    }
+}
+
+/// Group by immediate parent directory, as given on the command line. Bare
+/// file names land in `.`. Directories come out in path order.
+fn group_by_parent(files: &[PathBuf]) -> Vec<AlbumGroup> {
+    let mut groups: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+    for file in files {
+        groups
+            .entry(parent_of(file))
+            .or_default()
+            .push(file.clone());
+    }
+    groups
+        .into_iter()
+        .map(|(dir, files)| AlbumGroup {
+            id: AlbumId::Directory(dir),
+            files,
+        })
+        .collect()
+}
+
+fn parent_of(file: &Path) -> PathBuf {
+    file.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."))
+        .to_path_buf()
+}
+
+/// The grouping key in `tag` mode.
+#[derive(PartialEq, Eq, Hash, Clone)]
+enum TagKey {
+    /// MUSICBRAINZ_ALBUMID, preferred whenever it is present: it is the one
+    /// field that separates two releases of the same album without guessing
+    /// at how the user chose to tell them apart.
+    MusicBrainz(String),
+    /// (album artist or artist, album).
+    Release(String, String),
+    /// No ALBUM tag: this file falls back to its directory.
+    Directory(PathBuf),
+}
+
+/// Group by release. Files with no ALBUM tag fall back to their directory
+/// rather than pooling together, since pooling every untagged file in a
+/// library into one album is silently wrong.
+fn group_by_tags(files: &[PathBuf]) -> (Vec<AlbumGroup>, Vec<String>) {
+    let tags: Vec<Option<AlbumTags>> = files.par_iter().map(|f| read_album_tags(f)).collect();
+
+    // First-seen key order. `files` arrives sorted, so groups come out ordered
+    // by their first file's path, which is stable across runs and matches how
+    // `dir` mode orders its output.
+    let mut order: Vec<TagKey> = Vec::new();
+    let mut members: HashMap<TagKey, Vec<usize>> = HashMap::new();
+    let mut untagged = 0usize;
+
+    for (i, file_tags) in tags.iter().enumerate() {
+        let key = match file_tags {
+            Some(t) if t.has_album() => match &t.musicbrainz_album_id {
+                Some(id) => TagKey::MusicBrainz(id.clone()),
+                None => TagKey::Release(
+                    t.effective_artist().unwrap_or_default().to_string(),
+                    t.album.clone().unwrap_or_default(),
+                ),
+            },
+            _ => {
+                untagged += 1;
+                TagKey::Directory(parent_of(&files[i]))
+            }
+        };
+        let slot = members.entry(key.clone()).or_default();
+        if slot.is_empty() {
+            order.push(key);
+        }
+        slot.push(i);
+    }
+
+    let mut warnings = Vec::new();
+    if untagged > 0 {
+        warnings.push(format!(
+            "  {} {} file(s) carry no ALBUM tag and were grouped by directory instead",
+            "!".yellow(),
+            untagged
+        ));
+    }
+
+    let mut groups = Vec::with_capacity(order.len());
+    for key in order {
+        let indices = members.remove(&key).unwrap_or_default();
+        let id = match &key {
+            TagKey::Directory(dir) => AlbumId::Directory(dir.clone()),
+            _ => {
+                let first = tags[indices[0]].as_ref();
+                AlbumId::Release {
+                    artist: first
+                        .and_then(|t| t.effective_artist())
+                        .map(|s| s.to_string()),
+                    album: first
+                        .and_then(|t| t.album.clone())
+                        .unwrap_or_else(|| "(unknown album)".to_string()),
+                }
+            }
+        };
+        if let Some(warning) = collision_warning(&id, &indices, &tags, files) {
+            warnings.push(warning);
+        }
+        groups.push(AlbumGroup {
+            files: indices.iter().map(|&i| files[i].clone()).collect(),
+            id,
+        });
+    }
+
+    (groups, warnings)
+}
+
+/// Detect two releases that collapsed into one group because they share an
+/// artist and album string.
+///
+/// skamp raised this on #333 with five releases of "The Dark Side of the Moon":
+/// the ways users tell releases apart (version, release date, a suffix in the
+/// directory name) are too varied to enumerate, and guessing at them is, in
+/// their words, dodgy. So nothing is guessed here. A repeated (disc, track)
+/// pair inside one group is structural proof that more than one release is in
+/// it, whatever convention the user was following.
+fn collision_warning(
+    id: &AlbumId,
+    indices: &[usize],
+    tags: &[Option<AlbumTags>],
+    files: &[PathBuf],
+) -> Option<String> {
+    if matches!(id, AlbumId::Directory(_)) {
+        return None;
+    }
+
+    let mut seen: HashMap<(Option<u64>, u64), usize> = HashMap::new();
+    for &i in indices {
+        let Some(t) = tags[i].as_ref() else { continue };
+        let Some(track) = t.track else { continue };
+        *seen.entry((t.disc, track)).or_insert(0) += 1;
+    }
+    let (&(disc, track), &copies) = seen.iter().max_by_key(|(_, &n)| n)?;
+    if copies < 2 {
+        return None;
+    }
+
+    let mut dirs: Vec<String> = indices
+        .iter()
+        .map(|&i| parent_of(&files[i]).display().to_string())
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+
+    let position = match disc {
+        Some(d) => format!("disc {} track {}", d, track),
+        None => format!("track {}", track),
+    };
+    let mut warning = format!(
+        "  {} {}: {} appears {} times, so this is probably {} releases sharing one album and artist string\n",
+        "!".yellow(),
+        id.heading(),
+        position,
+        copies,
+        copies
+    );
+    for dir in &dirs {
+        warning.push_str(&format!("      {}\n", dir));
+    }
+    warning.push_str(
+        "      use --album-by=dir to keep them apart, or tag each release with its own MUSICBRAINZ_ALBUMID",
+    );
+    Some(warning)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod albumgroup;
 pub mod apply;
 pub mod info;
 pub mod max_amplitude;
@@ -10,13 +11,13 @@ pub mod utils;
 use anyhow::Result;
 use colored::*;
 
-use crate::cli::options::{Options, OutputFormat, StoredTagMode};
+use crate::cli::options::{AlbumGrouping, Options, OutputFormat, StoredTagMode};
 use crate::cli::parse_args::expand_files_recursive;
 
 use apply::{cmd_apply, cmd_apply_channel};
 use info::cmd_info;
 use max_amplitude::cmd_max_amplitude;
-use replaygain::{cmd_album_gain, cmd_album_gain_per_directory, cmd_track_gain};
+use replaygain::{cmd_album_gain, cmd_album_gain_grouped, cmd_track_gain};
 use tags::{cmd_check_tags, cmd_delete_tags};
 use undo::cmd_undo;
 
@@ -99,9 +100,10 @@ pub fn run(mut opts: Options) -> Result<()> {
     }
 
     if opts.album_gain && !opts.skip_album {
-        // -a: apply album gain (ReplayGain), per directory with --per-directory
-        if opts.per_directory {
-            return cmd_album_gain_per_directory(&opts.files, &opts);
+        // -a: apply album gain (ReplayGain). --album-by splits the run into
+        // one album per directory or per release instead of pooling.
+        if opts.album_by != AlbumGrouping::Pooled {
+            return cmd_album_gain_grouped(&opts.files, &opts);
         }
         return cmd_album_gain(&opts.files, &opts);
     }

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -12,7 +12,8 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use crate::cli::options::{Options, OutputFormat, StoredTagMode};
+use crate::cli::options::{AlbumGrouping, Options, OutputFormat, StoredTagMode};
+use crate::commands::albumgroup::{group_files, AlbumGroup, AlbumId};
 use crate::commands::threading::effective_threads;
 use crate::commands::utils::{
     create_json_summary, exit_if_failed, finish_with_album_summary, finish_with_summary,
@@ -278,13 +279,17 @@ impl AlbumBars {
 }
 
 /// TSV header plus the text-mode banner shared by both album commands.
-fn print_album_intro(file_count: usize, directories: Option<usize>, opts: &Options) {
+fn print_album_intro(file_count: usize, groups: Option<usize>, opts: &Options) {
     if opts.output_format == OutputFormat::Tsv {
         println!("{}", TSV_HEADER);
     }
     if opts.output_format == OutputFormat::Text && !opts.quiet {
-        let scope = match directories {
-            Some(n) => format!(" in {} directory(ies)", n),
+        let unit = match opts.album_by {
+            AlbumGrouping::Tag => "album(s)",
+            _ => "directory(ies)",
+        };
+        let scope = match groups {
+            Some(n) => format!(" in {} {}", n, unit),
             None => String::new(),
         };
         println!(
@@ -318,10 +323,10 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
     )
 }
 
-/// `-a --per-directory`: one album per parent directory (issue #324), the
-/// grouping the GUI has used since #159. A directory that fails analysis is
-/// counted and the run moves on, so a whole library can be tagged in a single
-/// invocation.
+/// `-a --album-by=...`: several albums in one invocation, one per directory
+/// (issue #324) or one per release read from the tags (issue #333). An album
+/// that fails analysis is counted and the run moves on, so a whole library can
+/// be tagged in a single invocation.
 ///
 /// Albums are analyzed concurrently on the shared rayon pool (issue #332).
 /// The per-file parallelism inside an album stays exactly as it was, so
@@ -334,19 +339,29 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 /// Everything the caller can observe stays in group order: results are
 /// collected by index, text output is buffered per album and flushed in
 /// order, and the counters are summed afterwards rather than by the workers.
-pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result<()> {
+pub fn cmd_album_gain_grouped(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
-    let groups = group_by_parent(files);
+    let (groups, warnings) = group_files(files, opts.album_by);
     print_album_intro(files.len(), Some(groups.len()), opts);
+    // Printed before any analysis starts: a grouping that merged two releases
+    // has to be visible while the run can still be cancelled, not buried under
+    // the per-album output (issue #333).
+    if !opts.quiet {
+        for warning in &warnings {
+            eprintln!("{}", warning);
+        }
+        if !warnings.is_empty() {
+            eprintln!();
+        }
+    }
 
     // One album, or -j 1, has nothing to overlap: keep the direct-to-stdout
     // path and the per-album bars rather than buffering for no reason.
     let concurrent = groups.len() > 1 && effective_threads(opts) > 1;
     let bars = concurrent.then(|| AlbumBars::new(files.len(), opts));
     let flush = OrderedFlush::default();
-    let entries: Vec<(&PathBuf, &Vec<PathBuf>)> = groups.iter().collect();
 
-    let run_group = |i: usize, dir: &Path, group: &[PathBuf]| -> Result<AlbumRun> {
+    let run_group = |i: usize, group: &AlbumGroup| -> Result<AlbumRun> {
         let mut sink = if concurrent {
             AlbumSink::buffered()
         } else {
@@ -359,26 +374,26 @@ pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result
             writeln!(
                 sink.out(),
                 "{} ({} file(s))",
-                dir.display().to_string().bold(),
-                group.len()
+                group.id.heading().bold(),
+                group.files.len()
             )?;
         }
-        let run = run_album(group, opts, &mut sink, bars.as_ref())?;
+        let run = run_album(&group.files, opts, &mut sink, bars.as_ref())?;
         flush.submit(i, sink)?;
         Ok(run)
     };
 
     let runs: Vec<AlbumRun> = if concurrent {
-        entries
+        groups
             .par_iter()
             .enumerate()
-            .map(|(i, &(dir, group))| run_group(i, dir, group))
+            .map(|(i, group)| run_group(i, group))
             .collect::<Result<Vec<_>>>()?
     } else {
-        entries
+        groups
             .iter()
             .enumerate()
-            .map(|(i, &(dir, group))| run_group(i, dir, group))
+            .map(|(i, group)| run_group(i, group))
             .collect::<Result<Vec<_>>>()?
     };
     if let Some(bars) = bars {
@@ -388,11 +403,17 @@ pub fn cmd_album_gain_per_directory(files: &[PathBuf], opts: &Options) -> Result
     let mut json_results = Vec::with_capacity(files.len());
     let mut albums = Vec::with_capacity(groups.len());
     let (mut successful, mut failed) = (0, 0);
-    for ((dir, group), run) in entries.iter().zip(runs) {
+    for (group, run) in groups.iter().zip(runs) {
         if let Some(album) = run.album {
+            let (directory, album_artist, album_title) = match &group.id {
+                AlbumId::Directory(dir) => (Some(dir.display().to_string()), None, None),
+                AlbumId::Release { artist, album } => (None, artist.clone(), Some(album.clone())),
+            };
             albums.push(JsonDirectoryAlbum {
-                directory: dir.display().to_string(),
-                files: group.len(),
+                directory,
+                album_artist,
+                album_title,
+                files: group.files.len(),
                 album,
             });
         }
@@ -427,23 +448,6 @@ fn advance(pb: Option<&ProgressBar>, files: usize) {
     if let Some(pb) = pb {
         pb.inc(files as u64);
     }
-}
-
-/// Group files by their immediate parent directory, as given on the command
-/// line. Bare file names land in `.`.
-fn group_by_parent(files: &[PathBuf]) -> BTreeMap<PathBuf, Vec<PathBuf>> {
-    let mut groups: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
-    for file in files {
-        let dir = file
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .unwrap_or(Path::new("."));
-        groups
-            .entry(dir.to_path_buf())
-            .or_default()
-            .push(file.clone());
-    }
-    groups
 }
 
 /// Analyze and apply album gain to `files` as one album, returning what the

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -19,7 +19,7 @@ pub struct JsonOutput {
     pub files: Option<Vec<JsonFileResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub album: Option<JsonAlbumResult>,
-    /// `-a --per-directory`: one entry per directory (issue #324).
+    /// `-a --album-by=...`: one entry per album (issues #324, #333).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub albums: Option<Vec<JsonDirectoryAlbum>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,7 +28,16 @@ pub struct JsonOutput {
 
 #[derive(Serialize)]
 pub struct JsonDirectoryAlbum {
-    pub directory: String,
+    /// `--album-by=dir`: the directory. Also set in `tag` mode for a group of
+    /// files that carried no ALBUM tag and fell back to directory grouping,
+    /// which is what tells the two apart in the output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+    /// `--album-by=tag`: the release the group was formed from (issue #333).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album_artist: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album_title: Option<String>,
     pub files: usize,
     #[serde(flatten)]
     pub album: JsonAlbumResult,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ mod aac_codebooks;
 #[cfg(feature = "aac")]
 pub mod adts;
 
+pub mod albummeta;
 pub mod analysis;
 pub mod ape;
 pub mod apply;
@@ -79,6 +80,7 @@ pub mod id3v2;
 pub mod mp4meta;
 pub mod replaygain;
 
+pub use albummeta::{read_album_tags, AlbumTags};
 pub use analysis::{
     analyze, analyze_data, find_max_amplitude, gain_range, is_mono, ChannelMode,
     MaxAmplitudeResult, Mp3Analysis, MpegVersion,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -732,9 +732,245 @@ fn per_directory_output_is_identical_whatever_the_thread_count() {
 
 #[test]
 fn per_directory_requires_album_mode() {
-    let out = run(&["--per-directory", "-r", "tests/fixtures/test_mono.mp3"]);
+    for flag in ["--per-directory", "--album-by=tag"] {
+        let out = run(&[flag, "-r", "tests/fixtures/test_mono.mp3"]);
+        assert!(!out.status.success(), "{flag}");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("requires -a"),
+            "{flag}"
+        );
+    }
+    let out = run(&[
+        "-a",
+        "--album-by=bogus",
+        "-n",
+        "tests/fixtures/test_mono.mp3",
+    ]);
     assert!(!out.status.success());
-    assert!(String::from_utf8_lossy(&out.stderr).contains("--per-directory requires -a"));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("unknown --album-by mode"));
+}
+
+/// Write `fixture` into `dst` behind a minimal ID3v2.3 tag. Tagging through an
+/// external tool would make these tests depend on ffmpeg being installed on
+/// every CI runner, and the frames needed here are four text frames.
+fn write_tagged_mp3(fixture: &str, dst: &Path, frames: &[(&str, &str)]) {
+    let audio = fs::read(Path::new("tests/fixtures").join(fixture)).expect("fixture");
+    let mut body = Vec::new();
+    for (id, text) in frames {
+        // Text frame payload: encoding byte, then the text. TXXX carries
+        // "description\0value" in that same payload.
+        let mut payload = vec![0u8]; // ISO-8859-1
+        payload.extend_from_slice(text.as_bytes());
+        body.extend_from_slice(id.as_bytes());
+        body.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        body.extend_from_slice(&[0, 0]);
+        body.extend_from_slice(&payload);
+    }
+    let size = body.len() as u32;
+    let mut out = Vec::from(*b"ID3\x03\x00\x00");
+    // The header length is synchsafe: 7 bits per byte.
+    out.extend_from_slice(&[
+        ((size >> 21) & 0x7f) as u8,
+        ((size >> 14) & 0x7f) as u8,
+        ((size >> 7) & 0x7f) as u8,
+        (size & 0x7f) as u8,
+    ]);
+    out.extend_from_slice(&body);
+    out.extend_from_slice(&audio);
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::write(dst, out).expect("write tagged mp3");
+}
+
+fn albums_of(out: &Output) -> Vec<serde_json::Value> {
+    json_of(out)["albums"].as_array().expect("albums").clone()
+}
+
+/// The bug in #331: a release whose discs live in subdirectories gets one
+/// album gain per disc under `dir` grouping, which is wrong for both
+/// compatibility targets. `tag` grouping is the fix, and the value it produces
+/// has to be the one the whole release would get pooled into a single album.
+#[test]
+fn album_by_tag_keeps_a_multi_disc_release_as_one_album() {
+    let root = TempAlbum::new(&[]);
+    let common = [("TALB", "The Wall"), ("TPE2", "Pink Floyd")];
+    for (disc, track, fixture) in [
+        (1, 1, "test_mono.mp3"),
+        (1, 2, "test_vbr.mp3"),
+        (2, 1, "test_stereo.mp3"),
+        (2, 2, "test_joint_stereo.mp3"),
+    ] {
+        let mut frames = common.to_vec();
+        let (disc_s, track_s) = (disc.to_string(), track.to_string());
+        frames.push(("TPOS", &disc_s));
+        frames.push(("TRCK", &track_s));
+        let dst = root.dir.join(format!("disc{disc}")).join(fixture);
+        write_tagged_mp3(fixture, &dst, &frames);
+    }
+    let root_arg = root.dir.to_str().unwrap();
+
+    let by_tag = albums_of(&run(&[
+        "-a",
+        "--album-by=tag",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root_arg,
+    ]));
+    assert_eq!(by_tag.len(), 1, "both discs are one release");
+    assert_eq!(by_tag[0]["album_title"], "The Wall");
+    assert_eq!(by_tag[0]["album_artist"], "Pink Floyd");
+    assert_eq!(by_tag[0]["files"], 4);
+    assert!(
+        by_tag[0]["directory"].is_null(),
+        "tag groups are not directories"
+    );
+
+    // The value must match pooling the same files with plain -a.
+    let pooled = json_of(&run(&["-a", "-n", "-R", "-o", "json", root_arg]));
+    assert_eq!(by_tag[0]["gain_db"], pooled["album"]["gain_db"]);
+
+    // dir grouping still splits them, which is the behavior #331 reported.
+    let by_dir = albums_of(&run(&[
+        "-a",
+        "--album-by=dir",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root_arg,
+    ]));
+    assert_eq!(by_dir.len(), 2);
+    assert_ne!(by_dir[0]["gain_db"], by_dir[1]["gain_db"]);
+}
+
+/// gcocatre on #333: several releases of one album share the artist and album
+/// string, and the ways users tell them apart are too varied to enumerate. So
+/// nothing is guessed. A repeated (disc, track) inside one group is structural
+/// proof that more than one release is in it, and that is what gets reported.
+#[test]
+fn album_by_tag_reports_two_releases_sharing_one_album_string() {
+    let root = TempAlbum::new(&[]);
+    for (edition, fixture) in [("1973", "test_mono.mp3"), ("2011", "test_stereo.mp3")] {
+        write_tagged_mp3(
+            fixture,
+            &root.dir.join(edition).join("01.mp3"),
+            &[
+                ("TALB", "The Dark Side of the Moon"),
+                ("TPE2", "Pink Floyd"),
+                ("TRCK", "1"),
+            ],
+        );
+    }
+    let out = run(&[
+        "-a",
+        "--album-by=tag",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root.dir.to_str().unwrap(),
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(albums_of(&out).len(), 1, "they do group together");
+    assert!(
+        stderr.contains("track 1 appears 2 times"),
+        "the collision has to be reported: {stderr}"
+    );
+    assert!(
+        stderr.contains("1973") && stderr.contains("2011"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("--album-by=dir"), "{stderr}");
+}
+
+/// The same two releases, tagged the way Picard tags them, must come apart
+/// without any warning: MUSICBRAINZ_ALBUMID is the one field that separates
+/// them without guessing.
+#[test]
+fn album_by_tag_separates_releases_by_musicbrainz_album_id() {
+    let root = TempAlbum::new(&[]);
+    for (edition, fixture) in [("1973", "test_mono.mp3"), ("2011", "test_stereo.mp3")] {
+        write_tagged_mp3(
+            fixture,
+            &root.dir.join(edition).join("01.mp3"),
+            &[
+                ("TALB", "The Dark Side of the Moon"),
+                ("TPE2", "Pink Floyd"),
+                ("TRCK", "1"),
+                (
+                    "TXXX",
+                    &format!("MusicBrainz Album Id\u{0}release-{edition}"),
+                ),
+            ],
+        );
+    }
+    let out = run(&[
+        "-a",
+        "--album-by=tag",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root.dir.to_str().unwrap(),
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(albums_of(&out).len(), 2, "two releases, two album gains");
+    assert!(
+        !stderr.contains("appears"),
+        "no collision to report: {stderr}"
+    );
+}
+
+/// Pooling every untagged file in a library into one album is the one outcome
+/// that must not happen silently.
+#[test]
+fn album_by_tag_falls_back_to_directory_without_an_album_tag() {
+    let root = TempAlbum::new(&[]);
+    for (dir, fixture) in [("a", "test_mono.mp3"), ("b", "test_stereo.mp3")] {
+        let dst = root.dir.join(dir).join(fixture);
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        fs::copy(Path::new("tests/fixtures").join(fixture), &dst).unwrap();
+    }
+    let out = run(&[
+        "-a",
+        "--album-by=tag",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root.dir.to_str().unwrap(),
+    ]);
+    let albums = albums_of(&out);
+    assert_eq!(albums.len(), 2, "not pooled into one album");
+    for album in &albums {
+        assert!(
+            album["directory"].is_string(),
+            "reported as a directory group"
+        );
+        assert!(album["album_title"].is_null());
+    }
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no ALBUM tag"),
+        "the fallback has to be reported"
+    );
+}
+
+/// `--per-directory` shipped in 3.6.1 and keeps working unchanged.
+#[test]
+fn per_directory_is_an_alias_for_album_by_dir() {
+    let root = TempAlbum::new(&[]);
+    for (dir, fixture) in [("a", "test_mono.mp3"), ("b", "test_stereo.mp3")] {
+        let dst = root.dir.join(dir).join(fixture);
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        fs::copy(Path::new("tests/fixtures").join(fixture), &dst).unwrap();
+    }
+    let root_arg = root.dir.to_str().unwrap();
+    for format in ["json", "text", "tsv"] {
+        let alias = run(&["-a", "--per-directory", "-n", "-R", "-o", format, root_arg]);
+        let explicit = run(&["-a", "--album-by=dir", "-n", "-R", "-o", format, root_arg]);
+        assert_eq!(stdout_of(&alias), stdout_of(&explicit), "-o {format}");
+    }
 }
 
 /// Reported on the Hydrogenaudio forum: `-o tsv` only produced rows for the


### PR DESCRIPTION
Implements #333: `--album-by=tag`, one album per release instead of per directory.

It needs the `--album-by` selector that #331 specified, so that flag comes with it, with `--per-directory` kept as the alias for `--album-by=dir`. `--album-by=arg` and `--album-depth` are **not** here, so #331 stays open for them.

## What changes

| Invocation | Album unit |
|---|---|
| `-a` | every file given, pooled (unchanged, mp3gain-compatible) |
| `-a --album-by=dir` | one album per leaf directory (`--per-directory` is the alias, unchanged) |
| `-a --album-by=tag` | one album per release, from the tags |

`tag` mode keys on `MUSICBRAINZ_ALBUMID` when present, otherwise on `ALBUMARTIST` (falling back to `ARTIST`) plus `ALBUM`. It fixes the multi-disc case #331 reported, since two discs of one release share an ALBUM tag no matter which directories they sit in.

## Reading the tags

One symphonia metadata probe per file covers every input format: ID3v2 in MP3, ID3v2 in raw ADTS, and the `ilst` atoms in M4A. That is one reader rather than the three that `id3v2.rs` and `mp4meta.rs` would have needed to keep in agreement.

One thing worth flagging, because it bit the first version and would have bitten real files: `Metadata::skip_to_latest()` discards every earlier revision. A file that carries ID3v2 at the front and ID3v1 at the end, or that has had a second ID3v2 tag prepended by a tool, therefore loses its richest tag. The reader now walks every revision, first definition winning, so the modern front tag beats a truncated legacy one behind it.

## @gcocatre's point, and what it changed

> I have about 4 or 5 different releases of Pink Floyd's "The Dark Side of the Moon". Same artist, same album. But there are different ways of telling them apart: "version", "release date", etc. It gets complicated as you'd have to imagine all the ways a user could have been differentiating each release. As I said in the HA thread, "it can be dodgy".

Agreed, and nothing is guessed here. No `version` heuristic, no parsing of a year out of a directory name, no sniffing of release dates. Two mechanisms instead:

**`MUSICBRAINZ_ALBUMID` is preferred over artist + album whenever it is present.** It is the one field that exists precisely to separate two releases of the same album, and it is what a Picard-tagged library already has. The issue body listed it as an open question; this is the argument for taking it.

**When it is absent, the collision is detected rather than guessed at.** A repeated `(disc, track)` pair inside one group is structural proof that more than one release is in it, whatever convention the user happened to follow. It is reported before any analysis starts, with the directories involved and the two ways out:

```
  ! Pink Floyd / The Dark Side of the Moon: track 1 appears 2 times, so this is probably 2 releases sharing one album and artist string
      ./dsotm/1973
      ./dsotm/2011
      use --album-by=dir to keep them apart, or tag each release with its own MUSICBRAINZ_ALBUMID
```

Keying on `(disc, track)` rather than track alone is what keeps a genuine multi-disc release quiet: disc 1 track 1 and disc 2 track 1 are not a collision.

Files with no ALBUM tag fall back to their own directory and are counted in a warning, never pooled together. That was the one outcome the issue said must not happen.

## Verification

Synthesized corpora, tagged with ID3v2 through ffmpeg and, in the tests, through a hand-written ID3v2.3 tag so CI needs no external tagger.

- **Multi-disc release**: `wall/disc1` + `wall/disc2`, one ALBUM tag, distinct disc numbers. `tag` gives one album whose gain equals what plain `-a` gives for the same four files pooled. `dir` still splits them into two different gains, which is the #331 bug reproduced.
- **Two releases, same strings, no MBID**: grouped together, warning fires naming both directories.
- **Same two, distinct `MUSICBRAINZ_ALBUMID`**: two album gains, and no warning.
- **Untagged**: falls back per directory, reported.
- **Regression against the 3.7.0 binary**: `--per-directory` is byte-identical across `-o json`, `-o tsv` and text, at `-j 1` and `-j 8`, and `--album-by=dir` is byte-identical to `--per-directory`. Plain `-a`, `-r` and the info command are untouched.
- `cargo test`: 221 passed, 0 failed, with 5 new tests covering the cases above. `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

## Cost

The probe pass is 0.07 s over 5,000 files warm, roughly 14 µs each. Measured on an untagged corpus, where `tag` mode falls back to the same directory groups as `dir` mode, so the album structure is identical and the difference is only the probe:

| Mode | 5,000 files, median of 3 |
|---|---|
| `--album-by=dir` | 0.63 s |
| `--album-by=tag` | 0.70 s |

The issue estimated ~0.2 ms per file from the `info` timing; a probe is much cheaper than a full frame scan, so it is further into noise than expected. Cold cache is not measured.

## Not in this PR

- `--album-by=arg` and `--album-depth N` (#331).
- The `dir`-mode warning for sibling directories that share an ALBUM tag (#331). The tag reader this PR adds makes it cheap to do, but it would put a probe pass into a mode that currently costs nothing, so it belongs with the rest of #331.
- mp3rgui still has its own folder grouping. Exposing the same modes there is a follow-up, as #333 notes.

Closes #333
