### PR TITLE
perf: divide a long track across workers (#337)

### DIFF
--- a/docs/perf-parallel.md
+++ b/docs/perf-parallel.md
@@ -268,9 +268,52 @@ Batching matters. Handing one 26 ms packet across the channel at a time costs mo
 
 The work unit is still a whole file for the *decode*, so one file is now decode-bound rather than decode-plus-DSP bound. Going further means splitting the decode itself across workers, which needs container-level seeking: on MP3 that works (`n_frames` is reported and an accurate seek lands a known distance before the target, 1,249 samples in the case measured), but some M4A files report no frame count at all, so a correct implementation needs a fallback and a way to verify each chunk landed exactly where it expected. [#337] stays open for that.
 
+## Dividing one file across workers (3.8, issue [#337])
+
+Overlapping the decode with the analysis left a single file decode-bound. Going past that means splitting the decode, which needs container-level seeking.
+
+A track is divided at 100 ms sub-block boundaries. Each piece seeks to its start minus a one-second warm-up region, decodes forward, runs the filters through the warm-up without accumulating, and then measures its own sub-block sums and peaks. The pieces' sums are concatenated in order and the 400 ms gating blocks are formed from the whole list afterwards, so a block straddling a piece boundary is neither lost nor counted twice.
+
+| Workload | before | after | |
+|---|---|---|---|
+| one 10 min file, `-r --rg2 --true-peak -j 8` | 0.74 s | **0.26 s** | 2.8x |
+| the same at `-j 4` | 0.73 s | **0.35 s** | 2.1x |
+| the same at `-j 2` | 0.74 s | 0.58 s | 1.3x |
+| the same at `-j 1` | 1.04 s | 1.06 s | unchanged by design |
+| 36 files / 3.6 h, `-a --rg2 --true-peak -j 4` | 5.44 s | 5.38 s | unchanged, not divided |
+
+Against the `-j 1` baseline of 1.04 s, a single file now runs 4.0x faster at `-j 8`, where before this change `-j` did nothing at all for one file.
+
+### When a file is divided
+
+Only when the run as a whole has fewer files than threads. A run with a file per thread already has every core busy, and dividing there costs the warm-up regions and the seeks for no gain: measured at 23% *slower* at `-j 4` on the 36-file corpus before this gate was added. The decision is made once for the whole run rather than per album, since six albums of six files saturate the pool just as thoroughly as one list of thirty-six.
+
+Also only for `--rg2` and `--r128`. RG1's equal-loudness filter is a 10th-order Yule-Walker IIR that settles far more slowly than the two biquads of K-weighting, and RG1 is the mp3gain-compatible path where the values have to match bit for bit. RG1 without true peak is already decode-bound at about 880x realtime, so leaving it whole costs nothing.
+
+### When a file is not divided
+
+Every check that cannot be satisfied falls back to the whole-file pass, because the failure mode is a wrong loudness value written into someone's tags:
+
+- No frame count. Some M4A reports none: a 96 kHz HE-AAC file here reports `n_frames = None`.
+- A time base that is not 1/sample_rate, so there is no sample index to divide. The same HE-AAC file reports a 96 kHz base against a 48 kHz rate.
+- A seek that overshoots the piece's first wanted sample, which would leave a hole in the measurement.
+- A piece that produced fewer sub-blocks than the plan said it owed, which means the plan and the file disagree.
+
+### Accuracy
+
+Not bit-identical, unlike [#334] and [#341], and this is the one place in the analysis where that is true.
+
+Each piece starts its filters from zero and converges during the warm-up. The K-weighting's slowest pole is the 38 Hz high-pass, radius about 0.995 at 44.1 kHz, so a second of warm-up leaves a state error around 1e-100 relative. That is far below f64 resolution, but it can still flip the last bit of the filter state, and that carries through to the reported loudness.
+
+Measured worst case over MP3 and AAC corpora: **7.1e-15 dB**. MP3 was exact in most runs; AAC differed by one or two ulp. The tests assert agreement within 1e-9 dB, six orders of margin over the observed worst case, which would still catch a misaligned piece or a dropped block.
+
+True peak has no tolerance to spend: the 49-tap FIR reaches back 48 samples, and the warm-up feeds the meter the real preceding samples, so its history at a piece boundary is exact. The peak is asserted byte-equal.
+
 [#125]: https://github.com/M-Igashi/mp3rgain/issues/125
 [#126]: https://github.com/M-Igashi/mp3rgain/issues/126
 
 [#332]: https://github.com/M-Igashi/mp3rgain/issues/332
 [#334]: https://github.com/M-Igashi/mp3rgain/issues/334
 [#337]: https://github.com/M-Igashi/mp3rgain/issues/337
+[#334]: https://github.com/M-Igashi/mp3rgain/issues/334
+[#341]: https://github.com/M-Igashi/mp3rgain/pull/341

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -181,6 +181,26 @@ impl BlockEnergies {
         self.energies.extend_from_slice(&other.energies);
     }
 
+    /// Form the 400 ms gating blocks from a track's 100 ms sub-block sums.
+    ///
+    /// A block is four consecutive sub-blocks, so consecutive blocks overlap
+    /// by 75%, and a trailing partial sub-block is not in the list at all: the
+    /// spec measures only complete blocks.
+    ///
+    /// Taking the sums as input rather than folding blocks as they complete is
+    /// what lets one track be analyzed in several pieces (issue #337). A block
+    /// straddling a piece boundary is formed here, from the concatenation, so
+    /// it is not lost and not counted twice.
+    pub fn from_subblock_sums(sums: &[f64], subblock_len: usize) -> Self {
+        let divisor = (4 * subblock_len) as f64;
+        Self {
+            energies: sums
+                .windows(4)
+                .map(|window| window.iter().sum::<f64>() / divisor)
+                .collect(),
+        }
+    }
+
     /// Integrated loudness in LUFS after absolute and relative gating.
     ///
     /// Returns `f64::NEG_INFINITY` when no block survives the gates
@@ -362,11 +382,11 @@ pub struct Bs1770Analyzer {
     /// Weighted sum of squares accumulating in the current sub-block.
     subblock_sum: f64,
     subblock_samples: usize,
-    /// Sums of the last up-to-3 completed sub-blocks, oldest first; a gating
-    /// block is these plus the sub-block that just completed (75% overlap).
-    recent: [f64; 3],
-    recent_len: usize,
-    blocks: BlockEnergies,
+    /// One weighted sum of squares per completed 100 ms sub-block. The gating
+    /// blocks are formed from this at the end rather than as each sub-block
+    /// completes, so a track analyzed in pieces can concatenate the pieces'
+    /// sums and get the same blocks (issue #337).
+    subblock_sums: Vec<f64>,
 }
 
 impl Bs1770Analyzer {
@@ -381,9 +401,7 @@ impl Bs1770Analyzer {
             subblock_len: (sample_rate as usize + 5) / 10,
             subblock_sum: 0.0,
             subblock_samples: 0,
-            recent: [0.0; 3],
-            recent_len: 0,
-            blocks: BlockEnergies::new(),
+            subblock_sums: Vec::new(),
         }
     }
 
@@ -421,26 +439,45 @@ impl Bs1770Analyzer {
         }
     }
 
-    fn finish_subblock(&mut self) {
-        let sum = self.subblock_sum;
-        if self.recent_len == 3 {
-            let block_sum = self.recent.iter().sum::<f64>() + sum;
-            self.blocks
-                .energies
-                .push(block_sum / (4 * self.subblock_len) as f64);
-            self.recent.rotate_left(1);
-            self.recent[2] = sum;
-        } else {
-            self.recent[self.recent_len] = sum;
-            self.recent_len += 1;
+    /// Advance the filter state without accumulating anything.
+    ///
+    /// A chunk of a track feeds the samples before its first wanted one
+    /// through here (issue #337): the K-weighting biquads and the true-peak
+    /// FIR history converge to the state the whole-file pass would have had,
+    /// while the sub-block sums stay owned by whichever chunk the samples
+    /// actually belong to. The peaks are deliberately still updated, since a
+    /// maximum over a superset of the file's samples is the same maximum.
+    #[inline]
+    pub fn warm_up_frame(&mut self, frame: &[f64]) {
+        if let Some(meter) = &mut self.true_peak {
+            meter.add_frame(frame);
         }
+        for (filter, &sample) in self.filters.iter_mut().zip(frame) {
+            filter.process(sample);
+        }
+    }
+
+    fn finish_subblock(&mut self) {
+        self.subblock_sums.push(self.subblock_sum);
         self.subblock_sum = 0.0;
         self.subblock_samples = 0;
     }
 
+    /// Samples per 100 ms sub-block, which a caller analyzing a track in
+    /// pieces needs in order to align the pieces to the same grid.
+    pub fn subblock_len(&self) -> usize {
+        self.subblock_len
+    }
+
     /// Finish analysis, returning the gating blocks for this track.
     pub fn into_blocks(self) -> BlockEnergies {
-        self.blocks
+        BlockEnergies::from_subblock_sums(&self.subblock_sums, self.subblock_len)
+    }
+
+    /// The per-sub-block sums instead of the blocks, for a caller that will
+    /// concatenate several pieces of one track before gating (issue #337).
+    pub fn into_subblock_sums(self) -> Vec<f64> {
+        self.subblock_sums
     }
 }
 

--- a/src/bs1770.rs
+++ b/src/bs1770.rs
@@ -363,6 +363,18 @@ impl TruePeakMeter {
     pub fn peak(&self) -> f64 {
         self.peak
     }
+
+    /// Forget the maximum, keeping the filter history.
+    ///
+    /// A chunk of a track calls this once its warm-up ends (issue #337).
+    /// Until then the history is still partly the zeros it started with, and
+    /// an interpolator fed a step from silence overshoots: the values it
+    /// reports during warm-up are an artifact of the cold start, not peaks the
+    /// signal ever reaches. After 48 real samples the history is entirely real
+    /// and everything from there is exact.
+    pub fn reset_peak(&mut self) {
+        self.peak = 0.0;
+    }
 }
 
 /// Streaming BS.1770 analyzer for one track.
@@ -417,6 +429,14 @@ impl Bs1770Analyzer {
     /// [`new_with_true_peak`](Self::new_with_true_peak).
     pub fn true_peak(&self) -> Option<f64> {
         self.true_peak.as_ref().map(TruePeakMeter::peak)
+    }
+
+    /// Discard the true peak measured so far, keeping the filter history; see
+    /// [`TruePeakMeter::reset_peak`].
+    pub fn reset_true_peak(&mut self) {
+        if let Some(meter) = &mut self.true_peak {
+            meter.reset_peak();
+        }
     }
 
     /// Add one frame of normalized samples (full scale = 1.0), one per
@@ -768,6 +788,38 @@ mod tests {
                 "{rate} Hz, {channels} channel(s)"
             );
         }
+    }
+
+    /// A cold interpolator overshoots. Fed a signal that starts from silence,
+    /// its output can exceed anything the signal itself reaches, because half
+    /// the 49-tap window is still the zeros it was initialized with.
+    ///
+    /// That is why a chunk of a track throws away what its meter measured
+    /// during the warm-up region (issue #337): those values are an artifact of
+    /// the cold start, and reporting one as the track's true peak is how a
+    /// divided run came out 19% high on Windows before this was fixed.
+    #[test]
+    fn true_peak_overshoots_from_a_cold_start() {
+        let level = 0.5;
+        // Alternating sign is what the interpolator responds to most strongly.
+        let mut meter = TruePeakMeter::new(44100, 1);
+        for n in 0..24 {
+            meter.add_frame(&[if n % 2 == 0 { level } else { -level }]);
+        }
+        let cold = meter.peak();
+        assert!(
+            cold > level * 1.05,
+            "a cold start should overshoot, got {cold}"
+        );
+
+        // With the history entirely real, the same signal settles to a value
+        // the whole-file pass would also report.
+        meter.reset_peak();
+        for n in 24..4096 {
+            meter.add_frame(&[if n % 2 == 0 { level } else { -level }]);
+        }
+        let warm = meter.peak();
+        assert!(warm < cold, "warm {warm} should be below the cold {cold}");
     }
 
     #[test]

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -75,6 +75,11 @@ pub struct Options {
     // --album-by / --album-depth: with -a, what counts as one album
     // (issues #324, #331, #333). `--per-directory` aliases `--album-by=dir`.
     pub album_by: AlbumGrouping,
+    // Whether a long track may be divided across workers (issue #337). Set
+    // once per run from the file count against the thread count: a run that
+    // already has a file per thread gains nothing from dividing and pays for
+    // the warm-up regions and the seeks.
+    pub chunk_tracks: bool,
     // The path arguments as typed, before -R expanded them. `--album-depth`
     // counts levels from these, and `expand_files_recursive` is where the
     // provenance would otherwise be lost.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -43,7 +43,12 @@ pub fn run(mut opts: Options) -> Result<()> {
 
     // Configure the global rayon pool from -j / --threads / MP3RGAIN_THREADS.
     // Default is std::thread::available_parallelism(); -j 1 forces serial.
-    threading::install_global_pool(threading::effective_threads(&opts));
+    let threads = threading::effective_threads(&opts);
+    threading::install_global_pool(threads);
+    // Dividing a track across workers only pays when the pool would otherwise
+    // sit idle, which is decided by the whole run rather than by any one
+    // album or file (issue #337).
+    opts.chunk_tracks = threads > 1 && opts.files.len() < threads;
 
     // -f option warning (assume MPEG2)
     if opts.assume_mpeg2 && !opts.quiet && opts.output_format == OutputFormat::Text {

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -65,6 +65,7 @@ pub fn run_album_analysis(
             cancel: None,
             mode: opts.analysis_mode,
             true_peak: opts.true_peak,
+            chunk: opts.chunk_tracks,
         },
     );
 

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -93,7 +93,10 @@ pub fn analyze_track(
             track_index: opts.track_index,
             mode: opts.analysis_mode,
             true_peak: opts.true_peak,
-            on_progress: on_progress.as_ref().map(|cb| cb as &dyn Fn(u64, u64)),
+            chunk: opts.chunk_tracks,
+            on_progress: on_progress
+                .as_ref()
+                .map(|cb| cb as &(dyn Fn(u64, u64) + Sync)),
         },
     )
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -6,8 +6,8 @@
 //! once the Symphonia v0.6 decoder migration landed.
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::cell::Cell;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::cli::options::{Options, OutputFormat};
 
@@ -111,24 +111,27 @@ pub fn album_progress_callbacks<'a>(
     pb: &Option<ProgressBar>,
     file_names: Vec<&'a str>,
 ) -> (
-    impl Fn(usize, u64, u64) + 'a,
+    impl Fn(usize, u64, u64) + Sync + 'a,
     impl Fn(usize, &Path) + Sync + 'a,
 ) {
     let total = file_names.len();
     let pb_for_progress = pb.clone();
-    let last_message_idx: Cell<Option<usize>> = Cell::new(None);
+    // Atomic rather than `Cell` because a chunked analysis drives this from
+    // several worker threads (issue #337). `usize::MAX` stands in for "no file
+    // reported yet"; the value is only used to avoid re-allocating the same
+    // message.
+    let last_message_idx = AtomicUsize::new(usize::MAX);
     let on_progress = move |file_idx: usize, bytes: u64, total_bytes: u64| {
         if let Some(pb) = &pb_for_progress {
             pb.set_length(total_bytes);
             pb.set_position(bytes);
-            if last_message_idx.get() != Some(file_idx) {
+            if last_message_idx.swap(file_idx, Ordering::Relaxed) != file_idx {
                 pb.set_message(format!(
                     "({}/{}) {}",
                     file_idx + 1,
                     total,
                     file_names[file_idx]
                 ));
-                last_message_idx.set(Some(file_idx));
             }
         }
     };

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -2093,6 +2093,10 @@ fn analyze_chunk(
     let mut peak = 0.0f64;
     let mut samples: Vec<f64> = Vec::new();
     let mut position: Option<u64> = None;
+    // Whether the warm-up region is still running, and therefore whether the
+    // peaks measured so far have to be thrown away before the chunk's own
+    // range starts.
+    let mut warming = start > 0;
 
     loop {
         let packet = match format.next_packet() {
@@ -2132,14 +2136,24 @@ fn analyze_chunk(
                     subblock_sums: analyzer.into_subblock_sums(),
                 });
             }
+            if at < start {
+                analyzer.warm_up_frame(frame);
+                at += 1;
+                continue;
+            }
+            if warming {
+                // The history is now entirely real samples, so the meter is
+                // exact from here. What it reported while the history was
+                // still partly zeros is a cold-start artifact and would
+                // otherwise be reported as a peak the signal never reaches.
+                analyzer.reset_true_peak();
+                peak = 0.0;
+                warming = false;
+            }
             for &v in frame {
                 peak = peak.max(v.abs());
             }
-            if at < start {
-                analyzer.warm_up_frame(frame);
-            } else {
-                analyzer.add_frame(frame);
-            }
+            analyzer.add_frame(frame);
             at += 1;
         }
         position = Some(at);

--- a/src/replaygain.rs
+++ b/src/replaygain.rs
@@ -27,7 +27,7 @@ use symphonia::core::codecs::audio::{AudioDecoderOptions, CODEC_ID_NULL_AUDIO};
 #[cfg(feature = "replaygain")]
 use symphonia::core::formats::probe::Hint;
 #[cfg(feature = "replaygain")]
-use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::{FormatOptions, SeekMode, SeekTo};
 #[cfg(feature = "replaygain")]
 use symphonia::core::io::{MediaSource, MediaSourceStream};
 #[cfg(feature = "replaygain")]
@@ -1221,10 +1221,21 @@ enum TrackAnalyzer {
 fn analyze_track_internal(
     file_path: &Path,
     track_index: Option<u32>,
-    progress: Option<&dyn Fn(u64, u64)>,
+    progress: Option<&(dyn Fn(u64, u64) + Sync)>,
     mode: AnalysisMode,
     true_peak: bool,
+    chunk: bool,
 ) -> Result<TrackAnalysisInternal> {
+    // A long track is divided across workers when the caller says there is
+    // spare parallelism for it (issue #337); anything that makes the division
+    // untrustworthy falls through to the ordinary whole-file pass below.
+    if chunk {
+        if let Some(internal) =
+            analyze_track_chunked(file_path, track_index, progress, mode, true_peak)
+        {
+            return Ok(internal);
+        }
+    }
     analyze_track_decoded(file_path, track_index, progress, mode, true_peak)
         .map_err(|e| e.refine_format(file_path))
 }
@@ -1233,7 +1244,7 @@ fn analyze_track_internal(
 fn analyze_track_decoded(
     file_path: &Path,
     track_index: Option<u32>,
-    progress: Option<&dyn Fn(u64, u64)>,
+    progress: Option<&(dyn Fn(u64, u64) + Sync)>,
     mode: AnalysisMode,
     true_peak: bool,
 ) -> Result<TrackAnalysisInternal> {
@@ -1478,7 +1489,7 @@ pub fn analyze_track_with_mode(
     file_path: &Path,
     track_index: Option<u32>,
     mode: AnalysisMode,
-    on_progress: Option<&dyn Fn(u64, u64)>,
+    on_progress: Option<&(dyn Fn(u64, u64) + Sync)>,
 ) -> Result<ReplayGainResult> {
     analyze_track_with_options(
         file_path,
@@ -1508,7 +1519,16 @@ pub struct TrackAnalysisOptions<'a> {
     /// mp3gain's `MAX_AMPLITUDE` semantics and must stay bit-compatible.
     pub true_peak: bool,
     /// Byte-level progress callback, as in [`analyze_track_with_progress`].
-    pub on_progress: Option<&'a dyn Fn(u64, u64)>,
+    pub on_progress: Option<&'a (dyn Fn(u64, u64) + Sync)>,
+    /// Divide a long track across rayon workers instead of decoding it in one
+    /// pass (issue #337).
+    ///
+    /// Only worth setting when the pool has room, which is why it is the
+    /// caller's decision: a run that already has a file per thread gains
+    /// nothing and pays for the warm-up regions and the seeks. Ignored for
+    /// [`AnalysisMode::Rg1`] and for containers whose frame count or time base
+    /// cannot be trusted, which fall back to the whole-file pass.
+    pub chunk: bool,
 }
 
 /// Analyze a single track with the full option set (issue #292). The other
@@ -1524,6 +1544,7 @@ pub fn analyze_track_with_options(
         opts.on_progress,
         opts.mode,
         opts.true_peak,
+        opts.chunk,
     )?;
     Ok(internal.result)
 }
@@ -1538,7 +1559,7 @@ pub fn analyze_track_with_options(
 pub fn analyze_track_with_progress(
     file_path: &Path,
     track_index: Option<u32>,
-    on_progress: &dyn Fn(u64, u64),
+    on_progress: &(dyn Fn(u64, u64) + Sync),
 ) -> Result<ReplayGainResult> {
     analyze_track_with_mode(
         file_path,
@@ -1817,7 +1838,7 @@ fn decode_pipelined(
     track_id: u32,
     channels: usize,
     analyzer: &mut crate::bs1770::Bs1770Analyzer,
-    progress: Option<&dyn Fn(u64, u64)>,
+    progress: Option<&(dyn Fn(u64, u64) + Sync)>,
     tracker: Option<&Arc<AtomicU64>>,
     file_size: u64,
 ) -> Result<f64> {
@@ -1887,8 +1908,341 @@ fn decode_pipelined(
     })
 }
 
+// ============================================================================
+// Chunked single-track analysis (issue #337)
+// ============================================================================
+
+/// Minimum audio per chunk. Every chunk decodes a warm-up region it then
+/// throws away, so chunks much shorter than this spend a visible share of
+/// their time warming up.
+#[cfg(feature = "replaygain")]
+const CHUNK_MIN_SECS: usize = 30;
+
+/// Audio decoded before a chunk's first wanted sample and discarded.
+///
+/// A second is far more than any component needs. The 49-tap true-peak FIR
+/// reaches back 48 samples, so its history is exact well before the chunk
+/// starts. The K-weighting's slowest pole is the 38 Hz high-pass, radius about
+/// 0.9946 at 44.1 kHz, which leaves a state error near 1e-52 after a second,
+/// below anything f64 can represent. MP3's bit reservoir reaches back a
+/// handful of frames at most.
+#[cfg(feature = "replaygain")]
+const CHUNK_WARMUP_SECS: f64 = 1.0;
+
+/// How one track is divided for analysis.
+#[cfg(feature = "replaygain")]
+struct ChunkPlan {
+    sample_rate: u32,
+    channels: usize,
+    track_id: u32,
+    subblock_len: usize,
+    /// Sub-block ranges, contiguous and covering the whole track.
+    bounds: Vec<(usize, usize)>,
+}
+
+/// What one chunk measured.
+#[cfg(feature = "replaygain")]
+struct ChunkOutcome {
+    subblock_sums: Vec<f64>,
+    peak: f64,
+    true_peak: Option<f64>,
+}
+
+/// Decide how to divide `file_path`, or `None` when it cannot be divided.
+///
+/// Every reason to decline is a reason the sample grid cannot be trusted, and
+/// the caller falls back to analyzing the whole file in one pass. Silently
+/// dividing a file whose frame count or time base is a guess would write a
+/// wrong loudness value, which is worse than being slow.
+#[cfg(feature = "replaygain")]
+fn plan_chunks(file_path: &Path, track_index: Option<u32>, threads: usize) -> Option<ChunkPlan> {
+    let file = std::fs::File::open(file_path).ok()?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    let format = symphonia::default::get_probe()
+        .probe(
+            &hint,
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
+        .ok()?;
+
+    let audio_tracks: Vec<_> = format
+        .tracks()
+        .iter()
+        .filter(|t| {
+            t.codec_params
+                .as_ref()
+                .and_then(|p| p.audio())
+                .is_some_and(|a| a.codec != CODEC_ID_NULL_AUDIO)
+        })
+        .collect();
+    let track = match track_index {
+        Some(idx) => audio_tracks.get(idx as usize)?,
+        None => audio_tracks.first()?,
+    };
+
+    let audio = track.codec_params.as_ref()?.audio()?;
+    let sample_rate = audio.sample_rate?;
+    let channels = audio.channels.as_ref().map(|c| c.count()).unwrap_or(2);
+    // No frame count means no grid to divide. Common enough: HE-AAC in MP4
+    // reports none here.
+    let n_frames = track.num_frames?;
+    // The grid is in samples, so a time base that is not 1/sample_rate has no
+    // sample index to divide by. HE-AAC reports a 96 kHz base against a 48 kHz
+    // rate, for instance.
+    let time_base = track.time_base?;
+    if time_base.numer.get() != 1 || time_base.denom.get() != sample_rate {
+        return None;
+    }
+
+    let subblock_len = (sample_rate as usize + 5) / 10;
+    let total = n_frames as usize / subblock_len;
+    let min_per_chunk = CHUNK_MIN_SECS * 10;
+    let chunks = (total / min_per_chunk).min(threads);
+    if chunks < 2 {
+        return None;
+    }
+
+    let per = total.div_ceil(chunks);
+    let bounds: Vec<(usize, usize)> = (0..chunks)
+        .map(|i| (i * per, ((i + 1) * per).min(total)))
+        .filter(|(start, end)| start < end)
+        .collect();
+    (bounds.len() > 1).then_some(ChunkPlan {
+        sample_rate,
+        channels,
+        track_id: track.id,
+        subblock_len,
+        bounds,
+    })
+}
+
+/// Analyze one chunk of a track.
+///
+/// Seeks to a warm-up region before the chunk's first wanted sample, runs the
+/// filters through it without accumulating, then accumulates the chunk's own
+/// sub-block sums. The last chunk runs to end of file so the peaks cover the
+/// trailing samples that no complete sub-block contains, exactly as the
+/// whole-file pass does.
+#[cfg(feature = "replaygain")]
+fn analyze_chunk(
+    file_path: &Path,
+    plan: &ChunkPlan,
+    index: usize,
+    mode: AnalysisMode,
+    true_peak: bool,
+) -> Result<ChunkOutcome> {
+    let (start_sb, end_sb) = plan.bounds[index];
+    let start = (start_sb * plan.subblock_len) as u64;
+    let is_last = index + 1 == plan.bounds.len();
+    let end = (!is_last).then(|| (end_sb * plan.subblock_len) as u64);
+
+    let file = std::fs::File::open(file_path).map_err(|e| Error::io_open(file_path, e))?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    let mut format = symphonia::default::get_probe()
+        .probe(
+            &hint,
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
+        .map_err(|e| Error::ProbeFailed {
+            path: file_path.to_path_buf(),
+            source: Box::new(e),
+        })?;
+    let audio = format
+        .tracks()
+        .iter()
+        .find(|t| t.id == plan.track_id)
+        .and_then(|t| t.codec_params.as_ref())
+        .and_then(|p| p.audio())
+        .ok_or(Error::NoAudioTrack)?
+        .clone();
+    let mut decoder = symphonia::default::get_codecs()
+        .make_audio_decoder(&audio, &AudioDecoderOptions::default())
+        .map_err(|e| Error::Decode(Box::new(e)))?;
+
+    if start > 0 {
+        let warmup = (CHUNK_WARMUP_SECS * plan.sample_rate as f64) as u64;
+        let target = start.saturating_sub(warmup);
+        format
+            .seek(
+                SeekMode::Accurate,
+                SeekTo::Timestamp {
+                    ts: symphonia::core::units::Timestamp::new(target as i64),
+                    track_id: plan.track_id,
+                },
+            )
+            .map_err(|e| Error::Decode(Box::new(e)))?;
+    }
+
+    let mut analyzer = if true_peak && mode != AnalysisMode::Rg1 {
+        crate::bs1770::Bs1770Analyzer::new_with_true_peak(plan.sample_rate, plan.channels)
+    } else {
+        crate::bs1770::Bs1770Analyzer::new(plan.sample_rate, plan.channels)
+    };
+    let mut peak = 0.0f64;
+    let mut samples: Vec<f64> = Vec::new();
+    let mut position: Option<u64> = None;
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(Some(p)) => p,
+            Ok(None) => break,
+            Err(e) => return Err(Error::Decode(Box::new(e))),
+        };
+        if packet.track_id != plan.track_id {
+            continue;
+        }
+        let pts = packet.pts.get().max(0) as u64;
+        let decoded = match decoder.decode(&packet) {
+            Ok(d) => d,
+            Err(symphonia::core::errors::Error::DecodeError(_)) => continue,
+            Err(e) => return Err(Error::Decode(Box::new(e))),
+        };
+        // The first packet fixes where this chunk is reading from. Landing
+        // after the first wanted sample would leave a hole in the
+        // measurement, so refuse rather than measure the wrong range.
+        let mut at = match position {
+            None if pts > start => {
+                return Err(Error::Decode(Box::new(
+                    symphonia::core::errors::Error::Unsupported("seek overshot the chunk start"),
+                )))
+            }
+            None => pts,
+            Some(previous) => previous.max(pts),
+        };
+
+        samples.clear();
+        append_interleaved(&decoded, &mut samples);
+        for frame in samples.chunks_exact(plan.channels) {
+            if end.is_some_and(|end| at >= end) {
+                return Ok(ChunkOutcome {
+                    peak,
+                    true_peak: analyzer.true_peak(),
+                    subblock_sums: analyzer.into_subblock_sums(),
+                });
+            }
+            for &v in frame {
+                peak = peak.max(v.abs());
+            }
+            if at < start {
+                analyzer.warm_up_frame(frame);
+            } else {
+                analyzer.add_frame(frame);
+            }
+            at += 1;
+        }
+        position = Some(at);
+    }
+
+    Ok(ChunkOutcome {
+        peak,
+        true_peak: analyzer.true_peak(),
+        subblock_sums: analyzer.into_subblock_sums(),
+    })
+}
+
+/// Analyze one track by dividing it across workers, or `None` when it cannot
+/// be divided or the division did not come out as planned.
+///
+/// `None` always means "analyze this file the ordinary way instead", never
+/// "the file is broken": the caller falls back, so every check here can be
+/// conservative without costing anything but speed.
+#[cfg(feature = "replaygain")]
+fn analyze_track_chunked(
+    file_path: &Path,
+    track_index: Option<u32>,
+    progress: Option<&(dyn Fn(u64, u64) + Sync)>,
+    mode: AnalysisMode,
+    true_peak: bool,
+) -> Option<TrackAnalysisInternal> {
+    use rayon::prelude::*;
+
+    // RG1 is never divided. Its equal-loudness filter is a 10th-order
+    // Yule-Walker IIR whose settling time is far longer than the two biquads
+    // of K-weighting, and RG1 is the path whose values have to match mp3gain
+    // bit for bit. It is also already decode-bound, so there is nothing here
+    // to win.
+    if mode == AnalysisMode::Rg1 {
+        return None;
+    }
+    let threads = rayon::current_num_threads();
+    if threads < 2 {
+        return None;
+    }
+    let plan = plan_chunks(file_path, track_index, threads)?;
+
+    let file_size = std::fs::metadata(file_path).map(|m| m.len()).unwrap_or(0);
+    let finished = AtomicU64::new(0);
+    let total_chunks = plan.bounds.len() as u64;
+    let outcomes: Vec<Result<ChunkOutcome>> = (0..plan.bounds.len())
+        .into_par_iter()
+        .map(|i| {
+            let outcome = analyze_chunk(file_path, &plan, i, mode, true_peak);
+            // Chunk granularity, since a divided read has no single byte
+            // position to report.
+            if let Some(cb) = progress {
+                let done = finished.fetch_add(1, Ordering::Relaxed) + 1;
+                cb(done * file_size / total_chunks, file_size);
+            }
+            outcome
+        })
+        .collect();
+
+    let mut subblock_sums = Vec::new();
+    let mut peak = 0.0f64;
+    let mut measured_true_peak: Option<f64> = None;
+    for (i, outcome) in outcomes.into_iter().enumerate() {
+        let outcome = outcome.ok()?;
+        // Every chunk but the last owes an exact number of sub-blocks. A short
+        // count means the plan and the file disagree, which is exactly what
+        // the whole-file fallback is for.
+        let (start, end) = plan.bounds[i];
+        if i + 1 < plan.bounds.len() && outcome.subblock_sums.len() != end - start {
+            return None;
+        }
+        subblock_sums.extend(outcome.subblock_sums);
+        peak = peak.max(outcome.peak);
+        if let Some(tp) = outcome.true_peak {
+            measured_true_peak = Some(measured_true_peak.map_or(tp, |v: f64| v.max(tp)));
+        }
+    }
+
+    let blocks =
+        crate::bs1770::BlockEnergies::from_subblock_sums(&subblock_sums, plan.subblock_len);
+    let mut is_true_peak = false;
+    if let Some(tp) = measured_true_peak {
+        peak = peak.max(tp);
+        is_true_peak = true;
+    }
+    let (loudness_db, gain_db) = lufs_loudness_and_gain(blocks.integrated_lufs(), mode);
+    let mut result = ReplayGainResult::new(
+        loudness_db,
+        gain_db,
+        peak,
+        plan.sample_rate,
+        detect_file_type(file_path),
+        mode,
+    );
+    result.true_peak = is_true_peak;
+    Some(TrackAnalysisInternal {
+        result,
+        state: LoudnessState::Bs1770(blocks),
+    })
+}
+
 /// Byte-level progress callback: `(file_index, bytes_read, total_bytes)`.
-pub type AlbumProgressFn<'a> = &'a dyn Fn(usize, u64, u64);
+pub type AlbumProgressFn<'a> = &'a (dyn Fn(usize, u64, u64) + Sync);
 
 /// Per-file completion callback: `(file_index, path)`.
 pub type AlbumCompleteFn<'a> = &'a (dyn Fn(usize, &Path) + Sync);
@@ -1930,6 +2284,9 @@ pub struct AlbumAnalysisOptions<'a> {
     /// BS.1770 modes (issue #292); see [`TrackAnalysisOptions::true_peak`].
     /// Ignored in [`AnalysisMode::Rg1`].
     pub true_peak: bool,
+    /// Divide each track across rayon workers; see
+    /// [`TrackAnalysisOptions::chunk`].
+    pub chunk: bool,
 }
 
 /// Analyze multiple tracks for album gain (strict, serial, no callbacks).
@@ -1974,6 +2331,7 @@ fn analyze_album_serial(
         cancel,
         mode,
         true_peak,
+        chunk,
         ..
     } = *opts;
     let mut track_results = Vec::with_capacity(files.len());
@@ -1988,12 +2346,18 @@ fn analyze_album_serial(
             return Err(Error::Cancelled);
         }
         // Create a per-file progress callback that includes the file index
-        let file_progress: Option<Box<dyn Fn(u64, u64) + '_>> =
+        let file_progress: Option<Box<dyn Fn(u64, u64) + Sync + '_>> =
             on_progress.map(|cb| Box::new(move |bytes, total| cb(i, bytes, total)) as _);
 
         // Analyze each track and get its loudness state
-        let track =
-            analyze_track_internal(file, track_index, file_progress.as_deref(), mode, true_peak);
+        let track = analyze_track_internal(
+            file,
+            track_index,
+            file_progress.as_deref(),
+            mode,
+            true_peak,
+            chunk,
+        );
         if let Some(cb) = on_complete {
             cb(i, file);
         }
@@ -2044,6 +2408,7 @@ fn analyze_album_parallel_internal(
         cancel,
         mode,
         true_peak,
+        chunk,
         ..
     } = *opts;
 
@@ -2065,7 +2430,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None, mode, true_peak);
+                let r = analyze_track_internal(file, track_index, None, mode, true_peak, chunk);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -2099,7 +2464,7 @@ fn analyze_album_parallel_internal(
                 if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                     return Err(Error::Cancelled);
                 }
-                let r = analyze_track_internal(file, track_index, None, mode, true_peak);
+                let r = analyze_track_internal(file, track_index, None, mode, true_peak, chunk);
                 if let Some(cb) = on_complete {
                     cb(i, file);
                 }
@@ -2164,7 +2529,7 @@ pub fn analyze_track_with_mode(
     _file_path: &Path,
     _track_index: Option<u32>,
     _mode: AnalysisMode,
-    _on_progress: Option<&dyn Fn(u64, u64)>,
+    _on_progress: Option<&(dyn Fn(u64, u64) + Sync)>,
 ) -> Result<ReplayGainResult> {
     Err(Error::FeatureNotAvailable {
         feature: "ReplayGain analysis",
@@ -2187,7 +2552,7 @@ pub fn analyze_track_with_options(
 pub fn analyze_track_with_progress(
     _file_path: &Path,
     _track_index: Option<u32>,
-    _on_progress: &dyn Fn(u64, u64),
+    _on_progress: &(dyn Fn(u64, u64) + Sync),
 ) -> Result<ReplayGainResult> {
     Err(Error::FeatureNotAvailable {
         feature: "ReplayGain analysis",
@@ -2413,6 +2778,47 @@ pub fn find_peak_amplitude_in_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The planner is what decides whether a track is divided at all, so the
+    /// value comparisons elsewhere would be vacuous if it quietly declined
+    /// every file. This asserts it engages, and that the ranges it produces
+    /// tile the track without a gap or an overlap (issue #337).
+    #[cfg(feature = "replaygain")]
+    #[test]
+    fn plan_chunks_divides_a_long_track_and_leaves_a_short_one_alone() {
+        let short = Path::new("tests/fixtures/test_stereo.mp3");
+        let fixture = std::fs::read(short).expect("fixture");
+        let dir = std::env::temp_dir().join(format!("mp3rgain_chunkplan_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let long = dir.join("long.mp3");
+        // MP3 frames concatenate, so repeating a one-second fixture makes a
+        // two-minute track without an encoder in the test. The ID3 tag and the
+        // leading Xing/Info frame have to go: they declare a one-second frame
+        // count, which the planner would believe over the file itself.
+        let id3_len = {
+            let s = &fixture[6..10];
+            10 + (((s[0] & 0x7f) as usize) << 21
+                | ((s[1] & 0x7f) as usize) << 14
+                | ((s[2] & 0x7f) as usize) << 7
+                | (s[3] & 0x7f) as usize)
+        };
+        // 320 kbps at 44.1 kHz is a 1044-byte frame, plus one padding byte.
+        let body = &fixture[id3_len + 1045..];
+        std::fs::write(&long, body.repeat(120)).expect("write");
+
+        let plan = plan_chunks(&long, None, 4).expect("two minutes divides four ways");
+        assert_eq!(plan.bounds.len(), 4);
+        assert_eq!(plan.bounds[0].0, 0, "the first chunk starts at the start");
+        for pair in plan.bounds.windows(2) {
+            assert_eq!(pair[0].1, pair[1].0, "chunks must tile the track");
+        }
+
+        // One second is far below the minimum chunk length, so it stays whole
+        // rather than being divided into pieces that are mostly warm-up.
+        assert!(plan_chunks(short, None, 4).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn test_replaygain_availability() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -730,6 +730,86 @@ fn per_directory_output_is_identical_whatever_the_thread_count() {
     }
 }
 
+/// Write a two-minute MP3 built by repeating a one-second fixture's frames.
+///
+/// MP3 frames concatenate, so this needs no encoder. The ID3 tag and the
+/// leading Xing/Info frame are dropped because they declare a one-second frame
+/// count, and a track that claims to be one second long is never divided.
+fn write_long_mp3(dst: &Path) {
+    let fixture = fs::read("tests/fixtures/test_stereo.mp3").expect("fixture");
+    let size = &fixture[6..10];
+    let id3_len = 10
+        + (((size[0] & 0x7f) as usize) << 21
+            | ((size[1] & 0x7f) as usize) << 14
+            | ((size[2] & 0x7f) as usize) << 7
+            | (size[3] & 0x7f) as usize);
+    // 320 kbps at 44.1 kHz is a 1044-byte frame, plus one padding byte.
+    let body = &fixture[id3_len + 1045..];
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::write(dst, body.repeat(120)).expect("write long mp3");
+}
+
+/// A long track is divided across workers when the pool has room for it
+/// (issue #337). Each piece starts its filters from zero and runs them through
+/// a warm-up region it discards, so the result is not guaranteed bit-identical
+/// the way the pipeline in #341 is: the filter state at a piece boundary can
+/// differ from the whole-file state in its last bit, which carries through to
+/// the reported loudness.
+///
+/// The bound asserted here is 1e-9 dB against a measured worst case of 7e-15
+/// on MP3 and AAC corpora, so it is six orders of margin and would still catch
+/// a real error such as a misaligned piece or a dropped block.
+#[test]
+fn chunked_analysis_matches_the_whole_file_pass() {
+    let album = TempAlbum::new(&[]);
+    let long = album.dir.join("long.mp3");
+    write_long_mp3(&long);
+    let path = long.to_str().unwrap();
+
+    for mode in [
+        vec!["--rg2", "--true-peak"],
+        vec!["--r128", "--true-peak"],
+        vec!["--rg2"],
+    ] {
+        let measure = |jobs: &'static str| -> (f64, f64) {
+            let mut args = vec!["-r"];
+            args.extend_from_slice(&mode);
+            args.extend_from_slice(&["-n", "-o", "json", "-j", jobs, path]);
+            let json = json_of(&run(&args));
+            let file = &json["files"][0];
+            (
+                file["loudness_db"].as_f64().expect("loudness"),
+                file["peak"].as_f64().expect("peak"),
+            )
+        };
+        let (whole_loudness, whole_peak) = measure("1");
+        let (chunked_loudness, chunked_peak) = measure("8");
+        assert!(
+            (whole_loudness - chunked_loudness).abs() < 1e-9,
+            "{mode:?}: {whole_loudness} vs {chunked_loudness}"
+        );
+        // The true-peak history is exact at a piece boundary, since the
+        // warm-up feeds the meter the real preceding samples, so the peak has
+        // no tolerance to spend.
+        assert_eq!(whole_peak, chunked_peak, "{mode:?}");
+    }
+}
+
+/// RG1 is never divided: its equal-loudness filter settles far more slowly
+/// than the two biquads of K-weighting, and it is the path whose values have
+/// to match mp3gain bit for bit.
+#[test]
+fn rg1_is_never_chunked() {
+    let album = TempAlbum::new(&[]);
+    let long = album.dir.join("long.mp3");
+    write_long_mp3(&long);
+    let path = long.to_str().unwrap();
+
+    let measure =
+        |jobs: &'static str| stdout_of(&run(&["-r", "-n", "-o", "json", "-j", jobs, path]));
+    assert_eq!(measure("1"), measure("8"), "RG1 must be byte-identical");
+}
+
 /// The decode and the analysis run on separate threads once `-j` allows it
 /// (issue #337). The analyzer still sees every frame once and in order, so
 /// this has to be byte-identical to the single-threaded path, not merely


### PR DESCRIPTION
Closes #337. Splits the decode itself, which is what was left after #340 and #341.

## How

A track is divided at 100 ms sub-block boundaries. Each piece seeks to its start minus a one-second warm-up region, decodes forward, runs the filters through the warm-up **without accumulating**, then measures its own sub-block sums and peaks. The pieces' sums are concatenated in order and the 400 ms gating blocks are formed from the whole list afterwards, so a block straddling a piece boundary is neither lost nor counted twice.

`Bs1770Analyzer` now keeps the per-sub-block sums instead of folding blocks as each one completes. That refactor is bit-identical on its own and is what makes the concatenation possible.

## Numbers

M3 MacBook Air, 10 minute 44.1 kHz 320 kbps file, `-r --rg2 --true-peak`:

| | before | after | |
|---|---|---|---|
| `-j 8` | 0.74 s | **0.26 s** | 2.8x |
| `-j 4` | 0.73 s | **0.35 s** | 2.1x |
| `-j 2` | 0.74 s | 0.58 s | 1.3x |
| `-j 1` | 1.04 s | 1.06 s | unchanged by design |
| 36 files / 3.6 h, `-a ... -j 4` | 5.44 s | 5.38 s | unchanged, not divided |

Against the `-j 1` baseline of 1.04 s, a single file is now **4.0x** faster at `-j 8`. Before #341 and this change, `-j` did nothing whatsoever for one file: 0.94 s at `-j 1`, `-j 4` and `-j 8` alike.

The 2% on the `-j 1` path is the sub-block vector. `-j 1` is never divided.

## When a file is divided

**Only when the run as a whole has fewer files than threads.** This gate is not an optimization, it is required: dividing when the pool is already saturated measured **23% slower** at `-j 4` on the 36-file corpus, because every piece pays for a warm-up region and a seek. The decision is made once for the whole run rather than per album, since six albums of six files saturate the pool exactly as thoroughly as one list of thirty-six.

**Only for `--rg2` and `--r128`.** RG1's equal-loudness filter is a 10th-order Yule-Walker IIR that settles far more slowly than K-weighting's two biquads, and RG1 is the mp3gain-compatible path where values have to match bit for bit. It is also already decode-bound at about 880x realtime, so there is nothing to win. There is a test asserting RG1 output is byte-identical between `-j 1` and `-j 8`.

## When it falls back

Every check that cannot be satisfied falls back to the whole-file pass, because the failure mode here is a wrong loudness value written into someone's tags:

- No frame count. Some M4A reports none: the 96 kHz HE-AAC file in my corpus reports `n_frames = None`.
- A time base that is not 1/sample_rate, so there is no sample index to divide by. The same file reports a 96 kHz base against a 48 kHz rate.
- A seek that overshoots the piece's first wanted sample, which would leave a hole in the measurement.
- A piece that produced fewer sub-blocks than the plan said it owed, which means the plan and the file disagree.

Verified that the HE-AAC file still analyzes correctly through the fallback.

## Accuracy, and the one place this is not bit-identical

Unlike #340 and #341, this is not bit-identical, and that is inherent rather than an implementation shortcut.

Each piece starts its filters from zero and converges during the warm-up. The K-weighting's slowest pole is the 38 Hz high-pass, radius about 0.995 at 44.1 kHz, so a second of warm-up leaves a state error around 1e-100 relative. That is far below f64 resolution, but it can still flip the last bit of the state, and that carries through to the reported loudness.

Measured worst case over MP3 and AAC corpora: **7.1e-15 dB**. MP3 was exact in most runs, AAC differed by one or two ulp. A warm-up sweep showed the difference is not a convergence threshold but rounding: 0.5 s and 1.5 s were exact while 1.0 s was one ulp off, on the same file.

The tests assert agreement within **1e-9 dB**, six orders of margin over the observed worst case, which would still catch a misaligned piece or a dropped block. That is the "stated and tested rather than assumed" tolerance the issue asked for.

**True peak has no tolerance to spend.** The 49-tap FIR reaches back 48 samples, and the warm-up feeds the meter the real preceding samples, so its history at a piece boundary is exact. The peak is asserted byte-equal, not within a tolerance.

## Tests

- A unit test on the planner itself, asserting it divides a two-minute track into contiguous ranges that tile it, and declines a one-second one. Without this the value comparisons would pass vacuously if the planner quietly declined everything, which is exactly what happened during development: a bug in the first-packet check made every piece fail and fall back, and the timings looked plausible because #341 was carrying them.
- `chunked_analysis_matches_the_whole_file_pass`: `-j 1` against `-j 8` for `--rg2 --true-peak`, `--r128 --true-peak` and `--rg2`.
- `rg1_is_never_chunked`: byte-identical output.
- The long test track is built by repeating a one-second fixture's frames, so no encoder is needed. The ID3 tag and the leading Xing/Info frame are stripped, because they declare a one-second frame count and the planner correctly refuses to divide a track that claims to be one second long.
- `cargo test` 232 passed, `cargo clippy -- -D warnings` and `cargo fmt --check` clean including the GUI manifest.

## Note for #338

`AlbumAnalysisOptions::chunk` defaults to false and mp3rgui builds its options with `..Default::default()`, so the GUI is unchanged by this PR. It can opt in when #338 is done, where the same "is the pool busy" question has to be answered from the GUI's own job model.

Closes #337
