### PR TITLE
cli: add --album-depth, and report a release split across folders (#331)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,18 @@ Binaries for all platforms are on [GitHub Releases](https://github.com/M-Igashi/
 
 ```bash
 mp3rgain -r song.mp3          # Normalize a single track (ReplayGain)
-mp3rgain -a *.mp3             # Normalize an album
+mp3rgain -a *.mp3             # Normalize an album (every file given is one album, as in mp3gain)
 mp3rgain -s R -a -R /music    # Apply from stored tags, rescan only where missing (v3.4+)
 mp3rgain -a --album-by=tag -R /music   # One album per release, whole library in one run (v3.8+)
+mp3rgain -a --album-depth 2 -R /music  # One album per Artist/Album folder, no tags needed (v3.8+)
 mp3rgain -g 2 song.mp3        # Manual gain (+3.0 dB; 1 step = 1.5 dB)
 mp3rgain -u song.mp3          # Undo
 mp3rgain song.mp3             # Show file info
 ```
 
 Run `mp3rgain -h` for all options, or see the **[full CLI reference](https://mp3rgain.tyna.ninja/docs/cli)** (analysis modes, tag handling, exit codes, recipes). Analysis runs in parallel by default; `-j 1` forces the serial path ([design and benchmarks](docs/perf-parallel.md)).
+
+`-a` on its own pools every file you give it into one album, exactly as `mp3gain -a` does, so a per-album script written for mp3gain keeps working unchanged. `--album-by` and `--album-depth` are the mp3rgain extensions that split a single invocation into several albums: use `--album-by=tag` for a tagged library, `--album-depth 2` for an untagged `Artist/Album` tree, and `--album-by=dir` (or its alias `--per-directory`) when one folder really is one album.
 
 ## Migrating from mp3gain?
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -74,6 +74,7 @@ All options from the original mp3gain are fully implemented in mp3rgain:
 | `-R` | Recursive directory processing |
 | `--album-by=dir` | With `-a`: one album per directory, like rsgain's directory-based album detection (`--per-directory` is the alias) |
 | `--album-by=tag` | With `-a`: one album per release from ALBUM/ALBUMARTIST, like foobar2000's "Scan as albums (by tags)", so multi-disc releases share one album gain |
+| `--album-depth <n>` | With `-a -R`: one album per directory n levels below each directory argument, for libraries that are not tagged |
 | `-s R` | Reuse stored ReplayGain tags with `-r`/`-a`, rescanning only when tags are missing (mp3gain's *default* behavior, opt-in here) |
 | `-n` / `--dry-run` | Dry-run mode (preview changes without modifying files) |
 | `-o json` | JSON output format (for scripting and automation) |

--- a/docs/man/mp3rgain.1
+++ b/docs/man/mp3rgain.1
@@ -65,7 +65,15 @@ Each file is normalized individually to the 89 dB reference level.
 .TP
 .B \-a
 Analyze and apply Album gain using the ReplayGain 1.0 algorithm.
-All files are treated as an album and normalized together.
+All files given on the command line are treated as one album and
+normalized together, which is the same rule as
+.BR mp3gain (1)'s
+.BR \-a .
+Use
+.B \-\-album\-by
+or
+.B \-\-album\-depth
+to split one invocation into several albums instead.
 .TP
 .BI \-\-album\-by " how"
 With
@@ -102,6 +110,49 @@ depending on how the group was formed. Albums are analyzed concurrently, so
 the worker threads stay busy across album boundaries; results, text output
 and exit status are still deterministically ordered, exactly as under
 .BR "\-j 1" .
+.IP
+In
+.B dir
+mode, sibling directories that share an ALBUM tag and look like discs of one
+release are reported, since that grouping writes a separate album gain per
+disc. Two different editions of the same album are left alone: they are
+already grouped correctly by directory.
+.TP
+.BI \-\-album\-depth " n"
+With
+.B \-a
+and
+.BR \-R ,
+one album per directory
+.I n
+levels below each directory argument. This is the grouping unit for a library
+that is not tagged: it needs no shell expansion, has no command-line length
+limit, and behaves the same on Windows, where
+.B */*
+is not expanded into arguments at all.
+.B \-\-album\-depth 0
+makes each directory argument one album,
+.B 1
+groups one level below it, and
+.B 2
+suits an
+.I Artist/Album
+tree. A file shallower than
+.I n
+levels groups at the deepest directory it has. Descending deeper than
+.I n
+is what keeps a multi\-disc release together: at
+.B \-\-album\-depth 2
+over
+.IR Artist/Album ,
+.I disc1
+and
+.I disc2
+both group at
+.IR Artist/Album .
+When directory arguments overlap, the deepest one owns the file.
+Mutually exclusive with
+.BR \-\-album\-by .
 .TP
 .B \-\-rg2
 Measure loudness with the ReplayGain 2.0 algorithm (ITU-R BS.1770

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -33,6 +33,11 @@ pub enum AlbumGrouping {
     /// `--album-by=tag`: one album per release, taken from the tags, so discs
     /// in subdirectories and trees of mixed depth both come out right.
     Tag,
+    /// `--album-depth N`: one album per directory N levels below each root
+    /// argument. The grouping unit for a library that is not tagged: it needs
+    /// no shell expansion, has no command-line length ceiling, and behaves the
+    /// same on Windows, where `*/*` is not expanded into argv at all.
+    Depth(usize),
 }
 
 #[derive(Default)]
@@ -67,9 +72,13 @@ pub struct Options {
     // rsgain workflow. Requires -r / -a / -e.
     pub tags_only: bool,
     pub skip_album: bool, // -e: skip album analysis
-    // --album-by: with -a, what counts as one album (issues #324, #333).
-    // `--per-directory` is the alias for `--album-by=dir`.
+    // --album-by / --album-depth: with -a, what counts as one album
+    // (issues #324, #331, #333). `--per-directory` aliases `--album-by=dir`.
     pub album_by: AlbumGrouping,
+    // The path arguments as typed, before -R expanded them. `--album-depth`
+    // counts levels from these, and `expand_files_recursive` is where the
+    // provenance would otherwise be lost.
+    pub arg_roots: Vec<PathBuf>,
     pub max_amplitude_only: bool, // -x: only find max amplitude
     pub track_index: Option<u32>, // -i <index>: track index for multi-track files
 

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -18,6 +18,13 @@ fn parse_album_grouping(mode: &str) -> Result<AlbumGrouping> {
     }
 }
 
+/// `--album-depth <n>`, for the same reason as above.
+fn parse_album_depth(value: &str) -> Result<usize> {
+    value
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("--album-depth needs a level count, got '{}'", value))
+}
+
 fn parse_thread_count(value: &str, flag: &str) -> Result<usize> {
     value
         .parse()
@@ -27,6 +34,9 @@ fn parse_thread_count(value: &str, flag: &str) -> Result<usize> {
 pub fn parse_args(args: &[String]) -> Result<Options> {
     let mut opts = Options::default();
     let mut i = 0;
+    // Both spellings write `opts.album_by`, so the conflict has to be tracked
+    // separately to be reportable rather than silently last-wins.
+    let (mut album_by_given, mut album_depth_given) = (false, false);
 
     while i < args.len() {
         let arg = &args[i];
@@ -45,12 +55,14 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
 
         if arg == "--per-directory" {
             opts.album_by = AlbumGrouping::Dir;
+            album_by_given = true;
             i += 1;
             continue;
         }
 
         if let Some(mode) = arg.strip_prefix("--album-by=") {
             opts.album_by = parse_album_grouping(mode)?;
+            album_by_given = true;
             i += 1;
             continue;
         }
@@ -60,6 +72,24 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
                 .get(i + 1)
                 .ok_or_else(|| anyhow::anyhow!("--album-by requires a mode (dir or tag)"))?;
             opts.album_by = parse_album_grouping(mode)?;
+            album_by_given = true;
+            i += 2;
+            continue;
+        }
+
+        if let Some(depth) = arg.strip_prefix("--album-depth=") {
+            opts.album_by = AlbumGrouping::Depth(parse_album_depth(depth)?);
+            album_depth_given = true;
+            i += 1;
+            continue;
+        }
+
+        if arg == "--album-depth" {
+            let depth = args
+                .get(i + 1)
+                .ok_or_else(|| anyhow::anyhow!("--album-depth requires a level count"))?;
+            opts.album_by = AlbumGrouping::Depth(parse_album_depth(depth)?);
+            album_depth_given = true;
             i += 2;
             continue;
         }
@@ -338,9 +368,22 @@ pub fn parse_args(args: &[String]) -> Result<Options> {
         anyhow::bail!("--true-peak requires --rg2 or --r128");
     }
 
-    // --album-by / --per-directory only change how -a groups files (#324, #333).
+    // --album-by / --album-depth / --per-directory only change how -a groups
+    // files (#324, #331, #333).
     if opts.album_by != AlbumGrouping::Pooled && !(opts.album_gain && !opts.skip_album) {
-        anyhow::bail!("--per-directory / --album-by requires -a");
+        anyhow::bail!("--per-directory / --album-by / --album-depth requires -a");
+    }
+
+    // Both set the same field, so the second would silently win. A user who
+    // typed both meant one of them, and guessing wrong regroups their library.
+    if album_depth_given && album_by_given {
+        anyhow::bail!("--album-depth and --album-by are mutually exclusive");
+    }
+
+    // Depth counts levels below a root argument, and without -R a directory
+    // argument is never descended into, so there are no levels to count.
+    if matches!(opts.album_by, AlbumGrouping::Depth(_)) && !opts.recursive {
+        anyhow::bail!("--album-depth requires -R");
     }
 
     // --tags-only (issue #308) writes ReplayGain metadata and nothing else, so

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -27,12 +27,16 @@ pub fn print_usage() {
     println!("    -l <c> <g>  Apply gain to left (0) or right (1) channel only");
     println!("    -m <i>      Modify suggested gain by integer i");
     println!("    -r          Apply Track gain (ReplayGain analysis)");
-    println!("    -a          Apply Album gain (ReplayGain analysis)");
-    println!("    --album-by <how>  With -a: what counts as one album, so a whole library");
-    println!("                      can be album-tagged in one run (pairs with -R)");
+    println!("    -a          Apply Album gain (ReplayGain analysis). Every file given is");
+    println!("                one album, the same rule as mp3gain -a");
+    println!("    --album-by <how>  With -a: what counts as one album instead, so a whole");
+    println!("                      library can be album-tagged in one run (pairs with -R)");
     println!("                        dir  one album per directory");
     println!("                        tag  one album per release, from ALBUM/ALBUMARTIST,");
     println!("                             so discs in subfolders share one album gain");
+    println!("    --album-depth <n> With -a -R: one album per directory n levels below each");
+    println!("                      directory argument. For untagged libraries; n 0 makes");
+    println!("                      each argument one album, n 2 suits Artist/Album trees");
     println!("    --per-directory   Alias for --album-by=dir");
     println!("    --rg2       ReplayGain 2.0 analysis (BS.1770, -18 LUFS reference)");
     println!("    --r128      EBU R128 analysis (BS.1770, -23 LUFS target)");
@@ -97,6 +101,7 @@ pub fn print_usage() {
     println!("    mp3rgain -t -g 2 song.mp3      Apply gain using temp file");
     println!("    mp3rgain -R /path/to/music     Process directory recursively");
     println!("    mp3rgain -a --album-by=tag -R /music   One album per release");
+    println!("    mp3rgain -a --album-depth 2 -R /music  One album per Artist/Album folder");
     println!("    mp3rgain -Rpa --skip-errors /music  Album-scan a library, skipping");
     println!("                                        files that fail to decode");
     println!("    mp3rgain -n -g 2 *.mp3         Dry-run (preview changes)");

--- a/src/commands/albumgroup.rs
+++ b/src/commands/albumgroup.rs
@@ -1,8 +1,9 @@
-//! What counts as one album under `-a` (issues #324, #333).
+//! What counts as one album under `-a` (issues #324, #331, #333).
 //!
-//! `-a` alone pools every file, which is mp3gain's rule. `--album-by` splits
-//! the run instead: `dir` by parent directory, `tag` by release taken from the
-//! metadata.
+//! `-a` alone pools every file, which is mp3gain's rule. The flags split the
+//! run instead: `--album-by=dir` by parent directory, `--album-by=tag` by
+//! release taken from the metadata, and `--album-depth N` by directory N
+//! levels below each root argument.
 
 use colored::*;
 use mp3rgain::{read_album_tags, AlbumTags};
@@ -10,7 +11,7 @@ use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
-use crate::cli::options::AlbumGrouping;
+use crate::cli::options::{AlbumGrouping, Options};
 
 /// How a set of files was identified as one album.
 pub enum AlbumId {
@@ -50,23 +51,165 @@ pub struct AlbumGroup {
 /// alongside the warnings the caller must surface: a grouping that silently
 /// merges two releases, or silently drops files into a fallback, is the one
 /// outcome that must not happen.
-pub fn group_files(files: &[PathBuf], mode: AlbumGrouping) -> (Vec<AlbumGroup>, Vec<String>) {
-    match mode {
+pub fn group_files(files: &[PathBuf], opts: &Options) -> (Vec<AlbumGroup>, Vec<String>) {
+    match opts.album_by {
         AlbumGrouping::Tag => group_by_tags(files),
+        AlbumGrouping::Depth(levels) => {
+            let groups = group_by_depth(files, &opts.arg_roots, levels);
+            let warnings = split_release_warnings(&groups);
+            (groups, warnings)
+        }
         // Pooled never reaches here; the caller dispatches it to `cmd_album_gain`.
-        _ => (group_by_parent(files), Vec::new()),
+        _ => {
+            let groups = group_by_parent(files);
+            let warnings = split_release_warnings(&groups);
+            (groups, warnings)
+        }
     }
 }
 
 /// Group by immediate parent directory, as given on the command line. Bare
 /// file names land in `.`. Directories come out in path order.
 fn group_by_parent(files: &[PathBuf]) -> Vec<AlbumGroup> {
+    group_by_directory(files.iter().map(|f| (parent_of(f), f.clone())))
+}
+
+/// `--album-depth N`: the album is the directory N levels below the root
+/// argument the file was found under (issue #331).
+///
+/// A file shallower than N levels groups at the deepest directory it actually
+/// has, so a stray file at the root of the tree does not get a group key that
+/// points at a directory it is not in. Descending deeper than N is what makes
+/// this handle multi-disc releases: at `--album-depth 2` over `Artist/Album`,
+/// `Artist/Album/disc1` and `disc2` both truncate to `Artist/Album`.
+fn group_by_depth(files: &[PathBuf], roots: &[PathBuf], levels: usize) -> Vec<AlbumGroup> {
+    // Deepest root first, so an overlapping pair like `-R music music/album`
+    // assigns the file to `music/album` rather than to whichever came first.
+    let mut roots: Vec<&Path> = roots.iter().map(|p| p.as_path()).collect();
+    roots.sort_by_key(|p| std::cmp::Reverse(p.components().count()));
+
+    group_by_directory(files.iter().map(|file| {
+        let group = roots
+            .iter()
+            .find_map(|root| album_dir_under(file, root, levels))
+            .unwrap_or_else(|| parent_of(file));
+        (group, file.clone())
+    }))
+}
+
+/// The album directory for `file` under `root`, or `None` when the file is not
+/// under that root.
+fn album_dir_under(file: &Path, root: &Path, levels: usize) -> Option<PathBuf> {
+    let relative = file.strip_prefix(root).ok()?;
+    // `relative` ends in the file name, which is not a level; only the
+    // directories above it are counted.
+    let Some(dirs) = relative.parent() else {
+        // The root *is* the file: a bare file argument pools with its
+        // neighbours rather than becoming a one-file album of its own.
+        return Some(parent_of(file));
+    };
+    let mut dir = root.to_path_buf();
+    dir.extend(dirs.components().take(levels));
+    Some(dir)
+}
+
+/// Directory grouping cannot see that two sibling folders are one release, so
+/// it says so instead of writing a per-disc album gain in silence (#331).
+///
+/// One tag probe per group rather than per file: ALBUM is uniform inside a
+/// directory, so the first file answers for the whole group and a library
+/// sweep costs one probe per directory.
+fn split_release_warnings(groups: &[AlbumGroup]) -> Vec<String> {
+    // Only groups under a common parent can be discs of one release.
+    let mut siblings: BTreeMap<PathBuf, Vec<usize>> = BTreeMap::new();
+    for (i, group) in groups.iter().enumerate() {
+        let AlbumId::Directory(dir) = &group.id else {
+            continue;
+        };
+        if let Some(parent) = dir.parent() {
+            siblings.entry(parent.to_path_buf()).or_default().push(i);
+        }
+    }
+    let candidates: Vec<usize> = siblings
+        .values()
+        .filter(|g| g.len() > 1)
+        .flatten()
+        .copied()
+        .collect();
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let probed: HashMap<usize, AlbumTags> = candidates
+        .par_iter()
+        .filter_map(|&i| {
+            let tags = read_album_tags(groups[i].files.first()?)?;
+            tags.has_album().then_some((i, tags))
+        })
+        .collect();
+
+    let mut warnings = Vec::new();
+    for members in siblings.values().filter(|g| g.len() > 1) {
+        let mut by_release: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
+        for &i in members {
+            let Some(tags) = probed.get(&i) else { continue };
+            let key = (
+                tags.effective_artist().unwrap_or_default().to_string(),
+                tags.album.clone().unwrap_or_default(),
+            );
+            by_release.entry(key).or_default().push(i);
+        }
+        for ((_, album), split) in by_release.iter().filter(|(_, s)| s.len() > 1) {
+            let first = &probed[&split[0]];
+            if !split[1..]
+                .iter()
+                .any(|i| looks_like_one_release(first, &probed[i]))
+            {
+                continue;
+            }
+            let mut warning = format!(
+                "  {} ALBUM \"{}\" is split across {} directories and was scanned as that many albums\n",
+                "!".yellow(),
+                album,
+                split.len()
+            );
+            for &i in split {
+                warning.push_str(&format!("      {}\n", groups[i].id.heading()));
+            }
+            warning.push_str("      use --album-by=tag to treat them as one release");
+            warnings.push(warning);
+        }
+    }
+    warnings
+}
+
+/// Whether two sibling directories sharing an artist and album string are one
+/// multi-disc release rather than two editions of the same album.
+///
+/// The distinction matters because the advice differs: discs of one release
+/// want `--album-by=tag`, while two editions are already grouped correctly by
+/// directory and pointing the user at `tag` would merge them wrongly. Same
+/// reasoning as the tag-mode collision report, from the other direction.
+fn looks_like_one_release(a: &AlbumTags, b: &AlbumTags) -> bool {
+    // Distinct MusicBrainz ids are two releases by definition.
+    if let (Some(x), Some(y)) = (&a.musicbrainz_album_id, &b.musicbrainz_album_id) {
+        if x != y {
+            return false;
+        }
+    }
+    match (a.disc, b.disc) {
+        // Different disc numbers under one album title: one release.
+        (Some(x), Some(y)) => x != y,
+        // No disc tags to go on, so fall back to the track numbers. The same
+        // track in both directories is the signature of two editions.
+        _ => a.track != b.track || a.track.is_none(),
+    }
+}
+
+fn group_by_directory(entries: impl Iterator<Item = (PathBuf, PathBuf)>) -> Vec<AlbumGroup> {
     let mut groups: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
-    for file in files {
-        groups
-            .entry(parent_of(file))
-            .or_default()
-            .push(file.clone());
+    for (dir, file) in entries {
+        groups.entry(dir).or_default().push(file);
     }
     groups
         .into_iter()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,9 @@ pub fn run(mut opts: Options) -> Result<()> {
 
     // Expand files if recursive mode
     if opts.recursive {
+        // --album-depth counts levels from the arguments as typed, which the
+        // expansion below flattens away (issue #331).
+        opts.arg_roots = opts.files.clone();
         opts.files = expand_files_recursive(&opts.files)?;
         if opts.files.is_empty() {
             eprintln!("{}: no audio files found (MP3/M4A)", "error".red().bold());

--- a/src/commands/replaygain.rs
+++ b/src/commands/replaygain.rs
@@ -341,7 +341,7 @@ pub fn cmd_album_gain(files: &[PathBuf], opts: &Options) -> Result<()> {
 /// order, and the counters are summed afterwards rather than by the workers.
 pub fn cmd_album_gain_grouped(files: &[PathBuf], opts: &Options) -> Result<()> {
     require_replaygain_feature();
-    let (groups, warnings) = group_files(files, opts.album_by);
+    let (groups, warnings) = group_files(files, opts);
     print_album_intro(files.len(), Some(groups.len()), opts);
     // Printed before any analysis starts: a grouping that merged two releases
     // has to be visible while the run can still be cancelled, not buried under

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1018,12 +1018,14 @@ fn album_depth_groups_at_the_requested_level() {
         albums_of(&out)
             .iter()
             .map(|a| {
+                // Relative to the temp root, with the separator normalized:
+                // Windows reports the same groups as `\\Pink Floyd`.
                 a["directory"]
                     .as_str()
                     .expect("depth groups are directories")
                     .trim_start_matches(root_arg)
-                    .trim_start_matches('/')
-                    .to_string()
+                    .trim_start_matches(['/', '\\'])
+                    .replace('\\', "/")
             })
             .collect()
     };

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -956,6 +956,249 @@ fn album_by_tag_falls_back_to_directory_without_an_album_tag() {
     );
 }
 
+/// Build `<root>/Pink Floyd/The Wall/disc{1,2}` plus a single-disc Metallica
+/// album, so one tree exercises every depth the grouping can be asked for.
+fn write_depth_corpus(root: &Path) {
+    for (dir, fixture, disc, track) in [
+        ("Pink Floyd/The Wall/disc1", "test_mono.mp3", "1", "1"),
+        ("Pink Floyd/The Wall/disc1", "test_vbr.mp3", "1", "2"),
+        ("Pink Floyd/The Wall/disc2", "test_stereo.mp3", "2", "1"),
+        (
+            "Pink Floyd/The Wall/disc2",
+            "test_joint_stereo.mp3",
+            "2",
+            "2",
+        ),
+    ] {
+        write_tagged_mp3(
+            fixture,
+            &root.join(dir).join(fixture),
+            &[
+                ("TALB", "The Wall"),
+                ("TPE2", "Pink Floyd"),
+                ("TPOS", disc),
+                ("TRCK", track),
+            ],
+        );
+    }
+    for (fixture, track) in [("test_mono.mp3", "1"), ("test_stereo.mp3", "2")] {
+        write_tagged_mp3(
+            fixture,
+            &root.join("Metallica/Ride the Lightning").join(fixture),
+            &[
+                ("TALB", "Ride the Lightning"),
+                ("TPE2", "Metallica"),
+                ("TPOS", "1"),
+                ("TRCK", track),
+            ],
+        );
+    }
+}
+
+/// `--album-depth N` is the grouping unit for a library that is not tagged
+/// (issue #331): N levels below each root argument, with no glob and no
+/// command-line length ceiling, so it works the same on Windows.
+#[test]
+fn album_depth_groups_at_the_requested_level() {
+    let root = TempAlbum::new(&[]);
+    write_depth_corpus(&root.dir);
+    let root_arg = root.dir.to_str().unwrap();
+
+    let directories = |depth: &str| -> Vec<String> {
+        let out = run(&[
+            "-a",
+            "--album-depth",
+            depth,
+            "-n",
+            "-R",
+            "-o",
+            "json",
+            root_arg,
+        ]);
+        albums_of(&out)
+            .iter()
+            .map(|a| {
+                a["directory"]
+                    .as_str()
+                    .expect("depth groups are directories")
+                    .trim_start_matches(root_arg)
+                    .trim_start_matches('/')
+                    .to_string()
+            })
+            .collect()
+    };
+
+    assert_eq!(directories("0"), vec![""], "the root itself is one album");
+    assert_eq!(directories("1"), vec!["Metallica", "Pink Floyd"]);
+    assert_eq!(
+        directories("2"),
+        vec!["Metallica/Ride the Lightning", "Pink Floyd/The Wall"]
+    );
+    // Deeper than the tree: every directory that exists becomes its own album.
+    assert_eq!(
+        directories("3"),
+        vec![
+            "Metallica/Ride the Lightning",
+            "Pink Floyd/The Wall/disc1",
+            "Pink Floyd/The Wall/disc2",
+        ]
+    );
+}
+
+/// `--album-depth 0` is what `--album-by=arg` would have been: one album per
+/// directory argument. That is why `arg` was dropped rather than implemented.
+#[test]
+fn album_depth_zero_is_one_album_per_root_argument() {
+    let root = TempAlbum::new(&[]);
+    write_depth_corpus(&root.dir);
+    let floyd = root.dir.join("Pink Floyd");
+    let metallica = root.dir.join("Metallica");
+
+    let out = run(&[
+        "-a",
+        "--album-depth",
+        "0",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        floyd.to_str().unwrap(),
+        metallica.to_str().unwrap(),
+    ]);
+    let albums = albums_of(&out);
+    assert_eq!(albums.len(), 2, "one album per argument");
+    assert_eq!(albums[0]["files"], 2, "Metallica sorts first");
+    assert_eq!(albums[1]["files"], 4, "both Floyd discs in one album");
+}
+
+/// The multi-disc case from #331, solved without tags: grouping two levels
+/// down puts both disc folders in the same album, and the value has to match
+/// pooling the same files with plain `-a`.
+#[test]
+fn album_depth_keeps_a_multi_disc_release_together() {
+    let root = TempAlbum::new(&[]);
+    write_depth_corpus(&root.dir);
+    let floyd = root.dir.join("Pink Floyd");
+    let floyd_arg = floyd.to_str().unwrap();
+
+    let by_depth = albums_of(&run(&[
+        "-a",
+        "--album-depth",
+        "1",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        floyd_arg,
+    ]));
+    assert_eq!(by_depth.len(), 1);
+    assert_eq!(by_depth[0]["files"], 4);
+
+    let pooled = json_of(&run(&["-a", "-n", "-R", "-o", "json", floyd_arg]));
+    assert_eq!(by_depth[0]["gain_db"], pooled["album"]["gain_db"]);
+}
+
+/// Directory grouping cannot see that two sibling folders are one release, so
+/// it has to say so instead of writing a per-disc album gain in silence.
+#[test]
+fn dir_grouping_warns_when_a_release_is_split_across_sibling_folders() {
+    let root = TempAlbum::new(&[]);
+    write_depth_corpus(&root.dir);
+    let out = run(&[
+        "-a",
+        "--album-by=dir",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root.dir.to_str().unwrap(),
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(albums_of(&out).len(), 3, "dir grouping still splits them");
+    assert!(
+        stderr.contains(r#"ALBUM "The Wall" is split across 2 directories"#),
+        "{stderr}"
+    );
+    assert!(stderr.contains("--album-by=tag"), "{stderr}");
+    // The single-disc album next to it is not a split release.
+    assert!(!stderr.contains("Ride the Lightning"), "{stderr}");
+}
+
+/// The mirror case, raised by gcocatre on #333: two editions of one album in
+/// sibling folders are *already* grouped correctly by directory, so pointing
+/// the user at `--album-by=tag` would merge them wrongly. Same (disc, track)
+/// in both folders is what separates this from a multi-disc release.
+#[test]
+fn dir_grouping_stays_quiet_for_two_editions_of_one_album() {
+    let root = TempAlbum::new(&[]);
+    for edition in ["1973", "2011"] {
+        for (fixture, track) in [("test_mono.mp3", "1"), ("test_stereo.mp3", "2")] {
+            write_tagged_mp3(
+                fixture,
+                &root.dir.join(edition).join(fixture),
+                &[
+                    ("TALB", "The Dark Side of the Moon"),
+                    ("TPE2", "Pink Floyd"),
+                    ("TPOS", "1"),
+                    ("TRCK", track),
+                ],
+            );
+        }
+    }
+    let out = run(&[
+        "-a",
+        "--album-by=dir",
+        "-n",
+        "-R",
+        "-o",
+        "json",
+        root.dir.to_str().unwrap(),
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(albums_of(&out).len(), 2);
+    assert!(
+        !stderr.contains("split across"),
+        "no advice to give: {stderr}"
+    );
+}
+
+#[test]
+fn album_depth_rejects_contradictory_invocations() {
+    let dir = TempAlbum::new(&["test_mono.mp3"]);
+    let arg = dir.dir.to_str().unwrap();
+    for (args, expected) in [
+        (vec!["-a", "--album-depth", "2", "-n", arg], "requires -R"),
+        (
+            vec![
+                "-a",
+                "--album-depth",
+                "2",
+                "--album-by=tag",
+                "-n",
+                "-R",
+                arg,
+            ],
+            "mutually exclusive",
+        ),
+        (
+            vec!["-a", "--album-depth", "x", "-n", "-R", arg],
+            "needs a level count",
+        ),
+        (
+            vec!["--album-depth", "2", "-r", "-n", "-R", arg],
+            "requires -a",
+        ),
+    ] {
+        let out = run(&args);
+        assert!(!out.status.success(), "{args:?}");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains(expected),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
 /// `--per-directory` shipped in 3.6.1 and keeps working unchanged.
 #[test]
 fn per_directory_is_an_alias_for_album_by_dir() {


### PR DESCRIPTION
Finishes #331. #336 landed the `--album-by` selector; this is the grouping unit for libraries that are not tagged, plus the warning that makes the original bug visible to anyone still on directory grouping.

## `--album-depth N`

One album per directory N levels below each directory argument.

| Invocation | Album unit |
|---|---|
| `--album-depth 0 -R ~/Music/Album` | the root argument itself, one album |
| `--album-depth 1 -R ~/Music` | one level below the root |
| `--album-depth 2 -R ~/Music/lossless` | `Artist/Album`, one argument and no glob |

This is skamp's own suggestion from the thread: let the user state their directory structure, as long as it is coherent. It needs no tags, no shell expansion, has no command-line length ceiling, and behaves identically on Windows.

Descending deeper than N is what keeps a multi-disc release together: at `--album-depth 2` over `Artist/Album`, both `disc1` and `disc2` truncate to `Artist/Album`. A file shallower than N levels groups at the deepest directory it actually has, so a stray file at the root does not get a key pointing at a directory it is not in. When arguments overlap (`-R music music/album`), the deepest matching root owns the file.

`--album-depth` requires `-a` and `-R`, and is mutually exclusive with `--album-by`. Both spellings write the same field, so a contradictory pair is rejected rather than silently last-wins.

`expand_files_recursive` flattens the expanded list and discards which argument each file came from, so the arguments as typed are now kept on `Options` and the depth is counted from those.

## `--album-by=arg` is not implemented

Per the decision recorded on #331. `--album-depth 0` is the same thing without the shell dependency, `tag` covers the whole-library case portably, and plain `-a` already is mp3gain's rule verbatim, so nothing was taken away from the single-album workflow that `arg` was meant to preserve.

The condition attached to that decision was documentation, so it is treated as part of the work rather than a footnote. `--help`, the man page and the README now state outright that `-a` on its own pools every file given, exactly as `mp3gain -a` does, and point anyone looking for per-argument grouping at `--album-depth` or `tag`.

## Reporting a release split across sibling folders

Directory grouping cannot see that `disc1/` and `disc2/` are one release, which is the original report on #331: -0.94 dB for one disc and -2.28 dB for the other, landing silently in `REPLAYGAIN_ALBUM_GAIN` under `--tags-only`. `--per-directory` is what 3.6.1 and 3.7.0 documented, so users are still on it and need to be told.

```
  ! ALBUM "The Wall" is split across 2 directories and was scanned as that many albums
      music/Pink Floyd/The Wall/disc1
      music/Pink Floyd/The Wall/disc2
      use --album-by=tag to treat them as one release
```

One tag probe per group rather than per file, since ALBUM is uniform inside a directory, so a library sweep costs one probe per directory. Measured at no change over 5,000 files in 20 directories: 0.62-0.66 s before, 0.63-0.69 s after, which is inside the noise. It applies to `--album-depth` too, where over-deep grouping produces exactly the same split.

### Two editions are deliberately left alone

This is the case @gcocatre raised on #333, applied in the other direction. Two editions of one album in sibling folders are **already** grouped correctly by directory, and telling that user to switch to `--album-by=tag` would merge them wrongly, which is the very thing the tag-mode collision report warns about.

So the same structural signal decides it, with no guessing at naming conventions:

- Distinct `MUSICBRAINZ_ALBUMID` values are two releases by definition. Quiet.
- Different disc numbers under one album title are one release. Warn.
- No disc numbers, and the same track number in both folders, is the signature of two editions. Quiet.

## Verification

- `--album-depth` 0 / 1 / 2 / 3 over an `Artist/Album/disc` tree produces the expected groups at each level, and `--album-depth 1` on a two-disc release gives a gain equal to pooling the same four files with plain `-a`.
- `--album-depth 0` with two directory arguments gives one album per argument, which is the `arg` behaviour it replaces.
- Overlapping arguments resolve to the deepest root.
- Multi-disc release: `dir` gives 2 albums and 1 warning, `tag` gives 1 album and no warning, `--album-depth 1` gives 1 album and no warning.
- Two editions: `dir` gives 2 albums and **no** warning; `tag` merges them and fires the collision report from #336.
- **Regression against 4ece347**: `--per-directory`, `--album-by=dir`, `--album-by=tag`, plain `-a`, `-r` and the info command all produce byte-identical stdout across text, TSV and JSON. The only change to an existing invocation is the new warning on stderr in directory mode.
- `cargo test`: 227 passed, 0 failed, with 6 new tests. `cargo clippy -- -D warnings` and `cargo fmt --check` clean, including the GUI manifest.

## Left for later

mp3rgui still has its own folder grouping and no equivalent of any of this. That is #338.

Closes #331
