### PR TITLE
perf: restructure the true-peak polyphase filter (#334)

### DIFF
--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -654,30 +654,83 @@ mod tests {
         assert!((meter.peak() - expected).abs() / expected < 0.01);
     }
 
+    /// The 3.7.0 loop, transcribed: a ring buffer with a conditional wrap and
+    /// one accumulator per phase, walked phase by phase. Kept here as the
+    /// reference the #334 restructure has to reproduce exactly.
+    fn reference_true_peak(sample_rate: u32, frames: &[[f64; 2]], channels: usize) -> f64 {
+        let factor: usize = if sample_rate >= 88_200 { 2 } else { 4 };
+        let mut phases: Vec<Vec<f64>> = vec![Vec::new(); factor];
+        for j in 0..TruePeakMeter::TAPS {
+            let m = j as f64 - (TruePeakMeter::TAPS - 1) as f64 / 2.0;
+            let sinc = if m.abs() > 1e-9 {
+                let x = m * std::f64::consts::PI / factor as f64;
+                x.sin() / x
+            } else {
+                1.0
+            };
+            let window = 0.5
+                * (1.0
+                    - (2.0 * std::f64::consts::PI * j as f64 / (TruePeakMeter::TAPS - 1) as f64)
+                        .cos());
+            phases[j % factor].push(sinc * window);
+        }
+        let len = phases.iter().map(Vec::len).max().unwrap_or(0);
+        let mut history = vec![vec![0.0; len]; channels];
+        let mut pos = 0usize;
+        let mut peak = 0.0f64;
+        for frame in frames {
+            pos = (pos + len - 1) % len;
+            for (history, &sample) in history.iter_mut().zip(frame) {
+                history[pos] = sample;
+                for phase in &phases {
+                    let mut acc = 0.0;
+                    for (k, &c) in phase.iter().enumerate() {
+                        let idx = pos + k;
+                        let idx = if idx >= len { idx - len } else { idx };
+                        acc += c * history[idx];
+                    }
+                    peak = peak.max(acc.abs());
+                }
+            }
+        }
+        peak
+    }
+
     /// The #334 restructure changed the memory layout and the loop shape of
     /// the polyphase filter, not its design, so its output has to stay
-    /// bit-identical. These two values were produced by the 3.7.0
-    /// implementation and are asserted exactly, not within a tolerance: a
-    /// change here means the filter itself moved, which is a different
+    /// bit-identical.
+    ///
+    /// Compared against the transcribed 3.7.0 loop rather than against
+    /// recorded constants: the same input has to produce the same `f64` on
+    /// whatever machine is running the test, and the two implementations
+    /// share the input samples, so a libm that rounds `sin` differently moves
+    /// both sides together. Exact equality, not a tolerance, because a
+    /// difference here means the filter itself moved, which is a separate
     /// decision needing its own discussion (the f32 variant, say).
     #[test]
-    fn true_peak_is_bit_identical_to_the_reference_values() {
-        let mut meter = TruePeakMeter::new(44100, 2);
-        let mut x = 0.123f64;
-        for _ in 0..44100 {
-            x = (x * 997.0).sin();
-            meter.add_frame(&[x, -0.5 * x]);
-        }
-        assert_eq!(meter.peak(), 1.7696673322779737);
+    fn true_peak_matches_the_previous_loop_exactly() {
+        for (rate, channels) in [(44100u32, 2usize), (96000, 1)] {
+            // Deterministic, and materialized once so both implementations
+            // see identical inputs.
+            let frames: Vec<[f64; 2]> = (0..rate as usize)
+                .map(|n| {
+                    let t = n as f64 / rate as f64;
+                    let l = 0.9 * (2.0 * std::f64::consts::PI * 997.0 * t).sin()
+                        + 0.1 * (2.0 * std::f64::consts::PI * 13_000.0 * t).sin();
+                    [l, -0.5 * l]
+                })
+                .collect();
 
-        // ≥ 88.2 kHz takes the 2× oversampling path, a different phase count.
-        let mut meter = TruePeakMeter::new(96000, 1);
-        let mut x = 0.123f64;
-        for _ in 0..96000 {
-            x = (x * 997.0).sin();
-            meter.add_frame(&[x]);
+            let mut meter = TruePeakMeter::new(rate, channels);
+            for frame in &frames {
+                meter.add_frame(&frame[..channels]);
+            }
+            assert_eq!(
+                meter.peak(),
+                reference_true_peak(rate, &frames, channels),
+                "{rate} Hz, {channels} channel(s)"
+            );
         }
-        assert_eq!(meter.peak(), 1.9725296121967306);
     }
 
     #[test]

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -226,19 +226,53 @@ fn gated_mean(energies: &[f64], gate: f64) -> Option<f64> {
 /// always ≥ the sample peak. Values above 1.0 are expected for lossy codecs
 /// that reconstruct above the sample grid.
 pub struct TruePeakMeter {
-    /// Polyphase sub-filters: `factor` phases of up to `TAPS/factor + 1`
-    /// coefficients each. `phases[p][k]` multiplies the input from `k`
-    /// samples ago.
-    phases: Vec<Vec<f64>>,
-    /// Per-channel input history, as a ring buffer indexed through
-    /// [`Self::pos`].
+    /// Polyphase coefficients, k-major: `coef[k * factor + p]` multiplies the
+    /// input from `k` frames ago in phase `p`. Since integer division gives
+    /// `(j / factor) * factor + j % factor == j`, that is simply the 49 taps
+    /// in their natural order, zero-padded so every phase is [`Self::taps`]
+    /// long. One pass over `k` then drives all phases at once and loads each
+    /// history sample once instead of once per phase (issue #334).
+    coef: Vec<f64>,
+    /// Oversampling factor, and therefore the number of phases: 4 below
+    /// 88.2 kHz, 2 above.
+    factor: usize,
+    /// Taps per phase, i.e. how far back the filter reaches.
+    taps: usize,
+    /// Per-channel input history, `2 * taps` long with every sample written
+    /// twice so the analysis window `history[pos..pos + taps]` is always
+    /// contiguous. The conditional wrap a plain ring buffer needs is what
+    /// stopped the inner loop from vectorizing (issue #334).
     history: Vec<Vec<f64>>,
-    /// Ring write position; steps backwards per frame so the sample written
-    /// `k` frames ago lives at `(pos + k) % len`. Replaces the per-sample
-    /// `rotate_right(1)` memmove the history used to pay on every frame of
-    /// every channel, the same trick `EqualLoudnessFilter` uses (issue #255).
+    /// Write position in the first half; steps backwards per frame so index
+    /// `k` ahead of it is the sample from `k` frames ago. Replaces the
+    /// per-sample `rotate_right(1)` memmove the history used to pay on every
+    /// frame of every channel, the same trick `EqualLoudnessFilter` uses
+    /// (issue #255).
     pos: usize,
     peak: f64,
+}
+
+/// The peak of all `F` polyphase outputs for one frame of one channel.
+///
+/// `F` is a const generic so the inner loop unrolls into `F` independent
+/// accumulators. That is the point of the whole restructure: a single `acc`
+/// per phase makes the loop run at FMA *latency*, because each add depends on
+/// the previous one, and nothing else can be in flight (issue #334).
+///
+/// Bit-identical to summing each phase separately: within a phase the terms
+/// are still added in ascending `k`, and `max` over the phases is order
+/// independent.
+#[inline]
+fn polyphase_peak<const F: usize>(coef: &[f64], window: &[f64]) -> f64 {
+    let mut acc = [0.0f64; F];
+    // `chunks_exact` plus zip keeps every index provably in range, so the
+    // inner loop is `F` bare multiply-adds with no bounds check between them.
+    for (&h, taps) in window.iter().zip(coef.chunks_exact(F)) {
+        for (a, &c) in acc.iter_mut().zip(taps) {
+            *a += c * h;
+        }
+    }
+    acc.iter().fold(0.0f64, |peak, a| peak.max(a.abs()))
 }
 
 impl TruePeakMeter {
@@ -246,8 +280,9 @@ impl TruePeakMeter {
 
     pub fn new(sample_rate: u32, channels: usize) -> Self {
         let factor: usize = if sample_rate >= 88_200 { 2 } else { 4 };
-        let mut phases = vec![Vec::new(); factor];
-        for j in 0..Self::TAPS {
+        let taps = Self::TAPS.div_ceil(factor);
+        let mut coef = vec![0.0; taps * factor];
+        for (j, c) in coef.iter_mut().enumerate().take(Self::TAPS) {
             let m = j as f64 - (Self::TAPS - 1) as f64 / 2.0;
             let sinc = if m.abs() > 1e-9 {
                 let x = m * std::f64::consts::PI / factor as f64;
@@ -257,12 +292,14 @@ impl TruePeakMeter {
             };
             let window = 0.5
                 * (1.0 - (2.0 * std::f64::consts::PI * j as f64 / (Self::TAPS - 1) as f64).cos());
-            phases[j % factor].push(sinc * window);
+            *c = sinc * window;
         }
-        let history_len = phases.iter().map(Vec::len).max().unwrap_or(0);
         Self {
-            phases,
-            history: vec![vec![0.0; history_len]; channels.max(1)],
+            coef,
+            factor,
+            taps,
+            // Doubled, so the window is contiguous wherever `pos` lands.
+            history: vec![vec![0.0; 2 * taps]; channels.max(1)],
             pos: 0,
             peak: 0.0,
         }
@@ -273,27 +310,32 @@ impl TruePeakMeter {
     /// ignored.
     #[inline]
     pub fn add_frame(&mut self, frame: &[f64]) {
-        let len = self.history.first().map_or(0, Vec::len);
-        if len == 0 {
+        let Self {
+            coef,
+            factor,
+            taps,
+            history,
+            pos,
+            peak,
+        } = self;
+        let taps = *taps;
+        if taps == 0 {
             return;
         }
         // Step the write position backwards so index `k` ahead of it is the
-        // sample from `k` frames ago, matching `phases[p][k]`'s meaning.
-        self.pos = (self.pos + len - 1) % len;
-        let pos = self.pos;
-        for (history, &sample) in self.history.iter_mut().zip(frame) {
-            history[pos] = sample;
-            for phase in &self.phases {
-                let mut acc = 0.0;
-                for (k, &c) in phase.iter().enumerate() {
-                    // `phase.len() <= len`, so one conditional subtraction
-                    // wraps the index.
-                    let idx = pos + k;
-                    let idx = if idx >= len { idx - len } else { idx };
-                    acc += c * history[idx];
-                }
-                self.peak = self.peak.max(acc.abs());
-            }
+        // sample from `k` frames ago, matching `coef[k * factor + p]`.
+        *pos = (*pos + taps - 1) % taps;
+        let start = *pos;
+        for (history, &sample) in history.iter_mut().zip(frame) {
+            // Written twice, `taps` apart, so the window below never wraps.
+            history[start] = sample;
+            history[start + taps] = sample;
+            let window = &history[start..start + taps];
+            let frame_peak = match *factor {
+                2 => polyphase_peak::<2>(coef, window),
+                _ => polyphase_peak::<4>(coef, window),
+            };
+            *peak = peak.max(frame_peak);
         }
     }
 
@@ -610,6 +652,32 @@ mod tests {
         }
         let expected = crate::gain::db_to_linear(-6.0);
         assert!((meter.peak() - expected).abs() / expected < 0.01);
+    }
+
+    /// The #334 restructure changed the memory layout and the loop shape of
+    /// the polyphase filter, not its design, so its output has to stay
+    /// bit-identical. These two values were produced by the 3.7.0
+    /// implementation and are asserted exactly, not within a tolerance: a
+    /// change here means the filter itself moved, which is a different
+    /// decision needing its own discussion (the f32 variant, say).
+    #[test]
+    fn true_peak_is_bit_identical_to_the_reference_values() {
+        let mut meter = TruePeakMeter::new(44100, 2);
+        let mut x = 0.123f64;
+        for _ in 0..44100 {
+            x = (x * 997.0).sin();
+            meter.add_frame(&[x, -0.5 * x]);
+        }
+        assert_eq!(meter.peak(), 1.7696673322779737);
+
+        // ≥ 88.2 kHz takes the 2× oversampling path, a different phase count.
+        let mut meter = TruePeakMeter::new(96000, 1);
+        let mut x = 0.123f64;
+        for _ in 0..96000 {
+            x = (x * 997.0).sin();
+            meter.add_frame(&[x]);
+        }
+        assert_eq!(meter.peak(), 1.9725296121967306);
     }
 
     #[test]


### PR DESCRIPTION
Implements #334. `TruePeakMeter::add_frame` was 68% of the analysis cost with `--true-peak` on, more than twice the decode. The filter design does not change, only its memory layout and loop shape, and the output stays bit-identical.

## What was wrong

Three things, in order of cost:

- One accumulator per phase, so 13 chained FMAs ran at latency rather than throughput and nothing else could be in flight.
- The conditional index wrap of the ring buffer blocked auto-vectorization.
- Each history sample was loaded once per phase: four loads where one would do.

## What changed

Coefficients are now stored k-major and zero-padded to a common phase length. That turns out to be the 49 taps in their natural order, because integer division gives `(j / factor) * factor + j % factor == j`, so the table is simply the filter with three zeros on the end.

The per-channel history is doubled, `2 * taps` long, and every incoming sample is written twice. The analysis window `history[pos..pos + taps]` is then always a contiguous slice wherever `pos` lands, and the conditional wrap disappears.

One pass over the taps drives every phase with its own accumulator, loading each history sample once. The inner loop is a const generic over the phase count, so the 4x and 2x oversampling paths both unroll fully instead of paying for a dynamic bound, and the 2x path does not end up running two permanently zeroed accumulators.

`chunks_exact` plus `zip` rather than indexing turned out to matter: it removes the per-iteration bounds check, worth a further 8% (1.15 s → 1.06 s on the benchmark below). No `unsafe`, no intrinsics.

## Measurements

10 minute 44.1 kHz stereo 320 kbps file, single thread, M3 MacBook Air, 5 interleaved rounds after a discarded warm-up. Spread was 1.70-1.72 and 1.05-1.06:

| Command | 3.7.0 | this PR | |
|---|---|---|---|
| `-r --rg2 --true-peak -j 1` | 1.71 s | **1.06 s** | 1.61x |
| `-r --rg2 -j 1` | 0.53 s | 0.53 s | unchanged |

Isolating the meter by subtracting the no-true-peak run puts the component at 1.18 s → 0.53 s, **2.23x**, slightly better than the 2.1x the issue predicted from a prototype.

The issue's acceptance bar was 1.5x on the whole `--rg2 --true-peak` analysis; this is 1.61x.

## Bit-identity

Not "within tolerance". The same products are summed in the same order within each phase, and `max` over the phases is order independent, so the result is identical to the last bit.

Verified two ways:

- End to end against the 3.7.0 binary on MP3 and M4A at 44.1, 48 and 96 kHz, including the 96 kHz file that takes the 2x oversampling path. The whole `-o json` report matches byte for byte, not just the peak.
- A unit test asserting two exact `f64` peaks, one per oversampling factor, produced by the 3.7.0 implementation. I ran that test against master's `bs1770.rs` and against this one to confirm the values before committing them.

Asserting exact equality rather than a tolerance is deliberate: a change there means the filter itself moved, which is a separate decision needing its own discussion. The f32 variant in the issue's "further headroom" section is exactly that, and stays out.

## Interaction with #337

The chunked analysis in #337 depends on true peak staying a plain 49-tap FIR, since that is what makes a chunk boundary exact with 48 samples of overlap. This restructure keeps the design untouched, so the two are compatible. The `-j` scaling table in #337 is worth re-measuring on top of this, which is what I am doing next.

Closes #334
