### PR TITLE
perf: overlap the decode with the analysis (#337)

### DIFF
--- a/docs/perf-parallel.md
+++ b/docs/perf-parallel.md
@@ -247,8 +247,30 @@ One thing does move: per-file warnings (clipping, saturation) are emitted by the
 
 The other half of [#332] is granularity: the smallest schedulable unit is still one whole file, so a 9-minute track cannot be split or stolen once a worker picks it up, and thread efficiency is down to 71% at 4 threads even with no album boundary anywhere. Splitting a file into chunks with overlap-warmup is a separate design problem, and [#334] (the true-peak inner loop, a measured 2.1x on 68% of the analysis cost) is a bigger and cheaper win that should land before either.
 
+## Overlapping the decode with the analysis (3.8, issue [#337])
+
+Every level of parallelism above was between files. The work unit was still one whole file, so a single track could never use more than one core: `mp3rgain -r --rg2 --true-peak long.mp3` took the same 0.94 s at `-j 1`, `-j 4` and `-j 8`, because there was nothing to hand to the other cores.
+
+The bitstream decode cannot be parallelized, but the DSP behind it can be taken off the decode thread. With true peak on, the split for a 10 minute 44.1 kHz file is roughly 0.46 s of decode plus conversion and 0.59 s of analysis, so overlapping them takes the file from the sum of the two down to the larger of them. The analyzer still receives every frame exactly once and in order, so this is not an approximation: output is byte-identical.
+
+Batching matters. Handing one 26 ms packet across the channel at a time costs more in wakeups and allocator traffic than the overlap buys back, and only reached 1.25x. Batching to roughly a second of audio, with the buffers travelling back for reuse, reaches 1.42x.
+
+| Workload | before | after | |
+|---|---|---|---|
+| one 10 min file, `-r --rg2 --true-peak` | 1.05 s | **0.74 s** | 1.42x |
+| 36 files / 3.6 h, `-a --rg2 --true-peak -j 4` | 6.33 s | 5.82 s | 1.09x |
+| 36 files / 3.6 h, `-a --rg2 --true-peak -j 8` | 5.34 s | 5.23 s | 1.02x |
+| one 10 min file, `-j 1` | 1.05 s | 1.05 s | unchanged by design |
+
+`-j 1` is documented as the single-threaded legacy path, so the pipeline is disabled there: measured CPU time stays at 1.04 s of user time for 1.05 s of wall time, i.e. one core. Above `-j 1` the pipeline costs about 7% more CPU time for 30% less wall time on a single file.
+
+### What this does not do
+
+The work unit is still a whole file for the *decode*, so one file is now decode-bound rather than decode-plus-DSP bound. Going further means splitting the decode itself across workers, which needs container-level seeking: on MP3 that works (`n_frames` is reported and an accurate seek lands a known distance before the target, 1,249 samples in the case measured), but some M4A files report no frame count at all, so a correct implementation needs a fallback and a way to verify each chunk landed exactly where it expected. [#337] stays open for that.
+
 [#125]: https://github.com/M-Igashi/mp3rgain/issues/125
 [#126]: https://github.com/M-Igashi/mp3rgain/issues/126
 
 [#332]: https://github.com/M-Igashi/mp3rgain/issues/332
 [#334]: https://github.com/M-Igashi/mp3rgain/issues/334
+[#337]: https://github.com/M-Igashi/mp3rgain/issues/337

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -654,30 +654,83 @@ mod tests {
         assert!((meter.peak() - expected).abs() / expected < 0.01);
     }
 
+    /// The 3.7.0 loop, transcribed: a ring buffer with a conditional wrap and
+    /// one accumulator per phase, walked phase by phase. Kept here as the
+    /// reference the #334 restructure has to reproduce exactly.
+    fn reference_true_peak(sample_rate: u32, frames: &[[f64; 2]], channels: usize) -> f64 {
+        let factor: usize = if sample_rate >= 88_200 { 2 } else { 4 };
+        let mut phases: Vec<Vec<f64>> = vec![Vec::new(); factor];
+        for j in 0..TruePeakMeter::TAPS {
+            let m = j as f64 - (TruePeakMeter::TAPS - 1) as f64 / 2.0;
+            let sinc = if m.abs() > 1e-9 {
+                let x = m * std::f64::consts::PI / factor as f64;
+                x.sin() / x
+            } else {
+                1.0
+            };
+            let window = 0.5
+                * (1.0
+                    - (2.0 * std::f64::consts::PI * j as f64 / (TruePeakMeter::TAPS - 1) as f64)
+                        .cos());
+            phases[j % factor].push(sinc * window);
+        }
+        let len = phases.iter().map(Vec::len).max().unwrap_or(0);
+        let mut history = vec![vec![0.0; len]; channels];
+        let mut pos = 0usize;
+        let mut peak = 0.0f64;
+        for frame in frames {
+            pos = (pos + len - 1) % len;
+            for (history, &sample) in history.iter_mut().zip(frame) {
+                history[pos] = sample;
+                for phase in &phases {
+                    let mut acc = 0.0;
+                    for (k, &c) in phase.iter().enumerate() {
+                        let idx = pos + k;
+                        let idx = if idx >= len { idx - len } else { idx };
+                        acc += c * history[idx];
+                    }
+                    peak = peak.max(acc.abs());
+                }
+            }
+        }
+        peak
+    }
+
     /// The #334 restructure changed the memory layout and the loop shape of
     /// the polyphase filter, not its design, so its output has to stay
-    /// bit-identical. These two values were produced by the 3.7.0
-    /// implementation and are asserted exactly, not within a tolerance: a
-    /// change here means the filter itself moved, which is a different
+    /// bit-identical.
+    ///
+    /// Compared against the transcribed 3.7.0 loop rather than against
+    /// recorded constants: the same input has to produce the same `f64` on
+    /// whatever machine is running the test, and the two implementations
+    /// share the input samples, so a libm that rounds `sin` differently moves
+    /// both sides together. Exact equality, not a tolerance, because a
+    /// difference here means the filter itself moved, which is a separate
     /// decision needing its own discussion (the f32 variant, say).
     #[test]
-    fn true_peak_is_bit_identical_to_the_reference_values() {
-        let mut meter = TruePeakMeter::new(44100, 2);
-        let mut x = 0.123f64;
-        for _ in 0..44100 {
-            x = (x * 997.0).sin();
-            meter.add_frame(&[x, -0.5 * x]);
-        }
-        assert_eq!(meter.peak(), 1.7696673322779737);
+    fn true_peak_matches_the_previous_loop_exactly() {
+        for (rate, channels) in [(44100u32, 2usize), (96000, 1)] {
+            // Deterministic, and materialized once so both implementations
+            // see identical inputs.
+            let frames: Vec<[f64; 2]> = (0..rate as usize)
+                .map(|n| {
+                    let t = n as f64 / rate as f64;
+                    let l = 0.9 * (2.0 * std::f64::consts::PI * 997.0 * t).sin()
+                        + 0.1 * (2.0 * std::f64::consts::PI * 13_000.0 * t).sin();
+                    [l, -0.5 * l]
+                })
+                .collect();
 
-        // ≥ 88.2 kHz takes the 2× oversampling path, a different phase count.
-        let mut meter = TruePeakMeter::new(96000, 1);
-        let mut x = 0.123f64;
-        for _ in 0..96000 {
-            x = (x * 997.0).sin();
-            meter.add_frame(&[x]);
+            let mut meter = TruePeakMeter::new(rate, channels);
+            for frame in &frames {
+                meter.add_frame(&frame[..channels]);
+            }
+            assert_eq!(
+                meter.peak(),
+                reference_true_peak(rate, &frames, channels),
+                "{rate} Hz, {channels} channel(s)"
+            );
         }
-        assert_eq!(meter.peak(), 1.9725296121967306);
     }
 
     #[test]

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -226,19 +226,53 @@ fn gated_mean(energies: &[f64], gate: f64) -> Option<f64> {
 /// always ≥ the sample peak. Values above 1.0 are expected for lossy codecs
 /// that reconstruct above the sample grid.
 pub struct TruePeakMeter {
-    /// Polyphase sub-filters: `factor` phases of up to `TAPS/factor + 1`
-    /// coefficients each. `phases[p][k]` multiplies the input from `k`
-    /// samples ago.
-    phases: Vec<Vec<f64>>,
-    /// Per-channel input history, as a ring buffer indexed through
-    /// [`Self::pos`].
+    /// Polyphase coefficients, k-major: `coef[k * factor + p]` multiplies the
+    /// input from `k` frames ago in phase `p`. Since integer division gives
+    /// `(j / factor) * factor + j % factor == j`, that is simply the 49 taps
+    /// in their natural order, zero-padded so every phase is [`Self::taps`]
+    /// long. One pass over `k` then drives all phases at once and loads each
+    /// history sample once instead of once per phase (issue #334).
+    coef: Vec<f64>,
+    /// Oversampling factor, and therefore the number of phases: 4 below
+    /// 88.2 kHz, 2 above.
+    factor: usize,
+    /// Taps per phase, i.e. how far back the filter reaches.
+    taps: usize,
+    /// Per-channel input history, `2 * taps` long with every sample written
+    /// twice so the analysis window `history[pos..pos + taps]` is always
+    /// contiguous. The conditional wrap a plain ring buffer needs is what
+    /// stopped the inner loop from vectorizing (issue #334).
     history: Vec<Vec<f64>>,
-    /// Ring write position; steps backwards per frame so the sample written
-    /// `k` frames ago lives at `(pos + k) % len`. Replaces the per-sample
-    /// `rotate_right(1)` memmove the history used to pay on every frame of
-    /// every channel, the same trick `EqualLoudnessFilter` uses (issue #255).
+    /// Write position in the first half; steps backwards per frame so index
+    /// `k` ahead of it is the sample from `k` frames ago. Replaces the
+    /// per-sample `rotate_right(1)` memmove the history used to pay on every
+    /// frame of every channel, the same trick `EqualLoudnessFilter` uses
+    /// (issue #255).
     pos: usize,
     peak: f64,
+}
+
+/// The peak of all `F` polyphase outputs for one frame of one channel.
+///
+/// `F` is a const generic so the inner loop unrolls into `F` independent
+/// accumulators. That is the point of the whole restructure: a single `acc`
+/// per phase makes the loop run at FMA *latency*, because each add depends on
+/// the previous one, and nothing else can be in flight (issue #334).
+///
+/// Bit-identical to summing each phase separately: within a phase the terms
+/// are still added in ascending `k`, and `max` over the phases is order
+/// independent.
+#[inline]
+fn polyphase_peak<const F: usize>(coef: &[f64], window: &[f64]) -> f64 {
+    let mut acc = [0.0f64; F];
+    // `chunks_exact` plus zip keeps every index provably in range, so the
+    // inner loop is `F` bare multiply-adds with no bounds check between them.
+    for (&h, taps) in window.iter().zip(coef.chunks_exact(F)) {
+        for (a, &c) in acc.iter_mut().zip(taps) {
+            *a += c * h;
+        }
+    }
+    acc.iter().fold(0.0f64, |peak, a| peak.max(a.abs()))
 }
 
 impl TruePeakMeter {
@@ -246,8 +280,9 @@ impl TruePeakMeter {
 
     pub fn new(sample_rate: u32, channels: usize) -> Self {
         let factor: usize = if sample_rate >= 88_200 { 2 } else { 4 };
-        let mut phases = vec![Vec::new(); factor];
-        for j in 0..Self::TAPS {
+        let taps = Self::TAPS.div_ceil(factor);
+        let mut coef = vec![0.0; taps * factor];
+        for (j, c) in coef.iter_mut().enumerate().take(Self::TAPS) {
             let m = j as f64 - (Self::TAPS - 1) as f64 / 2.0;
             let sinc = if m.abs() > 1e-9 {
                 let x = m * std::f64::consts::PI / factor as f64;
@@ -257,12 +292,14 @@ impl TruePeakMeter {
             };
             let window = 0.5
                 * (1.0 - (2.0 * std::f64::consts::PI * j as f64 / (Self::TAPS - 1) as f64).cos());
-            phases[j % factor].push(sinc * window);
+            *c = sinc * window;
         }
-        let history_len = phases.iter().map(Vec::len).max().unwrap_or(0);
         Self {
-            phases,
-            history: vec![vec![0.0; history_len]; channels.max(1)],
+            coef,
+            factor,
+            taps,
+            // Doubled, so the window is contiguous wherever `pos` lands.
+            history: vec![vec![0.0; 2 * taps]; channels.max(1)],
             pos: 0,
             peak: 0.0,
         }
@@ -273,27 +310,32 @@ impl TruePeakMeter {
     /// ignored.
     #[inline]
     pub fn add_frame(&mut self, frame: &[f64]) {
-        let len = self.history.first().map_or(0, Vec::len);
-        if len == 0 {
+        let Self {
+            coef,
+            factor,
+            taps,
+            history,
+            pos,
+            peak,
+        } = self;
+        let taps = *taps;
+        if taps == 0 {
             return;
         }
         // Step the write position backwards so index `k` ahead of it is the
-        // sample from `k` frames ago, matching `phases[p][k]`'s meaning.
-        self.pos = (self.pos + len - 1) % len;
-        let pos = self.pos;
-        for (history, &sample) in self.history.iter_mut().zip(frame) {
-            history[pos] = sample;
-            for phase in &self.phases {
-                let mut acc = 0.0;
-                for (k, &c) in phase.iter().enumerate() {
-                    // `phase.len() <= len`, so one conditional subtraction
-                    // wraps the index.
-                    let idx = pos + k;
-                    let idx = if idx >= len { idx - len } else { idx };
-                    acc += c * history[idx];
-                }
-                self.peak = self.peak.max(acc.abs());
-            }
+        // sample from `k` frames ago, matching `coef[k * factor + p]`.
+        *pos = (*pos + taps - 1) % taps;
+        let start = *pos;
+        for (history, &sample) in history.iter_mut().zip(frame) {
+            // Written twice, `taps` apart, so the window below never wraps.
+            history[start] = sample;
+            history[start + taps] = sample;
+            let window = &history[start..start + taps];
+            let frame_peak = match *factor {
+                2 => polyphase_peak::<2>(coef, window),
+                _ => polyphase_peak::<4>(coef, window),
+            };
+            *peak = peak.max(frame_peak);
         }
     }
 
@@ -610,6 +652,32 @@ mod tests {
         }
         let expected = crate::gain::db_to_linear(-6.0);
         assert!((meter.peak() - expected).abs() / expected < 0.01);
+    }
+
+    /// The #334 restructure changed the memory layout and the loop shape of
+    /// the polyphase filter, not its design, so its output has to stay
+    /// bit-identical. These two values were produced by the 3.7.0
+    /// implementation and are asserted exactly, not within a tolerance: a
+    /// change here means the filter itself moved, which is a different
+    /// decision needing its own discussion (the f32 variant, say).
+    #[test]
+    fn true_peak_is_bit_identical_to_the_reference_values() {
+        let mut meter = TruePeakMeter::new(44100, 2);
+        let mut x = 0.123f64;
+        for _ in 0..44100 {
+            x = (x * 997.0).sin();
+            meter.add_frame(&[x, -0.5 * x]);
+        }
+        assert_eq!(meter.peak(), 1.7696673322779737);
+
+        // ≥ 88.2 kHz takes the 2× oversampling path, a different phase count.
+        let mut meter = TruePeakMeter::new(96000, 1);
+        let mut x = 0.123f64;
+        for _ in 0..96000 {
+            x = (x * 997.0).sin();
+            meter.add_frame(&[x]);
+        }
+        assert_eq!(meter.peak(), 1.9725296121967306);
     }
 
     #[test]

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -1237,6 +1237,12 @@ fn analyze_track_decoded(
     mode: AnalysisMode,
     true_peak: bool,
 ) -> Result<TrackAnalysisInternal> {
+    // Whether to run the decode and the analysis on separate threads
+    // (issue #337). Keyed on the rayon pool because that is what `-j` sizes:
+    // `-j 1` is documented as the single-threaded legacy path and must stay
+    // one thread, and a library caller that never installs a pool gets the
+    // machine's parallelism, which is the right default for it too.
+    let pipeline = rayon::current_num_threads() > 1;
     // Detect file type
     let file_type = detect_file_type(file_path);
 
@@ -1353,37 +1359,57 @@ fn analyze_track_decoded(
     };
     let mut peak: f64 = 0.0;
 
-    // Process all packets
-    loop {
-        let packet = match format.next_packet() {
-            Ok(Some(p)) => p,
-            Ok(None) => break,
-            Err(e) => return Err(Error::Decode(Box::new(e))),
-        };
-
-        if packet.track_id != track_id {
-            continue;
+    // Decode and analysis on separate threads (issue #337). The bitstream
+    // decode is inherently serial, but the DSP behind it is over half the
+    // cost once true peak is on, and the two overlap perfectly: the analyzer
+    // still sees every frame in order, so the result is bit-identical.
+    match (&mut track_analyzer, pipeline) {
+        (TrackAnalyzer::Bs1770 { analyzer }, true) => {
+            peak = peak.max(decode_pipelined(
+                &mut format,
+                decoder.as_mut(),
+                track_id,
+                channels,
+                analyzer,
+                progress,
+                position_tracker.as_ref(),
+                file_size,
+            )?);
         }
+        (track_analyzer, _) => {
+            // Process all packets
+            loop {
+                let packet = match format.next_packet() {
+                    Ok(Some(p)) => p,
+                    Ok(None) => break,
+                    Err(e) => return Err(Error::Decode(Box::new(e))),
+                };
 
-        let decoded = match decoder.decode(&packet) {
-            Ok(d) => d,
-            Err(symphonia::core::errors::Error::DecodeError(_)) => continue,
-            Err(e) => return Err(Error::Decode(Box::new(e))),
-        };
+                if packet.track_id != track_id {
+                    continue;
+                }
 
-        // Process audio buffer
-        match &mut track_analyzer {
-            TrackAnalyzer::Rg1 { filters, analyzer } => {
-                process_audio_buffer(&decoded, filters, analyzer, &mut peak)
+                let decoded = match decoder.decode(&packet) {
+                    Ok(d) => d,
+                    Err(symphonia::core::errors::Error::DecodeError(_)) => continue,
+                    Err(e) => return Err(Error::Decode(Box::new(e))),
+                };
+
+                // Process audio buffer
+                match track_analyzer {
+                    TrackAnalyzer::Rg1 { filters, analyzer } => {
+                        process_audio_buffer(&decoded, filters, analyzer, &mut peak)
+                    }
+                    TrackAnalyzer::Bs1770 { analyzer } => {
+                        process_audio_buffer_bs1770(&decoded, analyzer, &mut peak)
+                    }
+                }
+
+                // Report progress
+                if let (Some(cb), Some(ref tracker)) = (progress, &position_tracker) {
+                    cb(tracker.load(Ordering::Relaxed), file_size);
+                }
             }
-            TrackAnalyzer::Bs1770 { analyzer } => {
-                process_audio_buffer_bs1770(&decoded, analyzer, &mut peak)
-            }
-        }
-
-        // Report progress
-        if let (Some(cb), Some(ref tracker)) = (progress, &position_tracker) {
-            cb(tracker.load(Ordering::Relaxed), file_size);
         }
     }
 
@@ -1702,6 +1728,163 @@ fn process_audio_buffer_bs1770(
             // Unsupported format, skip
         }
     }
+}
+
+/// Append one decoded buffer to `out` as interleaved f64, for the pipelined
+/// path.
+///
+/// The conversions are the ones [`process_audio_buffer_bs1770`] applies, and
+/// interleaving preserves frame order, so the analyzer on the other side of
+/// the channel sees exactly the same values in the same order.
+#[cfg(feature = "replaygain")]
+fn append_interleaved(buffer: &GenericAudioBufferRef, out: &mut Vec<f64>) {
+    fn append<T: Copy>(
+        planes: &[&[T]],
+        frames: usize,
+        conv: impl Fn(T) -> f64,
+        out: &mut Vec<f64>,
+    ) {
+        out.reserve(frames * planes.len());
+        for frame in 0..frames {
+            for plane in planes {
+                out.push(conv(plane[frame]));
+            }
+        }
+    }
+    match buffer {
+        GenericAudioBufferRef::F32(buf) => {
+            let planes: Vec<&[f32]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            append(&planes, buf.frames(), |s| s as f64, out);
+        }
+        GenericAudioBufferRef::S16(buf) => {
+            let planes: Vec<&[i16]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            append(
+                &planes,
+                buf.frames(),
+                |s| s as f64 / SAMPLE_SCALE_16BIT,
+                out,
+            );
+        }
+        GenericAudioBufferRef::S32(buf) => {
+            let planes: Vec<&[i32]> = (0..buf.num_planes())
+                .map(|i| buf.plane(i).unwrap())
+                .collect();
+            append(
+                &planes,
+                buf.frames(),
+                |s| s as f64 / SAMPLE_SCALE_32BIT,
+                out,
+            );
+        }
+        _ => {}
+    }
+}
+
+/// Feed interleaved frames to the BS.1770 analyzer, the receiving half of
+/// [`buffer_to_interleaved`].
+#[cfg(feature = "replaygain")]
+fn analyze_interleaved(
+    samples: &[f64],
+    channels: usize,
+    analyzer: &mut crate::bs1770::Bs1770Analyzer,
+    peak: &mut f64,
+) {
+    for frame in samples.chunks_exact(channels) {
+        for &v in frame {
+            *peak = peak.max(v.abs());
+        }
+        analyzer.add_frame(frame);
+    }
+}
+
+/// Decode on this thread and analyze on another, returning the sample peak
+/// (issue #337).
+///
+/// The bitstream decode cannot be parallelized, but the DSP behind it is over
+/// half the cost once true peak is on, so overlapping the two takes a file
+/// from decode-plus-DSP down to the larger of the two. The analyzer still
+/// receives every frame exactly once and in order, so this is not an
+/// approximation: the result is bit-identical to the serial path.
+#[cfg(feature = "replaygain")]
+#[allow(clippy::too_many_arguments)]
+fn decode_pipelined(
+    format: &mut Box<dyn symphonia::core::formats::FormatReader>,
+    decoder: &mut dyn symphonia::core::codecs::audio::AudioDecoder,
+    track_id: u32,
+    channels: usize,
+    analyzer: &mut crate::bs1770::Bs1770Analyzer,
+    progress: Option<&dyn Fn(u64, u64)>,
+    tracker: Option<&Arc<AtomicU64>>,
+    file_size: u64,
+) -> Result<f64> {
+    // Batched rather than one packet per send. A handoff per 26 ms packet
+    // costs more in channel wakeups and allocator traffic than the overlap
+    // buys back; batching to roughly a second of audio makes the sync cost
+    // disappear while the batch still fits comfortably in cache.
+    const BATCH_SAMPLES: usize = 64 * 1024;
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<f64>>(2);
+    // Buffers travel back for reuse, so a long file does not allocate one
+    // per batch.
+    let (recycle_tx, recycle_rx) = std::sync::mpsc::channel::<Vec<f64>>();
+
+    std::thread::scope(|scope| {
+        let worker = scope.spawn(move || {
+            let mut peak = 0.0f64;
+            for mut samples in rx {
+                analyze_interleaved(&samples, channels, analyzer, &mut peak);
+                samples.clear();
+                // The decoder may already have finished; dropping is fine.
+                let _ = recycle_tx.send(samples);
+            }
+            peak
+        });
+
+        let mut decode = || -> Result<()> {
+            let mut batch: Vec<f64> = Vec::with_capacity(BATCH_SAMPLES);
+            loop {
+                let packet = match format.next_packet() {
+                    Ok(Some(p)) => p,
+                    Ok(None) => break,
+                    Err(e) => return Err(Error::Decode(Box::new(e))),
+                };
+                if packet.track_id != track_id {
+                    continue;
+                }
+                let decoded = match decoder.decode(&packet) {
+                    Ok(d) => d,
+                    Err(symphonia::core::errors::Error::DecodeError(_)) => continue,
+                    Err(e) => return Err(Error::Decode(Box::new(e))),
+                };
+                append_interleaved(&decoded, &mut batch);
+                if batch.len() >= BATCH_SAMPLES {
+                    // A send error means the analysis thread is gone, which
+                    // only happens if it panicked; the join below reports it.
+                    if tx.send(std::mem::take(&mut batch)).is_err() {
+                        return Ok(());
+                    }
+                    batch = recycle_rx
+                        .try_recv()
+                        .unwrap_or_else(|_| Vec::with_capacity(BATCH_SAMPLES));
+                }
+                if let (Some(cb), Some(tracker)) = (progress, tracker) {
+                    cb(tracker.load(Ordering::Relaxed), file_size);
+                }
+            }
+            if !batch.is_empty() {
+                let _ = tx.send(batch);
+            }
+            Ok(())
+        };
+        let outcome = decode();
+        // Closing the channel is what ends the worker's loop.
+        drop(tx);
+        let peak = worker.join().expect("analysis thread panicked");
+        outcome.map(|()| peak)
+    })
 }
 
 /// Byte-level progress callback: `(file_index, bytes_read, total_bytes)`.

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -730,6 +730,42 @@ fn per_directory_output_is_identical_whatever_the_thread_count() {
     }
 }
 
+/// The decode and the analysis run on separate threads once `-j` allows it
+/// (issue #337). The analyzer still sees every frame once and in order, so
+/// this has to be byte-identical to the single-threaded path, not merely
+/// close. `--true-peak` is the case that actually exercises it, being over
+/// half the analysis cost.
+#[test]
+fn pipelined_analysis_matches_the_single_threaded_path() {
+    let album = TempAlbum::new(&[
+        "test_mono.mp3",
+        "test_stereo.mp3",
+        "test_vbr.mp3",
+        "test_joint_stereo.mp3",
+        "test_aac.m4a",
+    ]);
+    for mode in [
+        vec!["--rg2", "--true-peak"],
+        vec!["--r128", "--true-peak"],
+        vec!["--rg2"],
+    ] {
+        for command in [vec!["-r"], vec!["-a"]] {
+            let render = |jobs: &'static str| {
+                let mut args = command.clone();
+                args.extend_from_slice(&mode);
+                args.extend_from_slice(&["-n", "-o", "json", "-j", jobs]);
+                args.extend(album.args());
+                stdout_of(&run(&args))
+            };
+            assert_eq!(
+                render("1"),
+                render("4"),
+                "{command:?} {mode:?} differs between -j 1 and -j 4"
+            );
+        }
+    }
+}
+
 #[test]
 fn per_directory_requires_album_mode() {
     for flag in ["--per-directory", "--album-by=tag"] {


### PR DESCRIPTION
Addresses part of #337. **Does not close it** — the remaining half is described at the bottom.

Stacked on #340, so review that first; the diff here is the last two commits.

## Re-measurement first

Both #334 and #337 said to re-measure before designing, since #334 removes two thirds of the per-file cost. Done, on the corpus from #337 (6 albums of 6 tracks, ragged lengths 240/300/360/420/300/540 s, 3.6 h of audio), pooled into one album so no album barrier is in the picture:

| `-j` | 3.7.0 | with #340 | efficiency then | efficiency now |
|---|---|---|---|---|
| 1 | 36.60 s | 22.39 s | 100% | 100% |
| 2 | 20.45 s | 11.37 s | 89% | 98% |
| 4 | 11.99 s | 6.67 s | 76% | 84% |
| 8 | 10.22 s | 5.53 s | 45% | 51% |

#340 improved the scaling as well as the absolute numbers. What is left at `-j 4` is 1.07 s of loss on a 6.67 s run, and the longest track in the corpus is 0.93 s of single-thread wall time, so the remaining loss is the tail, exactly as #337 diagnosed.

The sharper case is one file. `-r --rg2 --true-peak` on a single 9 minute track took 0.94 s at `-j 1`, 0.92 s at `-j 4` and 0.93 s at `-j 8`: `-j` did nothing at all, because the work unit was the whole file.

## What this PR does

Moves the DSP off the decode thread. The bitstream decode cannot be parallelized, but with true peak on, a 10 minute 44.1 kHz file splits into roughly 0.46 s of decode plus conversion and 0.59 s of analysis, so overlapping the two takes it from the sum down to the larger.

The analyzer still receives every frame exactly once and in order, so this is **not an approximation**: no chunk boundaries, no warm-up, no tolerance to state. Output is byte-identical.

Batching is what makes it pay. One 26 ms packet per handoff costs more in channel wakeups and allocator traffic than the overlap buys back, and only reached 1.25x. Batching to about a second of audio, with the buffers travelling back through a second channel for reuse, reaches 1.42x.

| Workload | before | after | |
|---|---|---|---|
| one 10 min file, `-r --rg2 --true-peak` | 1.05 s | **0.74 s** | 1.42x |
| 36 files / 3.6 h, `-a --rg2 --true-peak -j 4` | 6.33 s | 5.82 s | 1.09x |
| 36 files / 3.6 h, `-a --rg2 --true-peak -j 8` | 5.34 s | 5.23 s | 1.02x |
| one 10 min file, `-j 1` | 1.05 s | 1.05 s | unchanged |

`-j 1` is documented as the single-threaded legacy path, so the pipeline is keyed on the rayon pool size and stays off there. Measured: `-j 1` uses 1.04 s of user time for 1.05 s of wall time, one core. Above `-j 1` it costs about 7% more CPU for 30% less wall time on a single file, and it does not hurt a run that already saturates the pool.

## Verification

- Byte-identical `-o json` against the #340 binary on MP3 and M4A at 44.1, 48 and 96 kHz, at both `-j 1` and `-j 8`, for `-r` and `-a`.
- New test asserting `-o json` is identical between `-j 1` and `-j 4` for `--rg2 --true-peak`, `--r128 --true-peak` and `--rg2`, on both `-r` and `-a`.
- `cargo test` 228 passed, `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

## What is left in #337

The decode is still whole-file, so one file is now decode-bound instead of decode-plus-DSP bound. The ceiling for a single file is the decode, around 0.46 s of the current 0.74 s.

Going past that means splitting the decode itself, which needs container-level seeking. I probed it:

- MP3 works. `n_frames` is reported, and an accurate seek to 100 s lands at a known 1,249 samples *before* the target, so a chunk can decode forward to its exact start.
- Some M4A does not. A 96 kHz HE-AAC file here reports `n_frames = None`, and its sample rate and time base disagree, so there is nothing to divide into chunks.

So a correct implementation needs a fallback to the whole-file path and a way for each chunk to verify it landed exactly where it expected, because the failure mode is silently wrong loudness values written into people's tags. That is a bigger and riskier change than this one, and I did not want to land it half-understood in the same pass. #337 stays open with these findings.

Refs #337
